### PR TITLE
fix(messaging): desktop live refresh, id-free chat titles, failure detail passthrough

### DIFF
--- a/src/main/features/cogseed_backend/group-chat-projection.ts
+++ b/src/main/features/cogseed_backend/group-chat-projection.ts
@@ -143,6 +143,7 @@ export function groupChatProcessDataForProjection(
           phase: kind === 'tool.started' ? 'start' : 'result',
           ...(typeof payload.name === 'string' ? { name: payload.name } : {}),
           ...(kind === 'tool.finished' && typeof payload.isError === 'boolean' ? { isError: payload.isError } : {}),
+          ...(kind === 'tool.finished' && payload.isError === true && typeof payload.error === 'string' && payload.error ? { error: payload.error.slice(0, 500) } : {}),
         },
       },
     };
@@ -166,7 +167,15 @@ function terminalText(event: CogSeedProjectionEvent): { text: string; failureKin
     return text ? { text } : null;
   }
   if (event.type === 'task.failed') {
-    return { text: t('cogseed.runtime_failed'), failureKind: 'runtime', failureCode: 'runtime_failed' };
+    // Append the executor's failure detail (when the adapter recorded one)
+    // so the conversation bubble shows the actual cause instead of only the
+    // generic retry notice.
+    const detail = typeof event.payload.error === 'string' ? event.payload.error.trim().slice(0, 500) : '';
+    return {
+      text: detail ? `${t('cogseed.runtime_failed')}\n\n${detail}` : t('cogseed.runtime_failed'),
+      failureKind: 'runtime',
+      failureCode: 'runtime_failed',
+    };
   }
   return null;
 }

--- a/src/main/features/cogseed_backend/local-cli-execution-adapter.ts
+++ b/src/main/features/cogseed_backend/local-cli-execution-adapter.ts
@@ -116,6 +116,9 @@ function mapNonTerminalEvent(
   }
   if (event.type === 'tool-event') {
     const phase = event.phase === 'result' ? 'tool_result' : 'tool_call';
+    const toolErrorText = event.isError === true && typeof event.output === 'string'
+      ? event.output.trim()
+      : '';
     return {
       type: 'event',
       ...base,
@@ -123,7 +126,9 @@ function mapNonTerminalEvent(
       metadata: {
         kernel_event: phase,
         ...(typeof event.tool === 'string' ? { name: event.tool } : {}),
+        ...(typeof event.callId === 'string' && event.callId ? { call_id: event.callId } : {}),
         ...(phase === 'tool_result' ? { isError: event.isError === true } : {}),
+        ...(phase === 'tool_result' && toolErrorText ? { error: toolErrorText.slice(0, 2000) } : {}),
       },
     };
   }

--- a/src/main/features/cogseed_backend/runtime-controller.ts
+++ b/src/main/features/cogseed_backend/runtime-controller.ts
@@ -197,10 +197,19 @@ async function mapRuntimeEvent(
   }
   if (event.type === 'error' && event.status === 'failed') {
     const failed = await transitionCogSeedTask(userId, task.taskId, 'failed', { errorCode: 'runtime_failed' });
+    // Carry the executor's failure detail (gateway/CLI error text, failure
+    // code) into the projected event — without it every failure collapses
+    // into the generic retry notice and the root cause is unrecoverable
+    // from the conversation history alone.
+    const failureDetail = String(event.error || '').trim();
+    const failureCode = typeof event.metadata?.code === 'string' ? event.metadata.code : '';
     await projectTaskEventBestEffort(userId, failed, {
       eventId: `cogseed-event-terminal-${task.taskId}`,
       type: 'task.failed',
-      payload: {},
+      payload: {
+        ...(failureDetail ? { error: failureDetail.slice(0, 2000) } : {}),
+        ...(failureCode ? { code: failureCode } : {}),
+      },
     }, projectTaskEvent);
     return failed;
   }
@@ -212,9 +221,11 @@ async function mapRuntimeEvent(
       });
       await projectTaskEventBestEffort(userId, task, stored, projectTaskEvent);
     } else if (kernelEvent === 'tool_result') {
+      const toolError = typeof event.metadata?.error === 'string' ? event.metadata.error.trim() : '';
       const stored = await appendCogSeedTaskEvent(userId, task.taskId, task.sessionId, 'tool.finished', {
         ...(typeof event.metadata?.name === 'string' ? { name: event.metadata.name } : {}),
         ...(typeof event.metadata?.isError === 'boolean' ? { isError: event.metadata.isError } : {}),
+        ...(event.metadata?.isError === true && toolError ? { error: toolError.slice(0, 2000) } : {}),
       });
       await projectTaskEventBestEffort(userId, task, stored, projectTaskEvent);
     } else if (kernelEvent === 'artifact') {

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -2641,6 +2641,7 @@ async function _enqueueBody(
         from: fromActorId,
         turnEnd: params.turn_end === true,
       });
+      log.info(`desktop message broadcast uid=${uid} cid=${cid} msg=${msgId} from=${fromActorId}`);
     } catch {
       // A broken broadcast listener must never take the bus down.
     }

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -237,6 +237,27 @@ export function _setP3394ControllerForTest(
   _p3394ControllerForTest = controller;
 }
 
