### PR TITLE
fix(sidebar): refresh conversation relative times without full re-render

### DIFF
--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -5443,8 +5443,10 @@ function _renderConversationSidebarItem(c, opts = {}) {
   const menuTitle = escapeHtml(t('project.menu.more_actions'));
   // ZCode 式行内相对时间（58分 / 3小时 / 6小时）：最近任务平铺列表没有时间桶标题，
   // 行尾的相对时间承担「新近度」信号。置顶区/空间组同样受益（一眼看出哪些最近动过）。
-  const timeHtml = _renderConversationRelativeTime(c)
-    ? `<span class="conv-item-time" title="${escapeHtml(_conversationAbsoluteTime(c))}">${escapeHtml(_renderConversationRelativeTime(c))}</span>`
+  // data-time-iso 是 ticker 定点刷新的时间源（见 _refreshConversationRelativeTimes）。
+  const timeText = _renderConversationRelativeTime(c);
+  const timeHtml = timeText
+    ? `<span class="conv-item-time" data-time-iso="${escapeHtml(_conversationActivityIso(c) || '')}" title="${escapeHtml(_conversationAbsoluteTime(c))}">${escapeHtml(timeText)}</span>`
     : '';
   // Auto-fired conversations get the same clock icon as the sidebar
   // "Automation" tab, rendered to the LEFT of the title text. Visible in
@@ -5542,9 +5544,8 @@ function _refreshConvTaskLine(cid) {
   else item.insertAdjacentHTML('beforeend', line);
 }
 
-/** ZCode 式相对时间（「刚刚 / N 分 / N 小时 / N 天」）。空串 = 无时间可显示。 */
-function _renderConversationRelativeTime(c) {
-  const iso = _conversationActivityIso(c);
+/** 相对时间纯计算（iso → 「刚刚 / N 分 / N 小时 / N 天」）。空串 = 无时间可显示。 */
+function _relativeTimeFromIso(iso) {
   if (!iso) return '';
   const dt = new Date(iso);
   if (isNaN(dt.getTime())) return '';
@@ -5557,6 +5558,37 @@ function _renderConversationRelativeTime(c) {
   const d = Math.floor(h / 24);
   if (d < 30) return t('sidebar.time_days', { n: d });
   return t('sidebar.time_old');
+}
+
+/** ZCode 式相对时间（「刚刚 / N 分 / N 小时 / N 天」）。空串 = 无时间可显示。 */
+function _renderConversationRelativeTime(c) {
+  return _relativeTimeFromIso(_conversationActivityIso(c));
+}
+
+// 相对时间不会自己走：整列表只在数据事件（新消息 / 置顶 / 重命名…）时重渲染，
+// 时间文本会一直冻结到重启或手动刷新。ticker 定点刷新 .conv-item-time 的文本
+// （时间源挂在 data-time-iso 上，不回查会话缓存），避免周期性全量重渲染打断
+// 行内重命名、合并勾选和滚动位置。
+let _convTimeTickerStarted = false;
+function _refreshConversationRelativeTimes() {
+  if (typeof document === 'undefined' || typeof document.querySelectorAll !== 'function') return;
+  document.querySelectorAll('.conv-item-time[data-time-iso]').forEach((el) => {
+    const next = _relativeTimeFromIso(el.getAttribute('data-time-iso'));
+    if (next && el.textContent !== next) el.textContent = next;
+  });
+}
+function _ensureConversationTimeTicker() {
+  if (_convTimeTickerStarted || typeof setInterval !== 'function') return;
+  _convTimeTickerStarted = true;
+  setInterval(() => {
+    if (typeof document === 'undefined' || document.hidden) return;
+    _refreshConversationRelativeTimes();
+  }, 30000);
+  if (typeof document.addEventListener === 'function') {
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) _refreshConversationRelativeTimes();
+    });
+  }
 }
 
 /** 绝对时间（悬停 title 用）。 */
@@ -6940,6 +6972,7 @@ function _sidebarHasMoreOld() {
 function renderConversationList() {
   _conversationBucketDateKey = _conversationLocalDateKey();
   const container = document.getElementById('conversation-list');
+  _ensureConversationTimeTicker();
   _sortConversationCacheForSidebar();
   // 三段结构：置顶（pinned）→ 空间（space_id）→ 最近（无 space_id，含纯 project_id 旧孤儿 F2-A）。
   // pin 的会话只在置顶区出现（不重复进空间/最近区）。

--- a/test/renderer/conversation-sidebar.test.ts
+++ b/test/renderer/conversation-sidebar.test.ts
@@ -1709,3 +1709,71 @@ describe('new chat quick-start scenarios', () => {
     expect(toasts).toHaveLength(0);
   });
 });
