### PR TITLE
docs: use ./run.cmd for Windows launcher invocation

### DIFF
--- a/README-源码包说明.txt
+++ b/README-源码包说明.txt
@@ -22,7 +22,7 @@ CogSeed 源码包
 --------
 npm install
 ./run.sh      # macOS / Linux shell
-run.cmd       # Windows
+./run.cmd     # Windows
 
 验证方式
 --------

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Start CogSeed on macOS or a Linux development environment:
 On Windows:
 
 ```bat
-run.cmd
+./run.cmd
 ```
 
 The source launcher verifies dependencies, prepares the `cogseed` runtime variant, and starts Electron with an isolated data root and application identity.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,7 +110,7 @@ npm install
 Windows 环境：
 
 ```bat
-run.cmd
+./run.cmd
 ```
 
 源码启动器会校验依赖、准备 `cogseed` runtime variant，并使用隔离的数据根目录和应用身份启动 Electron。


### PR DESCRIPTION
Fix the Windows launcher command in the README files.

**问题**：裸 `run.cmd` 只在 cmd.exe 里能解析（当前目录在 PATH 搜索中）；PowerShell 和 Git Bash 都不执行当前目录命令，需要显式路径。

**修复**：`run.cmd` → `./run.cmd`——在 cmd.exe / PowerShell / Git Bash 下均可用，且与上方 `./run.sh` 写法一致。

改动文件：README.md、README.zh-CN.md、README-源码包说明.txt
