### PR TITLE
chore: add CODEOWNERS for merge reviewers (reviewers team)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# Keep this owner aligned with .gitlab/CODEOWNERS when mirroring to GitHub.
-* @chenwankang
+# CogSeed 代码评审负责人（合并评审人员）
+# 由 bonc-ai/reviewers Team 承担：Usernames686、Zian-Anson、ab1-0301
+* @bonc-ai/reviewers


### PR DESCRIPTION
指定合并评审人员：**Usernames686、Zian-Anson、ab1-0301**（reviewers Team）。

- 新增 `.github/CODEOWNERS`：`* @bonc-ai/reviewers`
- 后续将开启分支保护 `require_code_owner_reviews`，使**仅这三人的 Approve 有效**，成为事实上的合并评审闸（符合会议 T15"专人负责合并"）。

注：ab1-0301 尚待接受组织邀请。