+
+describe('conversation sidebar relative time refresh', () => {
+  const isoAgo = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+  function fakeTimeEl(iso: string, text: string) {
+    return {
+      _text: text,
+      writes: 0,
+      get textContent() { return this._text; },
+      set textContent(v: string) { this._text = v; this.writes += 1; },
+      getAttribute: (name: string) => (name === 'data-time-iso' ? iso : null),
+    };
+  }
+
+  it('stamps the rendered time span with its ISO source', () => {
+    const context = loadConversationRenderer();
+    const iso = isoAgo(13 * 60_000);
+
+    const html = context._renderConversationSidebarItem({
+      conversation_id: 'c1',
+      title: 'Stale clock',
+      updated_at: iso,
+    });
+
+    expect(html).toContain('class="conv-item-time"');
+    expect(html).toContain(`data-time-iso="${iso}"`);
+  });
+
+  it('classifies relative-time buckets from a bare ISO string', () => {
+    const context = loadConversationRenderer();
+
+    expect(context._relativeTimeFromIso(isoAgo(10_000))).toBe('Just now');
+    expect(context._relativeTimeFromIso(isoAgo(13 * 60_000))).toBe('13m ago');
+    expect(context._relativeTimeFromIso(isoAgo(3 * 3_600_000))).toBe('3h ago');
+    expect(context._relativeTimeFromIso(isoAgo(2 * 86_400_000))).toBe('2d ago');
+    expect(context._relativeTimeFromIso(isoAgo(40 * 86_400_000))).toBe('Earlier');
+    expect(context._relativeTimeFromIso('')).toBe('');
+    expect(context._relativeTimeFromIso('not-a-date')).toBe('');
+  });
+
+  it('refreshes stale time texts in place and skips unchanged or empty rows', () => {
+    const context = loadConversationRenderer();
+    const stale = fakeTimeEl(isoAgo(13 * 60_000), 'Just now');
+    const fresh = fakeTimeEl(isoAgo(5 * 60_000), '5m ago');
+    const noIso = fakeTimeEl('', '13m ago');
+    context.document.querySelectorAll = () => [stale, fresh, noIso];
+
+    context._refreshConversationRelativeTimes();
+
+    expect(stale.textContent).toBe('13m ago');
+    expect(stale.writes).toBe(1);
+    expect(fresh.textContent).toBe('5m ago');
+    expect(fresh.writes).toBe(0);
+    expect(noIso.textContent).toBe('13m ago');
+    expect(noIso.writes).toBe(0);
+  });
+
+  it('renders the list without throwing in a host that has no setInterval', () => {
+    const context = loadConversationRenderer();
+    const container = { innerHTML: '', querySelectorAll: () => [] };
+    context.document.getElementById = (id: string) => (id === 'conversation-list' ? container : null);
+    context.conversations = [{ conversation_id: 'c1', title: 'Guarded', updated_at: isoAgo(60_000) }];
+
+    // 沙箱未提供 setInterval：若 ticker 启动缺少类型守卫，这里会直接 TypeError。
+    expect(() => context.renderConversationList()).not.toThrow();
+    expect(container.innerHTML).toContain('conv-item-time');
+  });
+});


### PR DESCRIPTION
## 问题

左侧对话条目卡片右侧的相对时间（「刚刚 / N 分钟前 / N 小时前 / N 天前」）不会实时更新：只有重启应用或 Cmd+R 刷新页面后才会重新计算，页面一直开着时时间永久冻结。

## 根因

`_renderConversationSidebarItem` 在构建列表 HTML 的那一刻用 `Date.now()` 算好时间文本并写入静态字符串；整列表只在数据事件（新消息、置顶、重命名等）时才重渲染，没有任何周期性机制触发重算，所以时间一直停留在上一次渲染的值。

## 修复方案

- 抽出纯函数 `_relativeTimeFromIso(iso)`（原 `_renderConversationRelativeTime` 改为它的薄封装）；
- 渲染时把时间源 ISO 挂到 `.conv-item-time` 的 `data-time-iso` 属性上；
- 新增 30 秒轻量 ticker（`_ensureConversationTimeTicker`，在 `renderConversationList` 惰性单例启动）：只定点更新时间元素的 `textContent`，文本有变化才写 DOM，**不做全量重渲染**，避免打断行内重命名、合并勾选和滚动位置；
- 页面隐藏（`document.hidden`）时暂停跳动省电，恢复可见时通过 `visibilitychange` 立即刷新一次；
- 环境守卫：宿主没有 `setInterval`（如 vm 测试沙箱）时自动跳过，不影响现有测试。

## 验证

- 新增 4 个单测：时间源属性戳记、相对时间分级边界、定点刷新只改变化行、无 `setInterval` 环境安全（TDD：先确认旧代码红灯，实现后转绿）；
- 全量 `npm run typecheck` / `npm run lint` / `npm test`（9269 通过）/ `npm run readme:check` 均通过；
- 真机验证：带 `--remote-debugging-port` 启动，经 CDP 确认 36/36 个时间元素已挂 `data-time-iso`（新代码生效）；向页面注入探针元素（文本 PROBE），15 秒内被生产 ticker 代码刷新为「1 分钟前」。