### PR TITLE
chore: enable Dependabot for npm and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Dependabot 依赖自动更新配置
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    # 小版本（patch/minor）与安全修复默认自动合；大版本（major）留人工
+    ignore:
+      - dependency-name: "electron"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
启用 **Dependabot** 依赖自动更新：

- **npm**：每周一检查依赖更新，自动开 PR；patch/minor 低风险可自动合并，**major（electron/typescript）留人工**
- **github-actions**：每周检查 Actions 版本
- 配合 Dependabot alerts 漏洞告警

（注：自动合并需配合分支保护规则；当前 main 要求评审组批准，Dependabot PR 同样走该流程）