### PR TITLE
ci: run compliance manually at release time instead of on every push

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -5,14 +5,14 @@
 #   - builtin:manifest:check  builtin resource inventory consistency
 #   - sbom:check            CycloneDX SBOM freshness (needs network)
 #
-# Runs on the default branch and on manual dispatch only, so feature/MR
-# pipelines are never blocked by these jobs.
+# Manual trigger only (Actions -> Run workflow) — run before each release.
+# Not run on every push: SBOM freshness depends on the committed
+# sbom.cdx.json being regenerated (`npm run sbom:generate`) when deps change,
+# so gate it at release time instead of blocking day-to-day development.
 
 name: compliance
 
 on:
-  push:
-    branches: [main, master, develop]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**背景**：compliance（含 sbom:check）在 push develop/main 时自动跑，但 sbom.cdx.json 只在依赖变更后手动 `npm run sbom:generate` 才更新——Dependabot 升级 PR 不生成 SBOM，导致每次合并依赖升级后 compliance 必红（BOM is stale）。

**改动**：compliance 触发从 `push: [main, master, develop]` 改为仅 `workflow_dispatch`（手动触发）。

**效果**：
- 日常开发合并不再被 SBOM 红灯打扰
- 发版前在 Actions 页手动 Run workflow，跑一次完整合规检查（reuse:check + manifest:check + sbom:check）
- SBOM 仍是发布合规关卡（P7 release gate），只是时机从"每次 push"改为"发版前"

对应手册 §2 门禁表格更新。