### PR TITLE
ci: 固定 Release 说明避免泄露邮箱和内部信息

### DIFF
--- a/.github/workflows/build-macos-signed.yml
+++ b/.github/workflows/build-macos-signed.yml
@@ -203,6 +203,17 @@ jobs:
           files: dist/*.dmg
           # tag 名字就用推送的那个 tag (比如 v0.0.6)
           tag_name: ${{ github.ref_name }}
+          # 显式关闭自动生成的更新日志。
+          # 若不设置 body,action 会让 GitHub 自动汇总本次 tag 涵盖的
+          # 所有 commit message(含提交者邮箱、co-author、内部实现细节),
+          # 这些会公开在 Release 页面。这里用固定的干净说明覆盖,避免泄露。
+          generate_release_notes: false
+          body: |
+            CogSeed ${{ github.ref_name }} macOS 安装包(已签名并公证)。
+
+            下载对应芯片的版本:
+            - arm64.dmg — Apple 芯片(M 系列)
+            - x64.dmg — Intel 芯片
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## 问题
发布 v0.1.2 时,Release 页面自动汇总了本次 tag 涵盖的所有 commit message,暴露了提交者真实邮箱、本地机器名、内部任务编号(COGSEED-*)和实现细节。仓库是 public,这些对外可见。

## 根因
build-macos-signed.yml 的发布步骤(softprops/action-gh-release)没设置 body,该 action 在 body 为空时会让 GitHub 自动生成更新日志(汇总所有 commit)。

## 修复
发布步骤加 `generate_release_notes: false` + 固定 body,以后 Release 页面只显示干净的下载指引,不再汇总 commit。

## 说明
- v0.1.2 已发布的 Release 说明已手动改为干净版本。
- 本 PR 让后续版本自动保持干净。
- commit 历史里已有的邮箱/内部信息不在本 PR 范围内(需另行决定是否清理历史)。