### PR TITLE
chore(deps): point Dependabot npm PRs at develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Why
Dependabot npm PRs currently default to the repository default branch (`main`). Dependency updates should land on the dev line (`develop`) and go through review before reaching `cicd` at release time.

## What
- `.github/dependabot.yml`: add `target-branch: develop` to the npm ecosystem

## How verified
- Config syntax valid (YAML); Dependabot will pick it up on next scheduled run (Monday 09:00 Asia/Shanghai)
- Related: closed PR #59 (electron-log bump had wrongly targeted `cicd`)