### PR TITLE
fix(test): stabilize messaging owner-bind integration mocks under load

### DIFF
--- a/test/main/features/messaging-owner-bind-integration.test.ts
+++ b/test/main/features/messaging-owner-bind-integration.test.ts
@@ -20,6 +20,36 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+// Static mocks for the group-chat dispatch seam. The per-test
+// `vi.doMock` + `vi.resetModules` + dynamic `import` sequence raced under
+// parallel load: intermittently the mock was never registered and the real
+// `group_chat.send` answered instead, leaving the test's spy at 0 calls
+// while the merged batch itself dispatched fine. `vi.mock` registers at
+// transform time and is immune to that race. The installed spy delegates to
+// the real implementation by default (vitest caches the factory result, so
+// one shared spy instance serves every module graph); the wechat end-to-end
+// cases below take it over per test, clearing accumulated calls first.
+const groupChatMocks = vi.hoisted(() => ({
+  send: undefined as undefined | ReturnType<typeof vi.fn>,
+}));
+const busMocks = vi.hoisted(() => ({
+  subscribe: undefined as undefined | ReturnType<typeof vi.fn>,
+}));
+
+vi.mock('../../../src/main/features/group_chat', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/features/group_chat')>();
+  const send = vi.fn((...args: Parameters<typeof actual.send>) => actual.send(...args));
+  groupChatMocks.send = send;
+  return { ...actual, send };
+});
+
+vi.mock('../../../src/main/features/group_chat/bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/features/group_chat/bus')>();
+  const subscribe = vi.fn((...args: Parameters<typeof actual.subscribe>) => actual.subscribe(...args));
+  busMocks.subscribe = subscribe;
+  return { ...actual, subscribe };
+});
+
 /**
  * Integration: a real Feishu receive_v1 event flows through the actual
  * FeishuAdapter → onInbound → manager.enqueueInbound → owner auto-bind.
@@ -274,7 +304,6 @@ describe('wechat_personal end-to-end', () => {
 
   it('merged burst replies use the LAST inbound tokenRef, not the first (spec §3.1)', async () => {
     let busListener: ((event: unknown) => void) | undefined;
-    const groupSend = vi.fn(async () => ({ ok: true, msg: { id: 'user-msg-1', from: 'user', text: '' } }));
     const sendMessage = vi.fn(async () => ({ deliveryId: 'remote-reply-1' }));
     const adapter: import('../../../src/main/features/messaging/types').MessagingAdapter = {
       platform: 'wechat_personal',
@@ -294,21 +323,29 @@ describe('wechat_personal end-to-end', () => {
       },
       sendMessage,
     };
-    const subscribe = vi.fn((_uid: string, _cid: string, listener: (event: unknown) => void) => {
-      busListener = listener;
-      return () => { busListener = undefined; };
-    });
     vi.doMock('../../../src/main/features/messaging/adapters', () => ({
       createAdapter: vi.fn(() => adapter),
     }));
-    vi.doMock('../../../src/main/features/group_chat', () => ({ send: groupSend }));
-    vi.doMock('../../../src/main/features/group_chat/bus', () => ({ subscribe }));
     vi.resetModules();
 
     try {
       const registry = await import('../../../src/main/features/messaging/registry');
       const manager = await import('../../../src/main/features/messaging/manager');
       const ledger = await import('../../../src/main/features/messaging/ledger');
+      // Fresh module graph: aim the static group-chat spies at this test's
+      // fakes before any inbound dispatch can run.
+      const groupSend = groupChatMocks.send;
+      const subscribe = busMocks.subscribe;
+      if (!groupSend || !subscribe) throw new Error('static group-chat mocks not installed');
+      // The static spies are shared across the file (vitest caches the mock
+      // factory result), so reset call counts left by earlier tests.
+      groupSend.mockClear();
+      subscribe.mockClear();
+      groupSend.mockImplementation(async () => ({ ok: true, msg: { id: 'user-msg-1', from: 'user', text: '' } }));
+      subscribe.mockImplementation((_uid: string, _cid: string, listener: (event: unknown) => void) => {
+        busListener = listener;
+        return () => { busListener = undefined; };
+      });
       const created = await registry.createWechatInstance('uid-1', {
         displayName: '我的微信',
         ilinkBotToken: 't'.repeat(64),
@@ -363,15 +400,12 @@ describe('wechat_personal end-to-end', () => {
       await manager.stopForUser('uid-1');
     } finally {
       vi.doUnmock('../../../src/main/features/messaging/adapters');
-      vi.doUnmock('../../../src/main/features/group_chat');
-      vi.doUnmock('../../../src/main/features/group_chat/bus');
       vi.resetModules();
     }
   });
 
   it('keeps each reply on the token of its own inbound when turns interleave', async () => {
     let busListener: ((event: unknown) => void) | undefined;
-    const groupSend = vi.fn(async () => ({ ok: true, msg: { id: 'user-msg-1', from: 'user', text: '' } }));
     const sendMessage = vi.fn(async () => ({ deliveryId: 'remote-reply-1' }));
     const adapter: import('../../../src/main/features/messaging/types').MessagingAdapter = {
       platform: 'wechat_personal',
@@ -391,21 +425,29 @@ describe('wechat_personal end-to-end', () => {
       },
       sendMessage,
     };
-    const subscribe = vi.fn((_uid: string, _cid: string, listener: (event: unknown) => void) => {
-      busListener = listener;
-      return () => { busListener = undefined; };
-    });
     vi.doMock('../../../src/main/features/messaging/adapters', () => ({
       createAdapter: vi.fn(() => adapter),
     }));
-    vi.doMock('../../../src/main/features/group_chat', () => ({ send: groupSend }));
-    vi.doMock('../../../src/main/features/group_chat/bus', () => ({ subscribe }));
     vi.resetModules();
 
     try {
       const registry = await import('../../../src/main/features/messaging/registry');
       const manager = await import('../../../src/main/features/messaging/manager');
       const ledger = await import('../../../src/main/features/messaging/ledger');
+      // Fresh module graph: aim the static group-chat spies at this test's
+      // fakes before any inbound dispatch can run.
+      const groupSend = groupChatMocks.send;
+      const subscribe = busMocks.subscribe;
+      if (!groupSend || !subscribe) throw new Error('static group-chat mocks not installed');
+      // The static spies are shared across the file (vitest caches the mock
+      // factory result), so reset call counts left by earlier tests.
+      groupSend.mockClear();
+      subscribe.mockClear();
+      groupSend.mockImplementation(async () => ({ ok: true, msg: { id: 'user-msg-1', from: 'user', text: '' } }));
+      subscribe.mockImplementation((_uid: string, _cid: string, listener: (event: unknown) => void) => {
+        busListener = listener;
+        return () => { busListener = undefined; };
+      });
       const created = await registry.createWechatInstance('uid-1', {
         displayName: '我的微信',
         ilinkBotToken: 't'.repeat(64),
@@ -483,8 +525,6 @@ describe('wechat_personal end-to-end', () => {
       await manager.stopForUser('uid-1');
     } finally {
       vi.doUnmock('../../../src/main/features/messaging/adapters');
-      vi.doUnmock('../../../src/main/features/group_chat');
-      vi.doUnmock('../../../src/main/features/group_chat/bus');
       vi.resetModules();
     }
   });


### PR DESCRIPTION
## 问题 / What

`messaging-owner-bind-integration.test.ts` 中 `merged burst replies use the LAST inbound tokenRef` 用例在 CI 上间歇性失败（同一提交 3 次运行挂 2 次， Dependabot PR 今晨同样中招），阻塞所有需要 CI 绿的 PR。

## 根因 / Root cause

失败签名是"前两行断言已通过、但 `groupSend` mock 调用数为 0"——逻辑上矛盾。加标记复现后确认：**产品代码没有 bug**，是每个用例里 `vi.doMock` + `vi.resetModules` + 动态 `import` 的组合在并行负载下偶发丢失 mock 注册，manager 实际调用了**真实** `group_chat.send`（且成功返回），测试等的假函数永远 0 次。本地 8 路并行复现 40 次挂 9 次，失败日志时间线可证明派发走了真实模块。

## 修复 / Fix

按仓库既有惯例（`vi.hoisted` + 静态 `vi.mock`，见 api_common.test.ts 等）改为文件级静态 mock：默认委托真实实现（不 mock 的用例行为不变），两个端到端用例按测试接管 spy 并先 `mockClear()`。

## 验证 / Verification

- 同样 8 路并行负载：修复前 9/40 失败 → 修复后 **40/40 通过**
- typecheck、lint 干净；空载单跑通过
- 仅改 1 个测试文件（+58/−18），不涉及产品代码

cc：消息模块相关，欢迎 @bonc-ai/reviewers 评审。