### PR TITLE
docs: add shields.io badges to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 </p>
 
 <p align="center">
+  <img src="https://img.shields.io/github/license/bonc-ai/cogseed" alt="License">
+  <img src="https://img.shields.io/github/actions/workflow/status/bonc-ai/cogseed/ci.yml" alt="CI">
+  <img src="https://img.shields.io/github/v/release/bonc-ai/cogseed" alt="Release">
+  <img src="https://img.shields.io/github/downloads/bonc-ai/cogseed/total" alt="Downloads">
+  <img src="https://img.shields.io/badge/platform-macOS%2012%2B-0071BC" alt="Platform">
+</p>
+
+<p align="center">
   <img src="./assets/cogseed-homepage-hero-agent-continuity.png" width="1000" alt="CogSeed desktop workspace">
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,6 +11,14 @@
 </p>
 
 <p align="center">
+  <img src="https://img.shields.io/github/license/bonc-ai/cogseed" alt="License">
+  <img src="https://img.shields.io/github/actions/workflow/status/bonc-ai/cogseed/ci.yml" alt="CI">
+  <img src="https://img.shields.io/github/v/release/bonc-ai/cogseed" alt="Release">
+  <img src="https://img.shields.io/github/downloads/bonc-ai/cogseed/total" alt="Downloads">
+  <img src="https://img.shields.io/badge/platform-macOS%2012%2B-0071BC" alt="Platform">
+</p>
+
+<p align="center">
   <img src="./assets/cogseed-homepage-hero-agent-continuity.png" width="1000" alt="CogSeed 桌面工作台">
 </p>
 


### PR DESCRIPTION
为 README 首屏添加 5 个徽章（License / CI / Release / Downloads / Platform），对齐主流开源项目展示规范。

**徽章清单**：
- License：MIT 许可标识
- CI：ci.yml 工作流状态（当前绿）
- Release：v0.0.5
- Downloads：Release 累计下载量
- Platform：macOS 12+

改动：README.md、README.zh-CN.md（标题与语言切换下方、hero 图前）