### PR TITLE
fix(providers): import CC Switch hermes rows so prefix-path endpoints probe correctly

### DIFF
--- a/src/main/features/ccswitch_import.ts
+++ b/src/main/features/ccswitch_import.ts
@@ -36,6 +36,11 @@
  *       options.baseURL + options.apiKey; CC Switch opencode rows usually
  *       carry an EMPTY apiKey (setCacheKey), so fall back to OpenCode's own
  *       auth store (~/.local/share/opencode/auth.json) — real data, read-only.
+ *   hermes → protocol 'openai' (api_mode 'anthropic' → 'anthropic')
+ *       flat base_url + api_key + models[] hints. The SAME third-party
+ *       service often ALSO exists as a codex row with a shorter base_url,
+ *       but only the hermes row's prefix-path base (e.g.
+ *       https://api.commandcode.ai/provider) serves the model-list API.
  *
  * `category='official'` rows are skipped: they're the built-in
  * Anthropic/OpenAI/Google endpoints, already covered by CogSeed's own catalog.
@@ -146,7 +151,13 @@ function codexModelsFromConfigToml(configToml: unknown): string[] {
  */
 function modelHints(cfg: Record<string, unknown>, env: Record<string, unknown>): string[] | undefined {
   const raw: unknown[] = [];
-  if (Array.isArray(cfg.models)) raw.push(...cfg.models);
+  // hermes rows store `models` as `[{ id, name }]` objects; other app types
+  // use plain string arrays — accept both shapes.
+  if (Array.isArray(cfg.models)) {
+    for (const entry of cfg.models) {
+      raw.push(entry && typeof entry === 'object' ? (entry as Record<string, unknown>).id : entry);
+    }
+  }
   if (cfg.modelCatalog && typeof cfg.modelCatalog === 'object') {
     const catalogModels = (cfg.modelCatalog as Record<string, unknown>).models;
     if (Array.isArray(catalogModels)) {
@@ -253,6 +264,18 @@ function mapRow(
     return { ...common, protocol: 'openai', baseUrl, apiKey, ...(apiKey ? {} : { needsKey: true }) };
   }
 
+  if (appType === 'hermes') {
+    // Flat shape: { base_url, api_key, api_mode, models: [{id, name}] }.
+    // Hermes endpoints are frequently prefix-path style (e.g.
+    // https://api.commandcode.ai/provider) — the model-list API lives under
+    // that prefix, which is exactly what the live probe needs.
+    const baseUrl = typeof cfg.base_url === 'string' ? cfg.base_url : '';
+    const apiKey = typeof cfg.api_key === 'string' ? cfg.api_key : '';
+    if (!baseUrl) return undefined;
+    const protocol = cfg.api_mode === 'anthropic' ? 'anthropic' : 'openai';
+    return { ...common, protocol, baseUrl, apiKey, ...(apiKey ? {} : { needsKey: true }) };
+  }
+
   return undefined;
 }
 
@@ -330,7 +353,7 @@ export function readCcSwitchImportItems(
       }
       let reason: CcSwitchSkippedItem['reason'] = item ? 'missing_api_key' : 'missing_base_url';
       if (r.category === 'official') reason = 'official';
-      else if (!['claude', 'claude-desktop', 'codex', 'gemini', 'opencode'].includes(r.app_type)) reason = 'unsupported_protocol';
+      else if (!['claude', 'claude-desktop', 'codex', 'gemini', 'opencode', 'hermes'].includes(r.app_type)) reason = 'unsupported_protocol';
       else {
         try { JSON.parse(r.settings_config || '{}'); }
         catch { reason = 'invalid_config'; }

--- a/test/main/features/ccswitch_import.test.ts
+++ b/test/main/features/ccswitch_import.test.ts
@@ -39,7 +39,7 @@ function createDb(rows: Array<Record<string, unknown>>): void {
 }
 
 describe('CC Switch importer', () => {
-  it('maps Claude, Codex and Gemini rows while skipping official providers', async () => {
+  it('maps Claude, Codex, Gemini and Hermes rows while skipping official providers', async () => {
     createDb([
       {
         id: 'claude-relay', app_type: 'claude', name: 'Claude Relay',
@@ -62,11 +62,26 @@ describe('CC Switch importer', () => {
 env_key = "OPENAI_API_KEY"` }),
       },
       {
+        // Real-world shape (e.g. command): prefix-path base whose /models the
+        // live probe can reach, plus [{id, name}] model hints.
+        id: 'hermes-command', app_type: 'hermes', name: 'command',
+        settings_config: JSON.stringify({
+          base_url: 'https://api.commandcode.ai/provider',
+          api_key: 'ck',
+          api_mode: 'chat_completions',
+          models: [{ id: 'gpt-5.6-luna', name: '' }, { id: 'zai-org/GLM-5.3', name: '' }],
+        }),
+      },
+      {
+        id: 'hermes-nokey', app_type: 'hermes', name: 'No Key Hermes',
+        settings_config: JSON.stringify({ base_url: 'https://relay.example/v1' }),
+      },
+      {
         id: 'official', app_type: 'claude', name: 'Official', category: 'official',
         settings_config: JSON.stringify({ env: { ANTHROPIC_BASE_URL: 'https://api.anthropic.com', ANTHROPIC_AUTH_TOKEN: 'skip' } }),
       },
       {
-        id: 'unsupported-hermes', app_type: 'hermes', name: 'DeepSeek', category: null,
+        id: 'unsupported-other', app_type: 'some-future-app', name: 'DeepSeek', category: null,
         settings_config: JSON.stringify({ env: { API_KEY: 'hidden' } }),
       },
     ]);
@@ -85,11 +100,17 @@ env_key = "OPENAI_API_KEY"` }),
       // Env-key-only rows are importable with needsKey so the user can fill
       // the key after the preview instead of losing the endpoint entirely.
       expect.objectContaining({ externalId: 'codex:codex-env-key', protocol: 'openai', apiKey: '', needsKey: true }),
+      expect.objectContaining({
+        externalId: 'hermes:hermes-command', protocol: 'openai',
+        baseUrl: 'https://api.commandcode.ai/provider', apiKey: 'ck',
+        models: ['gpt-5.6-luna', 'zai-org/GLM-5.3'],
+      }),
+      expect.objectContaining({ externalId: 'hermes:hermes-nokey', protocol: 'openai', apiKey: '', needsKey: true }),
     ]));
-    expect(result.items).toHaveLength(4);
+    expect(result.items).toHaveLength(6);
     expect(result.skipped).toEqual(expect.arrayContaining([
       expect.objectContaining({ externalId: 'claude:official', reason: 'official' }),
-      expect.objectContaining({ externalId: 'hermes:unsupported-hermes', reason: 'unsupported_protocol' }),
+      expect.objectContaining({ externalId: 'some-future-app:unsupported-other', reason: 'unsupported_protocol' }),
     ]));
   });
 


### PR DESCRIPTION
## 问题

「从 CC Switch 导入供应商」弹窗里，部分供应商（如 command）扫不出模型列表——不显示「N个模型」，而 CC Switch 自己能扫出几十个。

## 根因

CC Switch 里同一第三方服务常存成两行：**codex 行**的 base_url 是裸域名（如 `https://api.commandcode.ai`），**hermes 行**才是带前缀路径的真实接口地址（如 `https://api.commandcode.ai/provider`）。此前 mapRow 只认 claude / claude-desktop / codex / gemini / opencode 五种 app_type，hermes 行整体落入「格式不受支持」被丢弃；于是导入的是 codex 行的裸域名地址，实时探测 `/v1/models`、`/models` 全部 404，弹窗里自然没有模型数。

实测佐证：commandcode.ai 的模型接口在 `https://api.commandcode.ai/provider/v1/models`（返回 200 与完整列表），裸域名下的 `/v1/models` 为 404。

## 修复内容

- `mapRow` 新增 hermes 分支：读取 flat 的 `base_url` / `api_key` / `api_mode`，`api_mode='anthropic'` 映射 anthropic 协议，其余映射 openai；无 key 行标 needsKey 保持可导入
- `modelHints` 兼容 hermes 的 `models: [{id, name}]` 对象数组（原先只认字符串数组，对象会被静默滤掉）
- 支持类型白名单加入 hermes，文件头映射文档同步更新
- 测试更新：hermes 行断言从「跳过」改为「成功导入」（含按 command 真实数据形状构造的用例），`unsupported_protocol` 改用未知 app_type 保住覆盖

## 验证

- 单测 4/4 通过（`node scripts/run-tests.mjs run test/main/features/ccswitch_import.test.ts`）
- `npx tsc --noEmit` 通过，eslint 对改动文件通过
- 对本机真实 CC Switch DB 做只读冒烟：7 个 hermes 行全部映射成功，`hermes:command` 拿到 `…/provider` 前缀 base 与 key；实测该地址的模型接口返回 200

## 影响面

只改导入映射，不触碰运行时调度与同步写入逻辑；对没有 hermes 行的用户无行为变化。同服务两行并存（codex + hermes）在弹窗中会各显示一条，属预期，合并展示可另行讨论。