### PR TITLE
fix(security): use real contact channels, drop non-existent mailbox

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,9 +13,12 @@ supported on a best-effort basis.
 
 **Please do not open a public issue for security vulnerabilities.**
 
-Report vulnerabilities privately to:
+Report vulnerabilities privately through one of the following channels:
 
-**security@bonc.com.cn**
+1. **Preferred: GitHub private vulnerability reporting** — use the
+   **Security → Report a vulnerability** button on the repository page
+   (https://github.com/bonc-ai/cogseed/security).
+2. **Alternative: email** — **business@bonc.com.cn**
 
 Please include:
 

--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
   },
   "author": {
     "name": "BONC 东方国信",
-    "email": "security@bonc.com.cn",
+    "email": "business@bonc.com.cn",
     "url": "https://www.bonc.com.cn"
   }
 }


### PR DESCRIPTION
修复安全联系信息：移除不存在的 `security@bonc.com.cn`，改用真实可用通道。

**改动**：
1. **SECURITY.md**：漏洞上报主通道改为 **GitHub 私密漏洞报告**（Security → Report a vulnerability），备选 `business@bonc.com.cn`（公司真实对外邮箱）
2. **package.json**：author 邮箱 `security@bonc.com.cn`（不存在）→ `business@bonc.com.cn`

原因：`security@bonc.com.cn` 未经证实存在，留着会导致漏洞报告无人接收。