### PR TITLE
fix(chat): make workspace breadcrumb clickable on macOS

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -184,12 +184,15 @@
                  `_refreshChatHeader()` in conversation.js. -->
             <div class="chat-header" id="chat-header">
               <div class="chat-header-main">
+                <nav class="chat-header-breadcrumb" id="chat-header-breadcrumb" aria-label="面包屑导航" hidden></nav>
+                <div class="chat-header-main-inline">
                 <div class="chat-header-title-row">
                   <h1 class="chat-header-title" id="chat-header-title"></h1>
                   <input type="text" class="chat-header-title-input" id="chat-header-title-input"
                          autocomplete="off" spellcheck="false" hidden />
                 </div>
                 <div class="chat-header-meta" id="chat-header-meta"></div>
+                </div>
               </div>
               <div class="chat-header-actions">
                 <button type="button" class="chat-header-details-btn" id="chat-terminal-toggle"

--- a/src/renderer/locales/ja.json
+++ b/src/renderer/locales/ja.json
@@ -3436,6 +3436,7 @@
   "recall.projection.confirm_assets": "プリロード済みアセットを確認",
   "settings.title": "設定",
   "ws.center_title": "ワークスペース",
+  "ws.my_spaces": "マイスペース",
   "ws.delete_space_confirm": "スペース「{name}」を削除しますか？タスクは残りますが、スペース内の成果物と資産は削除されます。",
   "ws.delete_space_failed": "スペースの削除に失敗しました",
   "ws.open_folder_failed": "スペースフォルダを開けませんでした",

--- a/src/renderer/locales/pt.json
+++ b/src/renderer/locales/pt.json
@@ -3436,6 +3436,7 @@
   "recall.projection.confirm_assets": "Confirmar ativos pré-carregados",
   "settings.title": "Configurações",
   "ws.center_title": "Espaço de trabalho",
+  "ws.my_spaces": "Meus espaços",
   "ws.delete_space_confirm": "Excluir espaço {name}? As tarefas permanecem; artefatos e ativos do espaço serão removidos.",
   "ws.delete_space_failed": "Falha ao excluir espaço",
   "ws.open_folder_failed": "Falha ao abrir a pasta do espaço",

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -1520,7 +1520,61 @@ window.addEventListener('i18n-change', _refreshEmptyStateGreeting);
 // already consumes (conversations[] cache, _groupMembersCache, pendingConvs)
 // so the header stays consistent across refreshes without new IPC.
 
