### PR TITLE
ci: run verify only on cicd branch (release gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,16 @@
 name: CI
 
+# CI (verify) runs only on the cicd branch — the release gate.
+# Day-to-day development merges into develop via review only (no CI);
+# the full verify suite runs once when a PR targets cicd, and again on
+# push to cicd, right before tagging a release.
 on:
   pull_request:
+    branches:
+      - cicd
   push:
     branches:
-      - main
-      - develop
+      - cicd
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
**背景**（2026-08-24 例会方案落地）：CI 从"每个 PR + push main/develop 都跑"改为"只在发布前跑一次"——日常开发靠评审，发布前靠 CI 把关。

**改动**：
- ci.yml 触发改为仅 cicd 分支（PR 到 cicd + push cicd + 手动）
- develop 保护去掉 verify 必过（只留 PR + 1 评审）
- main 保护去掉 verify 必过（同上）
- cicd 保护**加上** verify 必过（发布前强制 CI 绿才能合入 cicd）

**效果**：
- 日常：dev/xxx → PR → develop（只评审，不跑 CI，快）
- 发布：develop → PR → cicd（CI 必跑 + 评审）→ 打 tag → CD
- cicd 是唯一有 CI 门禁的分支，发布前完整验证

对应手册 §1.1 / §2 更新。