### PR TITLE
chore: replace invented security@bonc.com.cn mailbox with business@ in metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ package.json.new
 # updates-server installer artifacts (large binaries; published via
 # updates-server/publish.cjs which copies them here)
 /updates-server/downloads/
+
+# 内部全流程开发手册（AGENTS.md，团队内部用，勿提交/勿推送）
+/AGENTS.md

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: CogSeed
-Upstream-Contact: security@bonc.com.cn
+Upstream-Contact: business@bonc.com.cn
 Source: https://github.com/bonc-ai/cogseed
 
 # Bulk license declaration for the whole repository, per the REUSE

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ an individual is officially representing the community in public spaces.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at:
 
-**security@bonc.com.cn**
+**business@bonc.com.cn**
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/NOTICE
+++ b/NOTICE
@@ -39,4 +39,4 @@ This product includes third-party software.  The complete list of
 third-party components, with their copyright and license information, is
 provided in the THIRD_PARTY_NOTICES.md file accompanying this distribution.
 
-Contact: security@bonc.com.cn
+Contact: business@bonc.com.cn

--- a/p3394-gateway/NOTICE
+++ b/p3394-gateway/NOTICE
@@ -32,4 +32,4 @@ standards body.
 
 This package has no third-party runtime dependencies (Node.js built-ins only).
 
-Contact: security@bonc.com.cn
+Contact: business@bonc.com.cn

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -52,7 +52,7 @@ maintenance:
   type: community
   contacts:
     - name: CogSeed Team
-      email: security@bonc.com.cn
+      email: business@bonc.com.cn
 
 localisation:
   localisationReady: true


### PR DESCRIPTION
## 变更

将 3 个元数据文件中的编造邮箱 `security@bonc.com.cn`（从未存在/未验证）统一替换为真实业务邮箱 `business@bonc.com.cn`，与 package.json、SECURITY.md 保持一致：

- `publiccode.yml` — maintenance.contacts.email
- `CODE_OF_CONDUCT.md` — 举报联系邮箱
- `NOTICE` — Contact 行

背景：`security@bonc.com.cn` 为项目早期编造的邮箱，此前已在提交历史与 SECURITY.md 中替换，本次补齐剩余文件。