+/** 会话顶部的返回面包屑：工作空间 / 我的空间 / <空间名>（会话名由标题行承担）。 */
+function _refreshChatBreadcrumb() {
+  const crumbEl = document.getElementById('chat-header-breadcrumb');
+  if (!crumbEl) return;
+  const cid = currentCid;
+  const conv = Array.isArray(conversations)
+    ? conversations.find((c) => c && c.conversation_id === cid)
+    : null;
+  const spaceId = (conv && conv.space_id) || '';
+  if (!cid || !spaceId) {
+    crumbEl.hidden = true;
+    crumbEl.innerHTML = '';
+    return;
+  }
+  let spaceName = (conv && conv.space_name) || '';
+  if (!spaceName) {
+    const sp = Array.isArray(_sidebarSpaces)
+      ? _sidebarSpaces.find((s) => s && s.space_id === spaceId)
+      : null;
+    if (sp) spaceName = _conversationSpaceDisplayName(sp);
+  }
+  if (!spaceName) spaceName = spaceId;
+  const rootLabel = t('ws.center_title', '工作空间');
+  const spacesLabel = t('ws.my_spaces', '我的空间');
+  crumbEl.innerHTML =
+    `<button type="button" class="chat-header-breadcrumb-link" data-breadcrumb-nav="workspace">${escapeHtml(rootLabel)}</button>` +
+    `<span class="chat-header-breadcrumb-sep">/</span>` +
+    `<button type="button" class="chat-header-breadcrumb-link" data-breadcrumb-nav="workspace">${escapeHtml(spacesLabel)}</button>` +
+    `<span class="chat-header-breadcrumb-sep">/</span>` +
+    `<button type="button" class="chat-header-breadcrumb-link" data-breadcrumb-nav="space" data-space-id="${escapeHtml(spaceId)}">${escapeHtml(spaceName)}</button>`;
+  crumbEl.hidden = false;
+  crumbEl.querySelectorAll('[data-breadcrumb-nav]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const nav = btn.getAttribute('data-breadcrumb-nav');
+      if (nav === 'workspace') {
+        window.setView('workspace');
+      } else if (nav === 'space') {
+        const sid = btn.getAttribute('data-space-id');
+        if (typeof window.openWorkspaceSpace === 'function') {
+          window.openWorkspaceSpace(sid);
+        } else {
+          // workspace.js 是懒加载的：首次点击时可能还没注册 openWorkspaceSpace。
+          // 先暂存目标空间 id，等 renderWorkspace 加载完成后消费它打开指定空间。
+          window.__cogseedPendingOpenSpace = sid;
+          window.setView('workspace');
+        }
+      }
+    });
+  });
+}
+
 function _refreshChatHeader() {
+  _refreshChatBreadcrumb();
   const cid = currentCid;
   const conv = Array.isArray(conversations)
     ? conversations.find((c) => c && c.conversation_id === cid)

--- a/src/renderer/modules/workspace.js
+++ b/src/renderer/modules/workspace.js
@@ -440,6 +440,7 @@
 
   let _view = 'center';            // 'center' | 'space' | 'task'
   let _detailSpaceId = null;       // 当前详情空间 space_id
+  let _pendingOpenSpaceId = null;  // 会话面包屑请求打开的空间 id（renderWorkspace 消费一次）
   let _spaceTab = 'tasks';         // 详情页签：tasks | artifacts | assets
   let _configOpen = false;         // 详情页配置抽屉
   let _centerSearch = '';
@@ -493,7 +494,21 @@
     root.innerHTML = `<div class="ws-loading">${_t('ws.loading', '加载中…')}</div>`;
     try {
       await _loadData();
-      _reRender();
+      // 会话面包屑「空间名」在 workspace.js 懒加载完成前被点击时，目标空间 id
+      // 暂存在 window 上；首次进入工作空间面板时在这里消费一次。
+      if (!_pendingOpenSpaceId && window.__cogseedPendingOpenSpace) {
+        _pendingOpenSpaceId = window.__cogseedPendingOpenSpace;
+        window.__cogseedPendingOpenSpace = null;
+      }
+      if (_pendingOpenSpaceId) {
+        _detailSpaceId = _pendingOpenSpaceId;
+        _pendingOpenSpaceId = null;
+        _view = 'space';
+        _reRender();
+        _loadSpaceDetail(_detailSpaceId).then(() => _reRender());
+      } else {
+        _reRender();
+      }
     } catch (err) {
       _loadError = (err && err.message) || String(err);
       _loaded = false;
@@ -1985,7 +2000,15 @@
     try { await renderWorkspace(); } catch (_) {}
     _openCreate(null);
   }
+  /** 会话面包屑「空间名」入口：切到工作空间面板并直接打开指定空间详情。 */
+  function openWorkspaceSpace(spaceId) {
+    if (!spaceId) return;
+    _pendingOpenSpaceId = spaceId;
+    window.__cogseedPendingOpenSpace = null;
+    if (typeof setView === 'function') setView('workspace');
+  }
   window.renderWorkspace = renderWorkspace;
   window.openWorkspaceCreate = openWorkspaceCreate;
+  window.openWorkspaceSpace = openWorkspaceSpace;
   window.addEventListener('i18n-change', () => { void _refreshForLanguageChange(); });
 })();

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -246,7 +246,8 @@ body.is-sidebar-resizing iframe { pointer-events: none; }
 .is-macos .chat-header { -webkit-app-region: drag; }
 .is-macos .chat-header-actions,
 .is-macos .chat-header-title-input,
-.is-macos .chat-header-meta {
+.is-macos .chat-header-meta,
+.is-macos .chat-header-breadcrumb {
   -webkit-app-region: no-drag;
 }
 /* 各视图顶部条（标题栏语义，与 .chat-header 同模式）：空白处拖窗口、
@@ -5399,10 +5400,55 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-header-main {
   flex: 1;
   min-width: 0;
-  /* Title + agent chip share the header row (compact one-line top bar). */
+  /* 面包屑（可返回）在上，标题 + agent chip 的紧凑单行在下的两行布局。 */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+}
+.chat-header-main-inline {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
+}
+.chat-header-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--muted);
+}
+.chat-header-breadcrumb[hidden] { display: none !important; }
+.chat-header-breadcrumb-item {
+  white-space: nowrap;
+}
+.chat-header-breadcrumb-link {
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 4px;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat-header-breadcrumb-link:hover {
+  color: var(--text);
+  text-decoration: underline;
+}
+.chat-header-breadcrumb-sep {
+  flex: 0 0 auto;
+  color: var(--muted);
+  opacity: 0.7;
+  user-select: none;
 }
 .chat-header-title-row {
   /* Shrinks (title truncates) but never grows — so the agent chip sits


### PR DESCRIPTION
The chat header is a macOS window drag region. The newly added breadcrumb was not in the no-drag whitelist, so its buttons swallowed clicks before they reached the DOM. Also stash a pending space id so the space-name crumb opens the target space even when workspace.js is still lazy-loading.

## What does this PR do?

Describe the change and why it is needed.

## Related issue

Fixes #(issue)

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Tests added/updated for the change
- [ ] Signed off with `git commit -s` (DCO)
