### PR TITLE
ci: add email hygiene gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -32,3 +34,15 @@ jobs:
       - run: npm test
       - run: npm run readme:check
       - run: npm run builtin:manifest:check
+      - name: Email hygiene gate (release gate)
+        run: |
+          set -euo pipefail
+          bad=$(git log --format='%h|%an|%ae' "origin/cicd..HEAD" 2>/dev/null \
+            | grep -vE '\|([0-9]+\+[^@]+@users\.noreply\.github\.com|business@bonc\.com\.cn)$' \
+            || true)
+          if [ -n "$bad" ]; then
+            echo "::error::Commits to cicd contain non-noreply author emails:"
+            echo "$bad"
+            exit 1
+          fi
+          echo "✅ All commit author emails are noreply."

--- a/.github/workflows/email-gate.yml
+++ b/.github/workflows/email-gate.yml
@@ -1,0 +1,44 @@
+# Email hygiene gate — blocks PRs whose commits carry personal email addresses.
+#
+# Personal emails (gmail / qq / 163 / corporate-personal / *.local) must never
+# enter public commit history. Every commit in a PR must use a noreply address:
+#   {GitHubUserID}+{username}@users.noreply.github.com
+# or a sanctioned team address (business@bonc.com.cn).
+#
+# This gate is fast (<5s): it only inspects commit author emails, no build.
+# It runs on every PR targeting develop (and is also wired into cicd's verify).
+
+name: email-gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-commit-emails:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check author emails
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          bad=$(git log --format='%h|%an|%ae' "$BASE_SHA..$HEAD_SHA" 2>/dev/null \
+            | grep -vE '\|([0-9]+\+[^@]+@users\.noreply\.github\.com|business@bonc\.com\.cn)$' \
+            || true)
+          if [ -n "$bad" ]; then
+            echo "::error::PR contains commits with non-noreply author emails:"
+            echo "$bad"
+            echo ""
+            echo "Fix: set git config user.email to {GitHubUserID}+{username}@users.noreply.github.com"
+            echo "  e.g. git config --global user.email 12345678+octocat@users.noreply.github.com"
+            echo "  then amend/rebase the offending commits."
+            exit 1
+          fi
+          echo "✅ All commit author emails are noreply."


### PR DESCRIPTION
**背景**：develop 历史出现 10+ 个带个人邮箱（qq/gmail）的提交，个人邮箱已进公开仓库历史。根因：本地 git config 未配 noreply，且 CI 移到 cicd 后 develop 无自动检查。

**改动**：
1. 新增 .github/workflows/email-gate.yml——秒级检查，跑在所有 PR 上：校验 PR 提交作者邮箱必须是 noreply 或 business@bonc.com.cn，否则打回
2. ci.yml（cicd verify）增加 email 检查步骤——发布前兜底

**配套**：develop 保护需加 required check（email-gate 的 job：check-commit-emails）

**效果**：以后任何人提交带个人邮箱，PR 直接红——从源头杜绝泄漏