### PR TITLE
ci: 校验 tag 必须来自 cicd 分支才允许发布

### DIFF
--- a/.github/workflows/build-macos-signed.yml
+++ b/.github/workflows/build-macos-signed.yml
@@ -1,7 +1,11 @@
 # GitHub Actions Workflow: 自动构建、签名、公证 macOS .dmg
 #
-# 触发条件: 推送到 main 分支或手动触发
-# 产物: 签名+公证后的 .dmg 文件
+# 发布流程: 在 cicd 分支上打 tag (如 v0.0.7) 触发本流程
+#           dev/<用户名> → develop → cicd → 打 tag → CD 打包发布
+# 产物: 签名+公证后的 .dmg,自动发布到 GitHub Release
+#
+# 注意: tag 不绑定分支,所以下面加了防呆检查,
+#       只有指向 cicd 分支的 tag 才允许构建发布(见 "校验 tag 来源分支" 步骤)
 
 name: Build & Sign macOS
 
@@ -9,8 +13,8 @@ name: Build & Sign macOS
 on:
   push:
     tags:
-      - 'v*'  # 只在推送 v1.0.0、v2.1.3 这样的 tag 时触发构建
-  workflow_dispatch:    # 允许手动触发(GitHub 网页上点 "Run workflow" 按钮)
+      - 'v*'  # 只在推送 v0.0.7 这样的 tag 时触发构建
+  workflow_dispatch:    # 允许手动触发(GitHub 网页上点 "Run workflow" 按钮,用于调试)
 
 # 给 workflow 用的默认 GITHUB_TOKEN 加上"可以创建 Release"的权限
 # 不需要额外申请 Secret,GitHub 每次运行自动生成这个 token
@@ -27,8 +31,33 @@ jobs:
       # ========================================
 
       # 步骤 1.1: 下载你的代码
+      # fetch-depth: 0 = 拉取完整 git 历史,
+      # 否则下一步无法判断 tag 到底属于哪个分支
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # 步骤 1.1b: 校验 tag 来源分支(防呆)
+      # tag 本身不绑分支,任何人在任何分支打 v* tag 都会触发本流程。
+      # 这里强制要求:tag 指向的提交必须已经在 cicd 分支上,
+      # 否则直接失败,防止有人误在 dev/develop/main 上打 tag 触发正式发布。
+      # 手动触发(workflow_dispatch)时跳过此检查,方便调试。
+      - name: Verify tag comes from cicd branch
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          # checkout tag 时默认不会拉取其他分支引用,这里显式拉一下 cicd
+          git fetch origin cicd:refs/remotes/origin/cicd
+
+          # merge-base --is-ancestor A B: 判断 A 是否是 B 的祖先(含 A==B)
+          # 即:tag 指向的提交是否已经包含在 cicd 分支的历史里
+          if git merge-base --is-ancestor "$GITHUB_SHA" origin/cicd; then
+            echo "✅ tag 指向的提交已包含在 cicd 分支,允许发布"
+          else
+            echo "❌ 这个 tag 不在 cicd 分支上,拒绝构建发布"
+            echo "   正确流程: 先把代码合并进 cicd 分支,再在 cicd 上打 tag"
+            exit 1
+          fi
 
       # 步骤 1.2: 安装 Node.js
       - name: Setup Node.js


### PR DESCRIPTION
- 头部注释更新为 cicd 分支发布流程
- checkout 加 fetch-depth: 0 以获取完整历史
- 新增防呆检查: tag 指向的提交必须已包含在 cicd 分支, 否则拒绝构建,防止误在其他分支打 tag 触发正式发布

## What does this PR do?

Describe the change and why it is needed.

## Related issue

Fixes #(issue)

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Tests added/updated for the change
- [ ] Signed off with `git commit -s` (DCO)