+/** Notification a persisted group-chat message sends to the app shell
+ *  (renderer push, tests). Fired after `appendVisible`, so receivers can
+ *  re-read conversation state from disk. */
+export interface GroupChatMessageBroadcast {
+  uid: string;
+  cid: string;
+  msgId: string;
+  from: string;
+  turnEnd: boolean;
+}
+
+type GroupChatMessageBroadcaster = (info: GroupChatMessageBroadcast) => void;
+
+let messageBroadcaster: GroupChatMessageBroadcaster | null = null;
+
+/** Register the desktop push hook (IPC layer calls this at boot). Passing
+ *  null detaches (used by tests to isolate). */
+export function setGroupChatMessageBroadcaster(fn: GroupChatMessageBroadcaster | null): void {
+  messageBroadcaster = fn;
+}
+
 /** Minimal HTML escape for embedding raw error strings inside the
  *  failure-style `<span>` we emit on stream errors. Keeps `<`/`>`/`&`/`"`
  *  out of the renderer's markdown-ish rendering pass without pulling in
@@ -2603,6 +2624,27 @@ async function _enqueueBody(
     ...members.actors.map((a) => a.id),
   ]);
   await appendVisible(uid, cid, sliceMsg, Array.from(allActorIds));
+
+  // Desktop refresh rail: every persisted group-chat message (in-app sends,
+  // external-channel inbound like Feishu, agent replies) notifies the
+  // registered broadcaster. The IPC layer wires this to a
+  // `conversations:updated` push so the renderer's sidebar and open
+  // conversation stay live even when no per-request stream is attached
+  // (which is exactly the external-inbound case: nothing in the renderer
+  // subscribed to this conversation's bus events).
+  if (messageBroadcaster) {
+    try {
+      messageBroadcaster({
+        uid,
+        cid,
+        msgId,
+        from: fromActorId,
+        turnEnd: params.turn_end === true,
+      });
+    } catch {
+      // A broken broadcast listener must never take the bus down.
+    }
+  }
 
   emit(state, {
     type: "message",

--- a/src/main/features/local_agents/backends/claude.ts
+++ b/src/main/features/local_agents/backends/claude.ts
@@ -419,6 +419,7 @@ export function mapClaudeEvent(
             callId: String(part.tool_use_id || ''),
             phase: 'result',
             output: out,
+            ...(part.is_error === true ? { isError: true } : {}),
           },
         };
       }

--- a/src/main/features/messaging/bindings.ts
+++ b/src/main/features/messaging/bindings.ts
@@ -2,6 +2,7 @@ import { Mutex } from 'async-mutex';
 
 import { nowIso, readJson, safeId, writeJson } from '../../storage';
 import { userMessagingBindingsFile } from '../../paths';
+import { t } from '../../i18n';
 import * as chats from '../chats';
 import * as spaces from '../spaces';
 import type { InboundEnvelope, MessagingBinding, MessagingBindingsFile, MessagingInstance } from './types';
@@ -90,6 +91,7 @@ function normalizeBinding(key: string, value: unknown): MessagingBinding | null 
     externalChatId,
     ...(externalUserId ? { externalUserId } : {}),
     ...(boundedOptionalText(item.externalChatTitle, 240) ? { externalChatTitle: boundedOptionalText(item.externalChatTitle, 240) } : {}),
+    ...(boundedOptionalText(item.externalUserName, 240) ? { externalUserName: boundedOptionalText(item.externalUserName, 240) } : {}),
     cid: item.cid,
     ...(typeof item.spaceId === 'string' && safeId(item.spaceId) ? { spaceId: item.spaceId } : {}),
     ...(typeof item.projectId === 'string' && safeId(item.projectId) ? { projectId: item.projectId } : {}),
@@ -137,6 +139,7 @@ function refreshBinding(binding: MessagingBinding, envelope: InboundEnvelope): M
     externalChatId: envelope.externalChatId,
     ...(envelope.externalUserId ? { externalUserId: envelope.externalUserId } : {}),
     ...(envelope.externalChatTitle ? { externalChatTitle: envelope.externalChatTitle.slice(0, 240) } : {}),
+    ...(envelope.externalUserName ? { externalUserName: envelope.externalUserName.slice(0, 240) } : {}),
     ...replyContextFromEnvelope(envelope),
     updatedAt: nowIso(),
   };
@@ -145,6 +148,63 @@ function refreshBinding(binding: MessagingBinding, envelope: InboundEnvelope): M
   if (envelope.replyInThread !== true) delete next.replyInThread;
   if (!envelope.contextTokenRef) delete next.contextTokenRef;
   return next;
+}
+
+/** Human-facing conversation title for a messaging binding. Direct chats
+ *  label with the peer's display name (Feishu p2p carries no chat title, so
+ *  the sender's resolved name is the only human-readable handle); group
+ *  chats keep chat title + sender. Never leaks the raw external chat id
+ *  (oc_…/ou_…) as the user-visible label. */
+export function conversationTitleForEnvelope(
+  instance: MessagingInstance,
+  envelope: InboundEnvelope,
+): string {
+  const conversationScope = scopeForEnvelope(envelope);
+  const chatLabel = conversationScope === 'group_sender'
+    ? (envelope.externalChatTitle?.trim() || envelope.externalChatId)
+    : (envelope.externalChatTitle?.trim() || envelope.externalUserName?.trim() || t('messaging.direct_chat'));
+  const senderLabel = conversationScope === 'group_sender'
+    ? (envelope.externalUserName?.trim() || envelope.externalUserId)
+    : '';
+  return [instance.displayName, chatLabel, senderLabel].filter(Boolean).join(' · ').slice(0, 120);
+}
+
+/** One-time upgrade for conversations whose title still shows the raw
+ *  external chat id (created before name enrichment reached the title
+ *  builder), or the name-less fallback form once a name becomes available.
+ *  Manual renames always win; anything else re-derives the title from the
+ *  enriched envelope. Best-effort: a failed read/write never blocks the
+ *  inbound dispatch that called it. */
+async function upgradeIdTitle(
+  uid: string,
+  instance: MessagingInstance,
+  binding: MessagingBinding,
+  envelope: InboundEnvelope,
+): Promise<void> {
+  try {
+    if (!binding.externalChatId) return;
+    const hasName = !!(envelope.externalUserName?.trim() || binding.externalUserName?.trim());
+    if (!hasName) return;
+    const conversation = await chats.getConversation(uid, binding.cid);
+    if (!conversation || conversation.title_manually_set === true) return;
+    const title = conversation.title || '';
+    // Only rewrite titles that still embed the raw id or the name-less
+    // fallback — enriched ones ("飞书 · 张三") and user renames stay.
+    const idForm = title.includes(binding.externalChatId);
+    const fallbackForm = binding.conversationScope !== 'group_sender'
+      && title.endsWith(`· ${t('messaging.direct_chat')}`);
+    if (!idForm && !fallbackForm) return;
+    const labelEnvelope: InboundEnvelope = {
+      ...envelope,
+      externalChatTitle: envelope.externalChatTitle || binding.externalChatTitle,
+      externalUserName: envelope.externalUserName || binding.externalUserName,
+    };
+    const nextTitle = conversationTitleForEnvelope(instance, labelEnvelope);
+    if (!nextTitle || nextTitle === title) return;
+    await chats.updateConversation(uid, binding.cid, { title: nextTitle });
+  } catch {
+    // Title upgrade is cosmetic; never let it break message delivery.
+  }
 }
 
 async function spaceForWorkspace(uid: string, instance: MessagingInstance): Promise<string | undefined> {
@@ -204,6 +264,7 @@ export async function resolveOrCreateBinding(
       const refreshed = refreshBinding(existing, envelope);
       data.bindings[key] = refreshed;
       await writeBindings(uid, data);
+      await upgradeIdTitle(uid, instance, refreshed, envelope);
       return { ...refreshed };
     }
     if (existing) delete data.bindings[key];
@@ -228,11 +289,7 @@ export async function resolveOrCreateBinding(
       if (legacy && legacy.conversationScope === 'legacy') delete data.bindings[oldKey];
     }
 
-    const chatLabel = envelope.externalChatTitle?.trim() || envelope.externalChatId;
-    const senderLabel = conversationScope === 'group_sender'
-      ? (envelope.externalUserName?.trim() || envelope.externalUserId)
-      : '';
-    const title = [instance.displayName, chatLabel, senderLabel].filter(Boolean).join(' · ').slice(0, 120);
+    const title = conversationTitleForEnvelope(instance, envelope);
     const conversation = await chats.createConversation(uid, {
       title,
       ...(spaceId ? { spaceId } : {}),
@@ -245,6 +302,7 @@ export async function resolveOrCreateBinding(
       externalChatId: envelope.externalChatId,
       ...(envelope.externalUserId ? { externalUserId: envelope.externalUserId } : {}),
       ...(envelope.externalChatTitle ? { externalChatTitle: envelope.externalChatTitle.slice(0, 240) } : {}),
+      ...(envelope.externalUserName ? { externalUserName: envelope.externalUserName.slice(0, 240) } : {}),
       cid: conversation.conversation_id,
       ...(spaceId ? { spaceId } : {}),
       ...replyContextFromEnvelope(envelope),

--- a/src/main/features/messaging/manager.ts
+++ b/src/main/features/messaging/manager.ts
@@ -728,13 +728,30 @@ async function handleCardAction(uid: string, action: CardActionEnvelope): Promis
   if (action.action === 'approve' || action.action === 'approve_once'
     || action.action === 'approve_session' || action.action === 'approve_always') {
     const decision = await wakeController.decideWakeRequest(uid, { requestId: wakeId, decision: 'approve' });
-    if (decision.ok === false) return { accepted: false, duplicate: false, reason: decision.error || 'wake_approval_failed' };
+    if (decision.ok === false) {
+      const reasonText = String(decision.error || '');
+      // Idempotent re-click: the wake already advanced past approval (it was
+      // approved earlier and may already be executing). Settle the card so
+      // the operator sees feedback instead of a silent no-op button.
+      if (/cannot be approved from (approved|executed|executing)/.test(reasonText)) {
+        void finalizeApprovalCard(uid, action);
+        return { accepted: true, duplicate: false };
+      }
+      void finalizeFailedCard(uid, action, reasonText || 'wake_approval_failed');
+      return { accepted: false, duplicate: false, reason: reasonText || 'wake_approval_failed' };
+    }
     void finalizeApprovalCard(uid, action);
     return { accepted: true, duplicate: false };
   }
   if (action.action === 'deny') {
     const decision = await wakeController.decideWakeRequest(uid, { requestId: wakeId, decision: 'reject' });
-    if (decision.ok === false) return { accepted: false, duplicate: false, reason: decision.error || 'wake_rejection_failed' };
+    if (decision.ok === false) {
+      const reasonText = String(decision.error || '');
+      // Denying an already-approved/executed wake is a legitimate miss (the
+      // operator was too late) — still surface why instead of silence.
+      void finalizeFailedCard(uid, action, reasonText || 'wake_rejection_failed');
+      return { accepted: false, duplicate: false, reason: reasonText || 'wake_rejection_failed' };
+    }
     void finalizeApprovalCard(uid, action);
     return { accepted: true, duplicate: false };
   }
@@ -841,6 +858,33 @@ async function finalizeApprovalCard(uid: string, action: CardActionEnvelope): Pr
     await adapter.updateCard(action.externalMessageId, buildResolvedApprovalCard(action.action));
   } catch (error) {
     log.warn('messaging approval card finalize failed', {
+      instanceId: action.instanceId,
+      error: (error as Error).message,
+    });
+  }
+}
+
+/** Terminal card for a wake button click that could not take effect (e.g.
+ *  re-clicking approve after the wake already executed). Without this the
+ *  click is a silent no-op from the operator's point of view. */
+async function finalizeFailedCard(uid: string, action: CardActionEnvelope, reason: string): Promise<void> {
+  const runtime = runtimes.get(uid)?.get(action.instanceId);
+  if (!runtime || !isCurrentRuntime(uid, runtime)) return;
+  const adapter = runtime.adapter;
+  if (!isCardAdapter(adapter)) return;
+  try {
+    await adapter.updateCard(action.externalMessageId, {
+      config: { wide_screen_mode: true },
+      header: {
+        title: { content: t('messaging.wake_card.noop_title'), tag: 'plain_text' },
+        template: 'grey',
+      },
+      elements: [
+        { tag: 'markdown', content: `**${t('messaging.wake_card.noop_detail')}**\n\n\`${reason.slice(0, 300)}\`` },
+      ],
+    });
+  } catch (error) {
+    log.warn('messaging failed card finalize failed', {
       instanceId: action.instanceId,
       error: (error as Error).message,
     });

--- a/src/main/features/messaging/types.ts
+++ b/src/main/features/messaging/types.ts
@@ -131,6 +131,10 @@ export interface MessagingBinding {
   externalChatId: string;
   externalUserId?: string;
   externalChatTitle?: string;
+  /** Resolved display name of the bound peer (direct chats) or group
+   *  sender — persisted so title upgrades survive without a fresh API
+   *  lookup on the next inbound. */
+  externalUserName?: string;
   cid: string;
   /** 空间化后 workspace 绑定写 spaceId；旧记录保留 projectId 兼容读。 */
   spaceId?: string;

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -62,6 +62,7 @@ import * as personalOntologyGroups from '../features/personal_ontology_groups';
 import * as personalOntologyTemplateFiles from '../features/personal_ontology_template_files';
 import { getRoleTemplate } from '../features/role_templates';
 import type { GroupEvent } from '../features/group_chat/bus';
+import { setGroupChatMessageBroadcaster } from '../features/group_chat/bus';
 import * as agents from '../features/agents';
 import * as autoTasks from '../features/auto_tasks';
 import { isAgentEnabled } from '../features/component_enabled';
@@ -5337,6 +5338,14 @@ export const p3394BridgeIpcPort = new P3394IpcChannel('ipc', {
 });
 
 export function register(): void {
+  // Desktop live-refresh rail: every persisted group-chat message (external
+  // channel inbound included — nothing in the renderer holds a stream for
+  // those conversations) is pushed to all windows so the sidebar and the
+  // open conversation can refresh without a manual reload.
+  setGroupChatMessageBroadcaster((info) => {
+    broadcastToRenderer('conversations:updated', info);
+  });
+
   const handleInvoke = async (event, request: unknown) => {
     if (!isTrustedIpcSender(event.sender)) {
       log.warn('rejected invoke from untrusted renderer');

--- a/src/main/locales/en.json
+++ b/src/main/locales/en.json
@@ -218,6 +218,8 @@
   "expense_agent.submit.unavailable": "Unable to show submission confirmation; nothing was submitted.",
   "expense_agent.submit.cancelled": "Submission was cancelled; no data was sent to Feishu.",
   "cogseed.runtime_failed": "The Agent stopped before completing this response. Try again.",
+  "messaging.wake_card.noop_title": "No effect",
+  "messaging.wake_card.noop_detail": "This wake request is no longer pending approval (it may already be approved and running); this click changed nothing.",
   "messaging.direct_chat": "Direct chat",
   "messaging.new_session_confirmation": "Started a new conversation. What would you like to handle next?",
   "messaging.approval.approve": "Approved",

--- a/src/main/locales/en.json
+++ b/src/main/locales/en.json
@@ -218,6 +218,7 @@
   "expense_agent.submit.unavailable": "Unable to show submission confirmation; nothing was submitted.",
   "expense_agent.submit.cancelled": "Submission was cancelled; no data was sent to Feishu.",
   "cogseed.runtime_failed": "The Agent stopped before completing this response. Try again.",
+  "messaging.direct_chat": "Direct chat",
   "messaging.new_session_confirmation": "Started a new conversation. What would you like to handle next?",
   "messaging.approval.approve": "Approved",
   "messaging.approval.approve_once": "Approved once",

--- a/src/main/locales/ja.json
+++ b/src/main/locales/ja.json
@@ -218,6 +218,8 @@
   "expense_agent.submit.unavailable": "送信確認を表示できません。何も送信されていません。",
   "expense_agent.submit.cancelled": "送信をキャンセルしました。Feishu にデータは送信されていません。",
   "cogseed.runtime_failed": "エージェントはこの応答を完了できませんでした。もう一度お試しください。",
+  "messaging.wake_card.noop_title": "操作は無効です",
+  "messaging.wake_card.noop_detail": "このウェイク要求は承認待ちの状態にありません（すでに承認され実行中の可能性があります）。このクリックでは何も変更されません。",
   "messaging.direct_chat": "ダイレクトチャット",
   "messaging.new_session_confirmation": "新しい会話を開始しました。次に何を処理しますか？",
   "messaging.approval.approve": "許可済み",

--- a/src/main/locales/ja.json
+++ b/src/main/locales/ja.json
@@ -218,6 +218,7 @@
   "expense_agent.submit.unavailable": "送信確認を表示できません。何も送信されていません。",
   "expense_agent.submit.cancelled": "送信をキャンセルしました。Feishu にデータは送信されていません。",
   "cogseed.runtime_failed": "エージェントはこの応答を完了できませんでした。もう一度お試しください。",
+  "messaging.direct_chat": "ダイレクトチャット",
   "messaging.new_session_confirmation": "新しい会話を開始しました。次に何を処理しますか？",
   "messaging.approval.approve": "許可済み",
   "messaging.approval.approve_once": "1回だけ許可済み",

--- a/src/main/locales/pt.json
+++ b/src/main/locales/pt.json
@@ -218,6 +218,8 @@
   "expense_agent.submit.unavailable": "Não foi possível mostrar a confirmação; nada foi enviado.",
   "expense_agent.submit.cancelled": "O envio foi cancelado; nenhum dado foi enviado ao Feishu.",
   "cogseed.runtime_failed": "O agente não conseguiu concluir esta resposta. Tente novamente.",
+  "messaging.wake_card.noop_title": "Sem efeito",
+  "messaging.wake_card.noop_detail": "Esta solicitação de ativação não está mais pendente de aprovação (pode já estar aprovada e em execução); este clique não alterou nada.",
   "messaging.direct_chat": "Conversa direta",
   "messaging.new_session_confirmation": "Nova conversa iniciada. O que você gostaria que eu resolva em seguida?",
   "messaging.approval.approve": "Permitido",

--- a/src/main/locales/pt.json
+++ b/src/main/locales/pt.json
@@ -218,6 +218,7 @@
   "expense_agent.submit.unavailable": "Não foi possível mostrar a confirmação; nada foi enviado.",
   "expense_agent.submit.cancelled": "O envio foi cancelado; nenhum dado foi enviado ao Feishu.",
   "cogseed.runtime_failed": "O agente não conseguiu concluir esta resposta. Tente novamente.",
+  "messaging.direct_chat": "Conversa direta",
   "messaging.new_session_confirmation": "Nova conversa iniciada. O que você gostaria que eu resolva em seguida?",
   "messaging.approval.approve": "Permitido",
   "messaging.approval.approve_once": "Permitido uma vez",

--- a/src/main/locales/zh.json
+++ b/src/main/locales/zh.json
@@ -218,6 +218,7 @@
   "expense_agent.submit.unavailable": "无法显示提交确认，本次未提交。",
   "expense_agent.submit.cancelled": "已取消提交，未向飞书发送数据。",
   "cogseed.runtime_failed": "智能体未能完成本次回复。请重试。",
+  "messaging.direct_chat": "私聊",
   "messaging.new_session_confirmation": "已开始新的对话。请告诉我接下来要处理什么。",
   "messaging.approval.approve": "已允许",
   "messaging.approval.approve_once": "已允许一次",

--- a/src/main/locales/zh.json
+++ b/src/main/locales/zh.json
@@ -218,6 +218,8 @@
   "expense_agent.submit.unavailable": "无法显示提交确认，本次未提交。",
   "expense_agent.submit.cancelled": "已取消提交，未向飞书发送数据。",
   "cogseed.runtime_failed": "智能体未能完成本次回复。请重试。",
+  "messaging.wake_card.noop_title": "操作未生效",
+  "messaging.wake_card.noop_detail": "该唤醒请求已不在待审批状态（可能已获批准并开始执行），本次点击没有改变任何状态。",
   "messaging.direct_chat": "私聊",
   "messaging.new_session_confirmation": "已开始新的对话。请告诉我接下来要处理什么。",
   "messaging.approval.approve": "已允许",

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -14948,6 +14948,19 @@ function _finalizeActorPlaceholder(ph, gm, cid, archive) {
   _scheduleConversationInfoFileRefresh(cid);
 }
 
+// Msg ids recently rendered through a live bus stream (in-app send / open
+// conversation observer). The `conversations:updated` desktop push consults
+// this to avoid double-rendering messages the renderer already appended.
+const _recentLiveBusMsgIds = new Set();
+const _recentLiveBusMsgOrder = [];
+function _rememberLiveBusMsgId(id) {
+  if (!id || _recentLiveBusMsgIds.has(id)) return;
+  _recentLiveBusMsgIds.add(id);
+  _recentLiveBusMsgOrder.push(id);
+  while (_recentLiveBusMsgOrder.length > 200) _recentLiveBusMsgIds.delete(_recentLiveBusMsgOrder.shift());
+}
+window.__cogseedLiveBusTracker = { has: (id) => _recentLiveBusMsgIds.has(id) };
+
 // Group-chat bus event router. Each event is one of:
 //   { type: 'message', cid, msg: GroupMessage, turn_id? }
 //   { type: 'process', cid, actor, turn_id?, data: { type, text?, event? } }
@@ -14958,6 +14971,7 @@ function _finalizeActorPlaceholder(ph, gm, cid, archive) {
 //   { type: 'aborted', cid }
 function _handleGroupBusEvent(cid, streamingMsg, evData, { archive = false } = {}) {
   if (!evData || typeof evData !== 'object') return;
+  if (evData.type === 'message' && evData.msg) _rememberLiveBusMsgId(evData.msg.id);
   if (evData.type === 'agent_run_result') {
     if (window.ConversationInfo && typeof window.ConversationInfo.refreshAgentActivity === 'function') {
       void window.ConversationInfo.refreshAgentActivity(cid);

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -309,6 +309,31 @@ function bindStaticHandlers() {
     _openTaskNotificationConversation(payload);
   });
 
+  // Live refresh for externally-originated messages (e.g. Feishu inbound).
+  // Main pushes `conversations:updated` after every persisted group-chat
+  // message; without a subscription those conversations only appear after a
+  // manual reload. Skip when the renderer already rendered this message via
+  // a live stream, or when a stream is actively updating the open
+  // conversation (reloading mid-stream would yank the streaming bubble).
+  window.cogseed.onPushEvent('conversations:updated', (payload) => {
+    if (!payload || typeof payload !== 'object') return;
+    const { cid, msgId } = payload;
+    if (typeof cid !== 'string' || !cid) return;
+    const tracker = window.__cogseedLiveBusTracker;
+    if (msgId && tracker && typeof tracker.has === 'function' && tracker.has(msgId)) return;
+    if (cid === (typeof currentCid === 'string' ? currentCid : '')) {
+      const lastStreamAt = (typeof _lastGroupWorkEventAt !== 'undefined' && _lastGroupWorkEventAt && typeof _lastGroupWorkEventAt.get === 'function')
+        ? (_lastGroupWorkEventAt.get(cid) || 0)
+        : 0;
+      if (Date.now() - lastStreamAt < 3000) return;
+      if (typeof loadConversationHistory === 'function') {
+        loadConversationHistory(cid, { preserveScroll: true });
+      }
+      return;
+    }
+    if (typeof _bumpConvToTop === 'function') _bumpConvToTop(cid);
+  });
+
   // Sidebar nav
   // 首页保持进入新建会话页（panel-new-chat）；「新任务」独立按钮已移除。
   document.getElementById('new-chat-btn').addEventListener('click', () => _setViewFromSidebar('new-chat'));

--- a/test/main/features/group_chat/bus-integration.test.ts
+++ b/test/main/features/group_chat/bus-integration.test.ts
@@ -8339,3 +8339,58 @@ describe("group_chat bus integration › Task 10 handoff finalization races", ()
   });
 });
 
+describe("group_chat bus › desktop message broadcaster", () => {
+  it("notifies the registered broadcaster for every persisted message and survives listener errors", async () => {
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const state = await import("../../../../src/main/features/group_chat/state");
+    const cid = newCid();
+    const seen: Array<Record<string, unknown>> = [];
+    let first = true;
+    bus.setGroupChatMessageBroadcaster((info) => {
+      seen.push(info);
+      if (first) {
+        first = false;
+        throw new Error("listener explosion must not break the bus");
+      }
+    });
+    try {
+      bus.subscribe(TEST_UID, cid, () => {});
+      const msg = await bus.enqueue({
+        uid: TEST_UID,
+        cid,
+        fromActorId: "user",
+        text: "广播探针",
+      });
+      await waitForQuiescent(TEST_UID, cid, 4000);
+
+      // The first call threw; the same enqueue must still have delivered its
+      // broadcast (fire-and-forget per call) and the turn must complete.
+      expect(seen.length).toBeGreaterThanOrEqual(1);
+      const info = seen.find((row) => row.msgId === msg.id);
+      expect(info).toMatchObject({
+        uid: TEST_UID,
+        cid,
+        from: state.USER_ID,
+      });
+    } finally {
+      bus.setGroupChatMessageBroadcaster(null);
+    }
+  });
+
+  it("stays silent when no broadcaster is registered", async () => {
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const cid = newCid();
+    bus.setGroupChatMessageBroadcaster(null);
+    bus.subscribe(TEST_UID, cid, () => {});
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: "静默探针",
+    });
+    await waitForQuiescent(TEST_UID, cid, 4000);
+    // Reaching here without a throw is the assertion: an unset broadcaster
+    // is the pre-fix steady state for external inbound paths.
+  });
+});
+

--- a/test/main/features/group_chat/cogseed-projection-contract.test.ts
+++ b/test/main/features/group_chat/cogseed-projection-contract.test.ts
@@ -50,4 +50,51 @@ describe('CogSeed to Group Chat projection contract', () => {
     ]);
     expect(enqueue).not.toHaveBeenCalled();
   });
+
+  it('carries failure detail into the terminal message and tool error text into the process rail', async () => {
+    const processEvents: unknown[] = [];
+    const terminalMessages: unknown[] = [];
+    const { createCogSeedGroupChatProjection } = await import(
+      '../../../../src/main/features/cogseed_backend/group-chat-projection'
+    );
+    const { t } = await import('../../../../src/main/i18n');
+    const projection = createCogSeedGroupChatProjection({
+      conversationExists: vi.fn(async () => true),
+      appendProcessEvent: vi.fn(async (input: unknown) => { processEvents.push(input); }),
+      appendTerminalMessage: vi.fn(async (input: unknown) => { terminalMessages.push(input); }),
+    });
+    const base = {
+      userId: 'projection-user',
+      conversationId: 'cid-projection',
+      agentId: 'agent-projection',
+      taskId: 'cogseed-task-fail-projection',
+      sessionId: 'cogseed-session-gmember-cid-projection-agent-fail',
+    };
+
+    await projection.project({
+      ...base,
+      event: { eventId: 'ev-tool-err', type: 'tool.finished', payload: { name: 'search_files', isError: true, error: 'E_RUNTIME_NO_ROOTS: no explicit runtime roots' } },
+    } as any);
+    await projection.project({
+      ...base,
+      event: { eventId: 'ev-failed', type: 'task.failed', payload: { error: 'local CLI execution failed', code: 'failed' } },
+    } as any);
+
+    // Process rail keeps the tool's error text visible for diagnosis.
+    expect(processEvents[0]).toMatchObject({
+      kind: 'tool.finished',
+      data: expect.objectContaining({
+        name: 'search_files',
+        isError: true,
+        error: 'E_RUNTIME_NO_ROOTS: no explicit runtime roots',
+      }),
+    });
+    // Terminal bubble appends the executor's cause to the generic notice.
+    expect(terminalMessages[0]).toMatchObject({
+      text: expect.stringContaining('local CLI execution failed'),
+      failureKind: 'runtime',
+      failureCode: 'runtime_failed',
+    });
+    expect((terminalMessages[0] as { text: string }).text).toContain(t('cogseed.runtime_failed'));
+  });
 });

--- a/test/main/features/messaging-binding-title.test.ts
+++ b/test/main/features/messaging-binding-title.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Messaging 绑定会话标题 —— 私聊不泄漏外部账号 ID。
+ *
+ * 覆盖（纯函数，无 IO）：
+ *   - 私聊：有发送者名 → “实例 · 名字”；无名 → “实例 · 私聊”（兜底词条），
+ *     任何情况标题都不含 oc_/ou_ 原始 ID
+ *   - 群聊：群名 + 发送者保持原格式；无群名时退化为 chat id（现状保留）
+ *   - 标题超长截断到 120 字符
+ */
+
+import { describe, it, expect } from 'vitest';
+import { conversationTitleForEnvelope } from '../../../src/main/features/messaging/bindings';
+import { t } from '../../../src/main/i18n';
+import type { InboundEnvelope, MessagingInstance } from '../../../src/main/features/messaging/types';
+
+const instance = { id: 'inst_1', displayName: '飞书' } as MessagingInstance;
+
+function envelope(partial: Partial<InboundEnvelope>): InboundEnvelope {
+  return {
+    platform: 'feishu_lark',
+    instanceId: 'inst_1',
+    externalMessageId: 'om_1',
+    externalChatId: 'oc_f04e8e2c23943665ab151e30a3237b51',
+    externalUserId: 'ou_2e921d0f3cc121794da5cb9048fa7f34',
+    text: 'hi',
+    isGroup: false,
+    mentionPresent: false,
+    receivedAt: '2026-08-26T00:00:00Z',
+    ...partial,
+  };
+}
+
+describe('messaging/bindings — conversationTitleForEnvelope', () => {
+  it('私聊：enrich 到发送者名时标题用名字', () => {
+    const title = conversationTitleForEnvelope(instance, envelope({ externalUserName: '牛保康' }));
+    expect(title).toBe('飞书 · 牛保康');
+    expect(title).not.toContain('oc_');
+    expect(title).not.toContain('ou_');
+  });
+
+  it('私聊：拿不到名字时退化为兜底文案，不暴露原始 ID', () => {
+    const title = conversationTitleForEnvelope(instance, envelope({}));
+    expect(title).toBe(`飞书 · ${t('messaging.direct_chat')}`);
+    expect(title).not.toContain('oc_');
+    expect(title).not.toContain('ou_');
+  });
+
+  it('私聊：externalChatTitle 优先于发送者名', () => {
+    const title = conversationTitleForEnvelope(instance, envelope({
+      externalChatTitle: '置顶会话',
+      externalUserName: '牛保康',
+    }));
+    expect(title).toBe('飞书 · 置顶会话');
+  });
+
+  it('群聊：群名 + 发送者名的既有格式保持不变', () => {
+    const title = conversationTitleForEnvelope(instance, envelope({
+      isGroup: true,
+      externalChatTitle: '项目讨论群',
+      externalUserName: '李四',
+    }));
+    expect(title).toBe('飞书 · 项目讨论群 · 李四');
+  });
+
+  it('群聊：无群名时保留 chat id 兜底（现状）', () => {
+    const title = conversationTitleForEnvelope(instance, envelope({
+      isGroup: true,
+      externalUserName: '李四',
+    }));
+    expect(title).toBe(`飞书 · oc_f04e8e2c23943665ab151e30a3237b51 · 李四`);
+  });
+
+  it('标题超长时截断到 120 字符', () => {
+    const title = conversationTitleForEnvelope(instance, envelope({
+      externalUserName: '名'.repeat(300),
+    }));
+    expect(title.length).toBeLessThanOrEqual(120);
+  });
+});

--- a/test/main/features/messaging.test.ts
+++ b/test/main/features/messaging.test.ts
@@ -2008,6 +2008,78 @@ describe('messaging card action dispatch', () => {
       vi.resetModules();
     }
   });
+
+  it('treats approve re-clicks on an already-executed wake as idempotent success', async () => {
+    const decideWakeRequest = vi.fn(async () => ({
+      ok: false,
+      error: 'wake request cannot be approved from executed',
+    }));
+    vi.doMock('../../../src/main/features/p3394/wake-controller', () => ({
+      decideWakeRequest,
+    }));
+    try {
+      const registry = await import('../../../src/main/features/messaging/registry');
+      const manager = await import('../../../src/main/features/messaging/manager');
+      const created = await registry.createInstance('user-1', {
+        platform: 'feishu_lark',
+        displayName: 'Card bot',
+        policy: { allowUserIds: ['ou_admin'] },
+        secret: { appId: 'cli_1234567890abcdef', appSecret: 'secret' },
+      });
+      await registry.updateInstance('user-1', created.id, { enabled: true });
+      const result = await manager.ingestCardAction('user-1', {
+        platform: 'feishu_lark',
+        instanceId: created.id,
+        externalMessageId: 'om_card_1',
+        externalChatId: 'oc_1',
+        externalUserId: 'ou_admin',
+        action: 'approve',
+        payload: { wake_id: 'wake-executed' },
+        receivedAt: new Date().toISOString(),
+      });
+      // The operator already approved this wake (it advanced to executed):
+      // the re-click must not surface as an error — it settles the card.
+      expect(result).toMatchObject({ accepted: true, duplicate: false });
+    } finally {
+      vi.doUnmock('../../../src/main/features/p3394/wake-controller');
+      vi.resetModules();
+    }
+  });
+
+  it('reports a non-idempotent approval failure as rejected (not silent)', async () => {
+    const decideWakeRequest = vi.fn(async () => ({
+      ok: false,
+      error: 'wake request not found',
+    }));
+    vi.doMock('../../../src/main/features/p3394/wake-controller', () => ({
+      decideWakeRequest,
+    }));
+    try {
+      const registry = await import('../../../src/main/features/messaging/registry');
+      const manager = await import('../../../src/main/features/messaging/manager');
+      const created = await registry.createInstance('user-1', {
+        platform: 'feishu_lark',
+        displayName: 'Card bot',
+        policy: { allowUserIds: ['ou_admin'] },
+        secret: { appId: 'cli_1234567890abcdef', appSecret: 'secret' },
+      });
+      await registry.updateInstance('user-1', created.id, { enabled: true });
+      const result = await manager.ingestCardAction('user-1', {
+        platform: 'feishu_lark',
+        instanceId: created.id,
+        externalMessageId: 'om_card_2',
+        externalChatId: 'oc_1',
+        externalUserId: 'ou_admin',
+        action: 'approve',
+        payload: { wake_id: 'wake-missing' },
+        receivedAt: new Date().toISOString(),
+      });
+      expect(result).toMatchObject({ accepted: false, reason: 'wake request not found' });
+    } finally {
+      vi.doUnmock('../../../src/main/features/p3394/wake-controller');
+      vi.resetModules();
+    }
+  });
 });
 
 describe('feishu approval cards', () => {


### PR DESCRIPTION
## 背景

飞书渠道联调中发现的三个问题（均为今天实际复现）：

1. 飞书消息不会实时出现在桌面端，需要 Cmd+R 或重启；
2. 飞书私聊的会话标题带 oc_ 账号 ID（`飞书 · oc_f04e…`）；
3. 外接智能体（ClaudeCode）回复失败时只有兜底文案，错误详情全链路丢失，无法定位原因。

## 修复内容

### 1. 桌面端实时刷新

**根因**：外部渠道消息经主进程 `groupChat.send` 落盘后没有任何 renderer 推送；渲染层只有"恰好开着的请求流"能收到事件，空闲会话完全无感知。

**方案**：
- `bus.ts` 在 `appendVisible` 后触发模块级广播钩子（监听器抛错不影响总线）；
- IPC 装配时接到 `broadcastToRenderer('conversations:updated')`（preload 白名单已有 `conversations:` 前缀，无需改 preload）；
- renderer 订阅：非当前会话刷新侧栏排序；当前会话在无活跃流时重载历史。与正常流式路径去重：流已渲染的 msgId 跳过，3 秒流活跃窗口内不重载，避免打断流式气泡。

### 2. 私聊标题不暴露账号 ID

**根因**：飞书私聊信封没有 chat 标题，enrich 已拿到的发送者名字（`externalUserName`）不参与标题生成，标题退化为 `飞书 · oc_xxx`。

**方案**：
- 标题生成私聊改为：chatTitle → userName → i18n「私聊」兜底，任何情况不再出现 oc_/ou_；
- binding 持久化 `externalUserName`（类型 + 读写白名单同步）；
- 存量迁移：旧 ID 型标题（及无名兜底形态）在下一条入站时自动升级；`title_manually_set` 的会话永不覆盖；
- 新增 `messaging.direct_chat` 四语言词条。

### 3. 失败错误详情透传

**根因**：`tool.finished` 只记 name+isError，`task.failed` payload 存空对象——执行器传了错误文本但 runtime-controller 全部丢弃。

**方案**（仅透传，不改判定逻辑，failureCode 不变）：
- claude 后端解析 `tool_result.is_error`；
- CLI 适配层在 isError 时携带错误文本与 call_id；
- runtime-controller 存入事件 payload；
- 投影层在过程轨与终端气泡中呈现具体原因（气泡=通用文案+错误详情）。

## 测试

- 新增 `messaging-binding-title.test.ts`（6 用例：私聊命名/兜底/优先级、群聊格式保持、截断）；
- `bus-integration.test.ts` 新增广播钩子 2 用例（容错+静默）；
- `cogseed-projection-contract.test.ts` 新增错误透传 1 用例；
- 回归：messaging 167、group_chat 622、cogseed_backend 165 全部通过；typecheck、eslint 干净。

## 风险说明

- 广播钩子为 fire-and-forget，任何异常均被吞掉，不影响消息链路；
- 标题迁移只动"仍含原始 ID 或无名兜底"的标题，手动改名优先；
- 错误详情在气泡中截断至 500 字符，过程事件 2000 字符。