### PR TITLE
docs: add branching and merge rules to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,30 @@ Add it with `git commit -s`. By signing off you agree to the terms of the
 - Ensure all CI checks pass.
 - A maintainer will review; be patient and responsive to feedback.
 
+## Branching and Merge Rules
+
+We follow a simplified **GitHub Flow**:
+
+- `main` is always releasable and **protected** — no direct pushes, all changes go through pull requests.
+- Short-lived branches: `feat/xxx` (new features), `fix/xxx` (bug fixes), `docs/xxx` (documentation), `chore/xxx` (tooling). Merge via **squash** and delete the branch.
+- `release/vX.Y` branches are cut from `main` at release time for patch-only fixes; they are protected by the same review rules.
+
+### Merge requirements (branch protection)
+
+1. At least **1 approving review** from a designated reviewer (see CODEOWNERS / `@bonc-ai/reviewers`).
+2. All required CI checks pass (`verify`).
+3. You cannot approve or merge your own pull request.
+
+### Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <subject>
+```
+
+Example: `fix(messaging): route wechat group messages correctly`.
+
 ## License
 
 By contributing, you agree that your contributions are licensed under the


### PR DESCRIPTION
补充 CONTRIBUTING.md：**分支与合并规范**章节。

- 采用 GitHub Flow：main 保护 / feat/fix/docs/chore 短分支 / release/vX.Y 发版分支
- 合并要求：≥1 名评审组（CODEOWNERS）批准 + CI(verify) 绿 + 禁止自提自合
- 提交信息规范：Conventional Commits