### PR TITLE
perf(workspace): 根治工作空间间歇卡顿（元数据表 + 向量化子进程）

### DIFF
--- a/bin/cogseed-embed-worker.cjs
+++ b/bin/cogseed-embed-worker.cjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('node:path');
+
+const pcDir = process.env.COGSEED_PC_DIR || path.resolve(__dirname, '..');
+require(require.resolve('tsx/cjs', { paths: [pcDir] }));
+require(path.join(pcDir, 'src/main/features/kb_embed_worker_entry.ts'));

--- a/bin/packaged-entrypoint-gate.cjs
+++ b/bin/packaged-entrypoint-gate.cjs
@@ -31,6 +31,9 @@ const INTERNAL_ENTRYPOINT_CONSUMERS = Object.freeze({
   'cogseed-runtime-worker.cjs': Object.freeze([
     'src/main/features/cogseed_runtime/worker-process.ts',
   ]),
+  'cogseed-embed-worker.cjs': Object.freeze([
+    'src/main/features/kb_embed_bridge.ts',
+  ]),
   'cogseed-bridge.cjs': Object.freeze([
     'src/main/features/local_agents/bridge.ts',
     'src/main/features/local_agents/runner.ts',

--- a/run.sh
+++ b/run.sh
@@ -40,6 +40,9 @@ if [ -n "${COGSEED_WORKSPACE_ROOT:-}" ]; then
 fi
 # Do not inherit gateway-only Anthropic credentials into the app model layer.
 unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL ANTHROPIC_DEFAULT_MODEL
+# ELECTRON_RUN_AS_NODE makes the Electron binary run as plain Node and is
+# inherited by `open`-launched app instances; never let it leak into the app.
+unset ELECTRON_RUN_AS_NODE
 
 export COGSEED_RUNTIME_VARIANT="cogseed"
 

--- a/scripts/perf-seed-local.ts
+++ b/scripts/perf-seed-local.ts
@@ -1,0 +1,141 @@
+/**
+ * 本地压测数据生成/清理脚本（演示用，只动自己创建的数据）。
+ *
+ * 用法（先退出 CogSeed 应用再跑）：
+ *   npx tsx scripts/perf-seed-local.ts seed   [--spaces 40 --convs 20 --files 100]
+ *   npx tsx scripts/perf-seed-local.ts clean
+ *
+ * seed 模式：在真实用户数据里创建 N 个「压测-」前缀空间、每空间 M 个会话
+ *   （带聊天记录 + members.json）、每个空间 K 个文件。创建清单记录在
+ *   <数据根>/perf-seed-manifest.json。
+ * clean 模式：按清单删除创建的空间/会话/文件，并清掉工作空间元数据表
+ *   （该表是纯派生缓存，删除后应用会自动重建）。
+ */
+
+/* eslint-disable no-console */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+function dataRoot(): string {
+  return (
+    process.env.COGSEED_WORKSPACE_ROOT
+    || path.join(os.homedir(), '.cogseed', 'runtime-variants', 'cogseed', 'data')
+  );
+}
+
+function activeUid(): string {
+  const usersFile = path.join(dataRoot(), 'users.json');
+  try {
+    const users = JSON.parse(fs.readFileSync(usersFile, 'utf8'));
+    // 应用会按 { current_user_id, users: [{ user_id }] } 重写该文件
+    if (typeof users.current_user_id === 'string' && users.current_user_id) return users.current_user_id;
+    if (Array.isArray(users.users) && users.users[0]?.user_id) return users.users[0].user_id;
+    if (Array.isArray(users) && users[0]?.id) return users[0].id;
+    if (typeof users === 'object' && users.active) return users.active;
+    if (typeof users === 'object') {
+      const keys = Object.keys(users).filter((k) => /^\d+$/.test(k) || users[k]?.id);
+      if (keys[0]) return typeof users[keys[0]] === 'object' ? users[keys[0]].id : keys[0];
+    }
+  } catch { /* fallthrough */ }
+  throw new Error('无法从 users.json 识别用户 id；请用 COGSEED_WORKSPACE_ROOT 指向数据根后重试');
+}
+
+function parseArgs(argv: string[]): { mode: string; spaces: number; convs: number; files: number } {
+  const mode = argv[0] || 'seed';
+  const out = { mode, spaces: 40, convs: 20, files: 100 };
+  for (let i = 1; i < argv.length; i += 1) {
+    if (argv[i] === '--spaces') out.spaces = Number(argv[++i]);
+    else if (argv[i] === '--convs') out.convs = Number(argv[++i]);
+    else if (argv[i] === '--files') out.files = Number(argv[++i]);
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  process.env.COGSEED_WORKSPACE_ROOT = dataRoot();
+  const uid = activeUid();
+
+  const users = await import('../src/main/features/users');
+  users.activateUser(uid);
+  const spaces = await import('../src/main/features/spaces');
+  const chats = await import('../src/main/features/chats');
+  const pathsMod = await import('../src/main/paths');
+
+  const manifestFile = path.join(dataRoot(), 'perf-seed-manifest.json');
+
+  if (args.mode === 'clean') {
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8')) as { spaceIds: string[]; dirs: string[]; files: string[] };
+    for (const sid of manifest.spaceIds) {
+      try { await spaces.deleteSpace(uid, sid); } catch { /* best-effort */ }
+    }
+    for (const f of manifest.files) { try { fs.rmSync(f, { force: true }); } catch { /* best-effort */ } }
+    for (const d of manifest.dirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ } }
+    // 元数据表是派生缓存，直接丢弃让应用重建
+    try { fs.rmSync(pathsMod.workspaceMetaDir(uid), { recursive: true, force: true }); } catch { /* best-effort */ }
+    try { fs.rmSync(manifestFile, { force: true }); } catch { /* best-effort */ }
+    console.log('[perf-seed] 已清理压测数据 + 元数据表');
+    return;
+  }
+
+  const spaceIds: string[] = [];
+  const dirs: string[] = [];
+  const files: string[] = [];
+
+  console.log(`[perf-seed] 开始创建：${args.spaces} 空间 × ${args.convs} 会话 × ${args.files} 文件 …`);
+  for (let s = 0; s < args.spaces; s += 1) {
+    const created = await spaces.createSpace(uid, { name: `压测-${s}` });
+    if (!created.ok) throw new Error(`create space failed: ${String(created.error)}`);
+    const sid = created.space.space_id;
+    spaceIds.push(sid);
+
+    for (let c = 0; c < args.convs; c += 1) {
+      const conv = await chats.createConversation(uid, { title: `压测任务-${s}-${c}`, spaceId: sid });
+      const cid = conv.conversation_id;
+      const membersDir = path.join(pathsMod.userChatsDir(uid), cid);
+      fs.mkdirSync(membersDir, { recursive: true });
+      dirs.push(membersDir);
+      fs.writeFileSync(path.join(membersDir, 'members.json'), JSON.stringify({
+        version: 1,
+        commander_spoken: true,
+        actors: [
+          { kind: 'commander', id: 'commander', name: 'Commander', joined_at: '2026-01-01T00:00:00.000Z' },
+          { kind: 'agent', id: 'agent-a', name: 'A', joined_at: '2026-01-01T00:00:00.000Z' },
+          { kind: 'agent', id: 'agent-b', name: 'B', joined_at: '2026-01-01T00:00:00.000Z' },
+        ],
+      }));
+      const jsonl = path.join(pathsMod.userChatsDir(uid), `${cid}.jsonl`);
+      const lines: string[] = [];
+      for (let k = 0; k < 200; k += 1) {
+        lines.push(JSON.stringify({
+          from: k % 2 === 0 ? 'commander' : 'user',
+          to: k % 2 === 0 ? 'user' : 'commander',
+          ts: `2026-01-01T00:${String(k % 60).padStart(2, '0')}.000Z`,
+          text: `压测消息 ${s}-${c}-${k}，用于模拟长聊天记录体积。`,
+        }));
+      }
+      fs.writeFileSync(jsonl, `${lines.join('\n')}\n`);
+      files.push(jsonl);
+    }
+
+    const filesRoot = pathsMod.spaceFilesDir(uid, sid);
+    fs.mkdirSync(filesRoot, { recursive: true });
+    dirs.push(filesRoot);
+    for (let f = 0; f < args.files; f += 1) {
+      const p = path.join(filesRoot, `压测文件-${f}.md`);
+      fs.writeFileSync(p, `# ${s}-${f}`);
+      files.push(p);
+    }
+  }
+
+  fs.writeFileSync(manifestFile, JSON.stringify({ spaceIds, dirs, files }, null, 2));
+  console.log(`[perf-seed] 完成：${spaceIds.length} 空间、${spaceIds.length * args.convs} 会话、${spaceIds.length * args.files} 文件`);
+  console.log('[perf-seed] 现在打开 CogSeed → 进入「工作空间」，观察日志：');
+  console.log('  tail -f ~/.cogseed/runtime-variants/cogseed/data/logs/$(date +%Y-%m-%d).log | grep -E "listSpaces|listSpaceConversations|listSpaceArtifacts|listSpaceFileTree"');
+}
+
+main().catch((err) => {
+  console.error(`[perf-seed] 失败: ${(err as Error)?.message || String(err)}`);
+  process.exitCode = 1;
+});

--- a/src/main/features/chats.ts
+++ b/src/main/features/chats.ts
@@ -380,23 +380,32 @@ async function _resolveParticipantSummary(
     const cached = _convSummaryCache.get(cacheKey);
     if (cached && Date.now() - cached.at < _convSummaryTtlMs) return cached.summary;
   }
-  const [membersRes, commRes] = await Promise.allSettled([
-    readMembers(userId, c.conversation_id, c.project_id ?? null),
-    (async () => {
-      // Substring scan of `<cid>.jsonl` for any `from:"commander"` line（与列表路径同口径）。
-      const file = conversationMessageReadFile(userId, c.conversation_id, c.project_id ?? null);
-      if (!fs.existsSync(file)) return false;
+  const membersRes = await readMembers(userId, c.conversation_id, c.project_id ?? null).catch(() => null);
+  // 指挥官在场：优先用 members.json 的 commander_spoken 标志（消息落盘时
+  // 由 bus.appendMain 顺手写入）。无标志的老数据懒补记：扫一次 jsonl，
+  // 命中即回写标志 —— 此后只读 members.json 小文件。指挥官从未发言的
+  // 会话 jsonl 极小（或不存在），扫描成本可忽略；真正长且费的是指挥官
+  // 已发言的会话，它们都被标志覆盖，不再进扫描分支。
+  let commanderInChat = membersRes?.commander_spoken === true;
+  if (!commanderInChat) {
+    const file = conversationMessageReadFile(userId, c.conversation_id, c.project_id ?? null);
+    if (fs.existsSync(file)) {
       try {
         const text = await fsp.readFile(file, 'utf8');
-        return /"from"\s*:\s*"commander"/.test(text);
-      } catch { return false; }
-    })(),
-  ]);
-  const commanderInChat = commRes.status === 'fulfilled' ? commRes.value : false;
+        if (/"from"\s*:\s*"commander"/.test(text)) {
+          commanderInChat = true;
+          try {
+            const { markCommanderSpoken } = await import('./group_chat/state');
+            await markCommanderSpoken(userId, c.conversation_id, c.project_id ?? null);
+          } catch { /* 补记失败不阻断展示 */ }
+        }
+      } catch { /* 扫描失败按 false 处理 */ }
+    }
+  }
   let agentIds: string[] = [];
-  if (membersRes.status === 'fulfilled' && membersRes.value) {
+  if (membersRes) {
     const seen = new Set<string>();
-    for (const a of membersRes.value.actors) {
+    for (const a of membersRes.actors) {
       if (a && a.kind === 'agent' && a.id && !seen.has(a.id)) {
         seen.add(a.id);
         agentIds.push(a.id);
@@ -1329,8 +1338,59 @@ export async function conversationSpaceId(uid: string, cid: string): Promise<str
   return sid;
 }
 
+/** 轻量版空间会话列表 —— 仅服务于「最近会话」展示（标题/时间）。
+ *  与 listSpaceConversations 同口径合并空间索引 + 全局索引，但跳过
+ *  _resolveParticipantSummary：那一步会读每个会话的 members.json 并
+ *  把整份 <cid>.jsonl 读进内存做 commander 正则扫描。工作空间中心
+ *  （listSpaces）对 N 个空间 × M 个会话调用它，成本会放大成「全部
+ *  消息字节总和」，是工作空间首屏卡顿的主因之一。最近会话只用到
+ *  convs[0].title / updated_at，不需要智能体名单口径（COGSEED-15 的
+ *  名单一致性只作用于空间任务行，仍走完整版路径）。 */
+export async function listSpaceConversationsLight(userId: string, spaceId: string): Promise<Conversation[]> {
+  if (!safeId(spaceId)) return [];
+  const byCid = new Map<string, Conversation>();
+
+  const spaceRaw: any = await readJson(spaceChatIndexFile(userId, spaceId));
+  const spaceItems = Array.isArray(spaceRaw)
+    ? spaceRaw : (spaceRaw && Array.isArray(spaceRaw.items) ? spaceRaw.items : []);
+  for (const raw of spaceItems) {
+    const row = _normaliseConversation(raw);
+    if (!row) continue;
+    if (!row.space_id) row.space_id = spaceId;
+    byCid.set(row.conversation_id, row);
+  }
+
+  for (const c of await _readIndexConversations(userId)) {
+    if (c.space_id !== spaceId) continue;
+    if (!byCid.has(c.conversation_id)) byCid.set(c.conversation_id, c);
+  }
+
+  return Array.from(byCid.values())
+    .filter((c) => !isDeletedConversation(c))
+    .sort(_compareConversationIndexRows);
+}
+
 export async function listSpaceConversations(userId: string, spaceId: string): Promise<Conversation[]> {
   if (!safeId(spaceId)) return [];
+  const startedAt = Date.now();
+  // 持久化元数据表路径：全部会话空闲（quiescent）且指纹命中 → 直接返回，
+  // 不再逐行读 members.json（COGSEED-15：bus 忙时必须实时，名单随 turn 变）。
+  const meta = await import('./workspace_meta');
+  const bus = require('./group_chat/bus') as typeof import('./group_chat/bus');
+  const tableEntry = await meta.getEntry<Conversation[]>(userId, 'conversations', spaceId);
+  if (tableEntry && Array.isArray(tableEntry.data)) {
+    let allQuiescent = true;
+    for (const c of tableEntry.data) {
+      if (!c || !c.conversation_id || !bus.isQuiescent(userId, c.conversation_id)) {
+        allQuiescent = false;
+        break;
+      }
+    }
+    if (allQuiescent && (await _spaceConversationsStamp(userId, spaceId, tableEntry.data)) === tableEntry.stamp) {
+      log.info('listSpaceConversations table hit', { rows: tableEntry.data.length, ms: Date.now() - startedAt });
+      return tableEntry.data.map((c) => ({ ...c }));
+    }
+  }
   const byCid = new Map<string, Conversation>();
 
   const spaceRaw: any = await readJson(spaceChatIndexFile(userId, spaceId));
@@ -1360,7 +1420,56 @@ export async function listSpaceConversations(userId: string, spaceId: string): P
     c.agent_ids = s.agentIds;
     c.commander_in_chat = s.commanderInChat;
   }));
+  // 回写持久化元数据表：下次冷启动/跨空间重进直接查表。
+  try {
+    const meta = await import('./workspace_meta');
+    await meta.putEntry(userId, 'conversations', spaceId, await _spaceConversationsStamp(userId, spaceId, rows), rows);
+  } catch { /* 表写入失败不阻断 */ }
+  // 性能埋点：空间任务列表耗时（诊断用，仅计数/时长）。
+  log.info('listSpaceConversations done', { rows: rows.length, ms: Date.now() - startedAt });
   return rows;
+}
+
+/** 会话索引文件指纹（全部根）：spaces.list 等工作空间摘要用它做验证。 */
+export async function conversationIndexStamp(userId: string): Promise<string> {
+  const parts: string[] = [];
+  for (const root of conversationRoots(userId)) {
+    parts.push(`ci:${root.indexFile}:${await _fileStamp(root.indexFile)}`);
+  }
+  return parts.join('|');
+}
+
+async function _fileStamp(file: string): Promise<string> {
+  try {
+    const st = await fsp.stat(file);
+    return `${st.mtimeMs}:${st.size}`;
+  } catch {
+    return 'missing';
+  }
+}
+
+async function _entryStamp(dir: string): Promise<string> {
+  try {
+    const st = await fsp.stat(dir);
+    return `${st.mtimeMs}:${st.size}`;
+  } catch {
+    return 'missing';
+  }
+}
+
+/** 空间任务列表的验证指纹：空间会话索引 + 全部会话索引根 + 每行 members
+ *  文件（名单/commander 标志的真源）。三者任一变化即失配 → 实时重算。 */
+async function _spaceConversationsStamp(userId: string, spaceId: string, rows: Conversation[]): Promise<string> {
+  const parts: string[] = [
+    `si:${await _fileStamp(spaceChatIndexFile(userId, spaceId))}`,
+    await conversationIndexStamp(userId),
+  ];
+  for (const c of rows) {
+    if (!c?.conversation_id) continue;
+    const layout = conversationLayout(userId, c.conversation_id, c.project_id ?? null);
+    parts.push(`m:${c.conversation_id}:${await _fileStamp(layout.membersFile)}`);
+  }
+  return parts.join('|');
 }
 
 export interface StartupConversationList {

--- a/src/main/features/contexts.ts
+++ b/src/main/features/contexts.ts
@@ -23,6 +23,7 @@
  */
 
 import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { shell } from 'electron';
@@ -223,14 +224,35 @@ export function isSupportedContextFileName(name: string): boolean {
 
 // ── Listing / Reading ────────────────────────────────────────────────────
 
-export function listContextsTreeForUser(uid: string): ContextNode[] {
+/** 并发相同 uid 的树遍历 in-flight 去重（导入/树接口叠加时共享一次遍历）。
+ *  结果每次都是新鲜数据，不引入陈旧窗口。 */
+const _treeInFlight = new Map<string, Promise<ContextNode[]>>();
+
+export function listContextsTreeForUser(uid: string): Promise<ContextNode[]> {
+  const existing = _treeInFlight.get(uid);
+  if (existing) return existing;
+  const run = walkContextsTree(uid).then(
+    (tree) => {
+      if (_treeInFlight.get(uid) === run) _treeInFlight.delete(uid);
+      return tree;
+    },
+    (err) => {
+      if (_treeInFlight.get(uid) === run) _treeInFlight.delete(uid);
+      throw err;
+    },
+  );
+  _treeInFlight.set(uid, run);
+  return run;
+}
+
+async function walkContextsTree(uid: string): Promise<ContextNode[]> {
   const root = contextsRootForUser(uid);
   fs.mkdirSync(root, { recursive: true });
 
-  function walk(d: string, rel = ''): ContextNode[] {
+  async function walk(d: string, rel = ''): Promise<ContextNode[]> {
     let items;
     try {
-      items = fs.readdirSync(d, { withFileTypes: true }).sort((a, b) => {
+      items = (await fsp.readdir(d, { withFileTypes: true })).sort((a, b) => {
         if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1;
         return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
       });
@@ -242,13 +264,13 @@ export function listContextsTreeForUser(uid: string): ContextNode[] {
       const relPath = rel ? `${rel}/${e.name}` : e.name;
       const full = path.join(d, e.name);
       if (e.isDirectory()) {
-        out.push({ name: e.name, path: relPath, type: 'dir', children: walk(full, relPath) });
+        out.push({ name: e.name, path: relPath, type: 'dir', children: await walk(full, relPath) });
       } else if (e.isFile()) {
         // Show every supported KB file kind in the tree — text + binary both
         // get vectorized, both deserve to be visible.
         if (!isAllowedName(e.name)) continue;
         let size = 0; let mtime = 0;
-        try { const st = fs.statSync(full); size = st.size; mtime = st.mtimeMs / 1000; }
+        try { const st = await fsp.stat(full); size = st.size; mtime = st.mtimeMs / 1000; }
         catch { /* ignore */ }
         out.push({ name: e.name, path: relPath, type: 'file', bytes: size, mtime });
       }
@@ -258,7 +280,7 @@ export function listContextsTreeForUser(uid: string): ContextNode[] {
   return walk(root);
 }
 
-export function listContextsTree(): ContextNode[] {
+export function listContextsTree(): Promise<ContextNode[]> {
   return listContextsTreeForUser(getActiveUserId());
 }
 

--- a/src/main/features/conversation_files.ts
+++ b/src/main/features/conversation_files.ts
@@ -8,6 +8,7 @@
  */
 
 import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { macosTccSensitivePath } from '../util/macos-tcc';
@@ -33,17 +34,47 @@ export interface ConversationWorkspaceFileList {
 const DEFAULT_MAX_FILES = 5000;
 const DEFAULT_MAX_DEPTH = 12;
 
+/** 并发相同参数调用的 in-flight 去重（渲染层 refreshFiles 风暴 + IPC
+ *  无去重叠加时共享同一次遍历）。结果每次都是新鲜数据，不引入陈旧窗口。 */
+const _inflight = new Map<string, Promise<ConversationWorkspaceFileList>>();
+
+function inflightKey(root: string, maxFiles: number, maxDepth: number): string {
+  return `${path.resolve(root || '')}|${maxFiles}|${maxDepth}`;
+}
+
 function toPosixRel(rel: string): string {
   return rel.split(path.sep).filter(Boolean).join('/');
 }
 
-export function listWorkspaceFiles(
+export async function listWorkspaceFiles(
   root: string,
   opts: { maxFiles?: number; maxDepth?: number } = {},
-): ConversationWorkspaceFileList {
+): Promise<ConversationWorkspaceFileList> {
   const rootAbs = path.resolve(root || '');
   const maxFiles = Math.max(1, Math.floor(opts.maxFiles ?? DEFAULT_MAX_FILES));
   const maxDepth = Math.max(0, Math.floor(opts.maxDepth ?? DEFAULT_MAX_DEPTH));
+  const key = inflightKey(rootAbs, maxFiles, maxDepth);
+  const existing = _inflight.get(key);
+  if (existing) return existing;
+  const run = walkWorkspaceFiles(rootAbs, maxFiles, maxDepth).then(
+    (result) => {
+      if (_inflight.get(key) === run) _inflight.delete(key);
+      return result;
+    },
+    (err) => {
+      if (_inflight.get(key) === run) _inflight.delete(key);
+      throw err;
+    },
+  );
+  _inflight.set(key, run);
+  return run;
+}
+
+async function walkWorkspaceFiles(
+  rootAbs: string,
+  maxFiles: number,
+  maxDepth: number,
+): Promise<ConversationWorkspaceFileList> {
   const items: ConversationWorkspaceFile[] = [];
   let truncated = false;
 
@@ -69,7 +100,7 @@ export function listWorkspaceFiles(
     return { root: rootAbs, items, count: 0, truncated: false, rootExists: false };
   }
 
-  const walk = (dir: string, depth: number): void => {
+  const walk = async (dir: string, depth: number): Promise<void> => {
     if (items.length >= maxFiles) {
       truncated = true;
       return;
@@ -80,7 +111,7 @@ export function listWorkspaceFiles(
     }
 
     let entries: fs.Dirent[];
-    try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+    try { entries = await fsp.readdir(dir, { withFileTypes: true }); }
     catch { return; }
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -89,14 +120,14 @@ export function listWorkspaceFiles(
       const abs = path.join(dir, e.name);
       if (e.isSymbolicLink()) continue;
       if (e.isDirectory()) {
-        walk(abs, depth + 1);
+        await walk(abs, depth + 1);
         if (items.length >= maxFiles) {
           truncated = true;
           return;
         }
       } else if (e.isFile()) {
         let st: fs.Stats;
-        try { st = fs.statSync(abs); }
+        try { st = await fsp.stat(abs); }
         catch { continue; }
         items.push({
           path: abs,
@@ -113,6 +144,6 @@ export function listWorkspaceFiles(
     }
   };
 
-  walk(rootAbs, 0);
+  await walk(rootAbs, 0);
   return { root: rootAbs, items, count: items.length, truncated, rootExists: true };
 }

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -1716,6 +1716,21 @@ async function appendMain(
   const file = layout.messageFile;
   fs.mkdirSync(path.dirname(file), { recursive: true });
   await appendJsonlAtomic<GroupMessage>(file, msg);
+  // 指挥官发言在落盘时顺手标记到 members.json（commander_spoken）。
+  // 展示路径（工作空间任务列表等）据此跳过整份 jsonl 的正则扫描；
+  // 老数据由读取侧懒补记。失败不阻断消息落盘流程。
+  if (msg.from === 'commander') {
+    try {
+      const { markCommanderSpoken } = await import('./state');
+      await markCommanderSpoken(uid, cid, layout.projectId);
+    } catch (err) {
+      log.warn('markCommanderSpoken failed', {
+        uid,
+        cid,
+        error: (err as Error)?.message,
+      });
+    }
+  }
   // Stamp `updated_at` on this cid's _index.json row so the sidebar can sort
   // by real last-activity time rather than file mtime (which sync clobbers
   // when pulling from another device — see chats.ts::listConversations).

--- a/src/main/features/group_chat/state.ts
+++ b/src/main/features/group_chat/state.ts
@@ -50,6 +50,10 @@ export interface Actor {
 export interface MembersFile {
   version: 1;
   actors: Actor[];
+  /** 指挥官是否已说过话。由消息落盘时（bus.appendMain）顺手写入，
+   *  老数据在读取侧懒补记 —— 展示路径据此跳过整份 jsonl 的 commander
+   *  正则扫描（工作空间任务列表等每行一次的全量读由此消失）。 */
+  commander_spoken?: boolean;
 }
 
 export type GroupStatus = 'idle' | 'running' | 'aborted';
@@ -376,17 +380,55 @@ function ensureGroupDir(uid: string, cid: string, projectIdHint?: string | null)
   return d;
 }
 
+/** members.json 解析缓存：按文件指纹（mtimeMs:size）复用解析结果。
+ *  任务列表每行要读一次 members，几百个会话时是几百次小文件读——
+ *  指纹不变直接复用，把 N 次读压成 0 次。写入路径（writeMembers /
+ *  markCommanderSpoken）直接删键，不依赖指纹失效；外部直接改文件
+ *  则靠指纹失效。返回浅拷贝，防止调用方 mutate 污染缓存。 */
+const _membersCache = new Map<string, { stamp: string; value: MembersFile }>();
+const MEMBERS_CACHE_MAX = 1024;
+
+function _membersCachePut(file: string, value: MembersFile, stamp: string): void {
+  if (_membersCache.size >= MEMBERS_CACHE_MAX) {
+    const oldest = _membersCache.keys().next().value;
+    if (oldest !== undefined) _membersCache.delete(oldest);
+  }
+  _membersCache.set(file, { stamp, value });
+}
+
+function _cloneMembers(value: MembersFile): MembersFile {
+  return {
+    version: 1,
+    actors: value.actors.slice(),
+    ...(value.commander_spoken ? { commander_spoken: true as const } : {}),
+  };
+}
+
 export async function readMembers(
   uid: string,
   cid: string,
   projectIdHint?: string | null,
 ): Promise<MembersFile> {
   const file = conversationLayout(uid, cid, projectIdHint).membersFile;
-  if (!fs.existsSync(file)) return { version: 1, actors: [] };
+  let stamp = '';
+  try {
+    const st = fs.statSync(file);
+    stamp = `${st.mtimeMs}:${st.size}`;
+  } catch {
+    return { version: 1, actors: [] };
+  }
+  const hit = _membersCache.get(file);
+  if (hit && hit.stamp === stamp) return _cloneMembers(hit.value);
   try {
     const data: any = await readJson(file);
     if (data && typeof data === 'object' && Array.isArray(data.actors)) {
-      return { version: 1, actors: data.actors as Actor[] };
+      const value: MembersFile = {
+        version: 1,
+        actors: data.actors as Actor[],
+        ...(data.commander_spoken === true ? { commander_spoken: true as const } : {}),
+      };
+      _membersCachePut(file, value, stamp);
+      return _cloneMembers(value);
     }
   } catch {
     log.warn('members read failed', {
@@ -406,7 +448,28 @@ async function writeMembers(
   projectIdHint?: string | null,
 ): Promise<void> {
   ensureGroupDir(uid, cid, projectIdHint);
-  await writeJson(conversationLayout(uid, cid, projectIdHint).membersFile, m);
+  const file = conversationLayout(uid, cid, projectIdHint).membersFile;
+  await writeJson(file, m);
+  _membersCache.delete(file);
+}
+
+/** 标记「指挥官已发言」。幂等：已标记过只读一次 members.json 就返回。
+ *
+ *  与 addMember 一样走 per-(uid,cid) 的 _stateLock —— read-modify-write
+ *  若与并发的 addMember 竞争，会互相覆盖对方刚写入的字段
+ *  （members.json tmp-rename 竞态，此前真实出现过）。 */
+export async function markCommanderSpoken(
+  uid: string,
+  cid: string,
+  projectIdHint?: string | null,
+): Promise<boolean> {
+  return _stateLock(uid, cid).runExclusive(async () => {
+    const members = await readMembers(uid, cid, projectIdHint);
+    if (members.commander_spoken) return false;
+    members.commander_spoken = true;
+    await writeMembers(uid, cid, members, projectIdHint);
+    return true;
+  });
 }
 
 /** Idempotent. Returns true if the actor was newly added.

--- a/src/main/features/kb_embed.ts
+++ b/src/main/features/kb_embed.ts
@@ -22,6 +22,7 @@ import { Mutex } from 'async-mutex';
 
 import { embeddingModelDir } from '../paths';
 import { createLogger } from '../logger';
+import { createEmbedBridge, type EmbedBridge } from './kb_embed_bridge';
 
 const log = createLogger('kb_embed');
 
@@ -34,6 +35,49 @@ const log = createLogger('kb_embed');
  * stable ceiling for bge-small-zh on desktop hardware.
  */
 const EMBED_BATCH_SIZE = 32;
+
+// ── 隔离子进程优先，进程内回退 ─────────────────────────────────────────
+// ONNX 推理是同步原生计算，放主进程会成批占用事件循环。优先走独立子进程
+// （bin/cogseed-embed-worker.cjs），worker 不可用（spawn 失败 / 握手超时 /
+// 中途崩溃 / 请求超时）时自动回退到进程内推理——功能永不因 worker 缺失
+// 而丢失，回退后本进程内只发生一次（_workerFailed 粘性标记）。
+let _bridge: EmbedBridge | null = null;
+let _workerFailed = false;
+const _bridgeStartLock = new Mutex();
+
+async function ensureBridge(): Promise<EmbedBridge | null> {
+  if (_workerFailed) return null;
+  if (_bridge) return _bridge;
+  return _bridgeStartLock.runExclusive(async () => {
+    if (_workerFailed) return null;
+    if (_bridge) return _bridge;
+    try {
+      const bridge = createEmbedBridge();
+      await bridge.ready;
+      _bridge = bridge;
+      log.info('embed worker ready');
+      return bridge;
+    } catch (err) {
+      _workerFailed = true;
+      log.warn('embed worker unavailable; falling back to in-process embedding', {
+        error: (err as Error)?.message || String(err),
+      });
+      return null;
+    }
+  });
+}
+
+async function embedViaWorker(texts: string[]): Promise<number[][]> {
+  const bridge = await ensureBridge();
+  if (!bridge) throw new Error('embed worker unavailable');
+  return bridge.embedTexts(texts);
+}
+
+function dropBridge(): void {
+  if (!_bridge) return;
+  try { _bridge.close(); } catch { /* already gone */ }
+  _bridge = null;
+}
 
 // Loaded lazily so test code that mocks this module never touches fastembed.
 // Use require() deliberately: fastembed's ESM entry imports `tar` as a default
@@ -59,12 +103,7 @@ async function initEmbedder(): Promise<void> {
   });
 }
 
-/**
- * Produce a 512-dim unit-normalised embedding for each input text. Preserves
- * input order 1:1. Throws on empty input or model load failure.
- */
-export async function embedTexts(texts: string[]): Promise<number[][]> {
-  if (!texts.length) return [];
+async function embedInProcess(texts: string[]): Promise<number[][]> {
   await initEmbedder();
   const out: number[][] = [];
   const gen = _embedder.embed(texts, EMBED_BATCH_SIZE);
@@ -74,11 +113,37 @@ export async function embedTexts(texts: string[]): Promise<number[][]> {
     for (const v of batch) {
       out.push(Array.isArray(v) ? v : Array.from(v as ArrayLike<number>));
     }
+    // 回退路径的批次间让出主循环（子进程路径不需要）：推理是同步原生
+    // 计算，长文本回填时连续占用事件循环会让 IPC/UI 排队。每批之间让
+    // 一次 macrotask 轮转；结果完全一致。
+    await new Promise<void>((resolve) => setImmediate(resolve));
   }
   if (out.length !== texts.length) {
     throw new Error(`embed count mismatch: ${out.length} vectors vs ${texts.length} texts`);
   }
   return out;
+}
+
+/**
+ * Produce a 512-dim unit-normalised embedding for each input text. Preserves
+ * input order 1:1. Throws on empty input or model load failure.
+ */
+export async function embedTexts(texts: string[]): Promise<number[][]> {
+  if (!texts.length) return [];
+  if (!_workerFailed) {
+    try {
+      return await embedViaWorker(texts);
+    } catch (err) {
+      // worker 中途失效（崩溃/请求超时）：本次请求进程内重试一次保证
+      // 结果正确，之后粘性回退到进程内路径。
+      _workerFailed = true;
+      dropBridge();
+      log.warn('embed worker failed mid-flight; retrying in-process', {
+        error: (err as Error)?.message || String(err),
+      });
+    }
+  }
+  return embedInProcess(texts);
 }
 
 /** Embed a single query. Shortcut for `embedTexts([q])[0]`. */
@@ -89,6 +154,7 @@ export async function embedQuery(query: string): Promise<number[]> {
 
 /** Close + release the ONNX session. Should be called on app shutdown. */
 export function closeEmbedder(): void {
+  dropBridge();
   if (!_embedder) return;
   try {
     // fastembed doesn't expose a release API; we just drop the reference and

--- a/src/main/features/kb_embed_bridge.ts
+++ b/src/main/features/kb_embed_bridge.ts
@@ -1,0 +1,176 @@
+/**
+ * Embed 子进程桥接 —— 把向量化请求转发给隔离的 ONNX 推理进程。
+ *
+ * 与 cogseed_runtime/worker-process 同款 spawn 模式：
+ *   spawn(process.execPath, [bin/cogseed-embed-worker.cjs], ELECTRON_RUN_AS_NODE)
+ * 协议见 bin/cogseed-embed-worker.cjs / kb_embed_worker_entry.ts。
+ *
+ * 桥接只负责进程生命周期与请求多路复用；失败时由调用方（kb_embed.ts）
+ * 回退到进程内推理，保证功能永不因 worker 不可用而丢失。
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import * as path from 'node:path';
+import { createInterface } from 'node:readline';
+
+import { PC_ROOT, embeddingModelDir } from '../paths';
+import { createLogger } from '../logger';
+
+const log = createLogger('kb_embed_bridge');
+
+export interface EmbedBridgeChild {
+  stdin: NodeJS.WritableStream;
+  stdout: NodeJS.ReadableStream;
+  stderr: NodeJS.ReadableStream;
+  kill(signal?: NodeJS.Signals | number): boolean;
+  on(event: string, listener: (...args: any[]) => void): this;
+  once(event: string, listener: (...args: any[]) => void): this;
+}
+
+export interface EmbedBridge {
+  /** 子进程就绪（模型加载完成）。reject 表示不可用，调用方应回退。 */
+  ready: Promise<void>;
+  embedTexts(texts: string[]): Promise<number[][]>;
+  close(): void;
+}
+
+/** 握手超时：模型加载 1-2s，留足余量。 */
+const READY_TIMEOUT_MS = 20_000;
+/** 单请求超时：批量回填可能较长；超时视为 worker 卡死，杀进程并失败。 */
+const REQUEST_TIMEOUT_MS = 10 * 60_000;
+
+function defaultSpawnWorker(): EmbedBridgeChild {
+  const pcDir = PC_ROOT.replace(/\bapp\.asar\b/, 'app.asar.unpacked');
+  const script = path.join(pcDir, 'bin', 'cogseed-embed-worker.cjs');
+  return spawn(process.execPath, [script], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: '1',
+      COGSEED_PC_DIR: pcDir,
+      COGSEED_EMBED_MODEL_DIR: embeddingModelDir(),
+    },
+  }) as ChildProcessWithoutNullStreams;
+}
+
+interface PendingRequest {
+  resolve: (vectors: number[][]) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export function createEmbedBridge(options: { spawnWorker?: () => EmbedBridgeChild } = {}): EmbedBridge {
+  const spawnWorker = options.spawnWorker || defaultSpawnWorker;
+  let child: EmbedBridgeChild | null = null;
+  let seq = 0;
+  let closed = false;
+  let failed = false;
+  const pending = new Map<number, PendingRequest>();
+
+  let readyResolve!: () => void;
+  let readyReject!: (err: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    readyResolve = resolve;
+    readyReject = reject;
+  });
+
+  const fail = (err: Error): void => {
+    if (failed) return;
+    failed = true;
+    readyReject(err);
+    for (const p of Array.from(pending.values())) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    pending.clear();
+  };
+
+  const handleLine = (line: string): void => {
+    let msg: any;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (!msg || typeof msg !== 'object') return;
+    if (msg.type === 'ready') {
+      readyResolve();
+      return;
+    }
+    if (msg.type === 'fatal') {
+      fail(new Error(`embed worker fatal: ${String(msg.error || 'unknown')}`));
+      return;
+    }
+    const id = Number(msg.id);
+    const p = pending.get(id);
+    if (!p) return;
+    pending.delete(id);
+    clearTimeout(p.timer);
+    if (msg.type === 'vectors' && Array.isArray(msg.vectors)) {
+      p.resolve(msg.vectors as number[][]);
+    } else if (msg.type === 'pong') {
+      p.resolve([]);
+    } else {
+      p.reject(new Error(String(msg.error || `unexpected embed worker response: ${String(msg.type)}`)));
+    }
+  };
+
+  const readyTimer = setTimeout(() => {
+    fail(new Error('embed worker handshake timeout'));
+    if (child) {
+      try { child.kill(); } catch { /* already gone */ }
+    }
+  }, READY_TIMEOUT_MS);
+  void ready.then(
+    () => clearTimeout(readyTimer),
+    () => clearTimeout(readyTimer),
+  );
+
+  try {
+    child = spawnWorker();
+    child.on('exit', (code) => {
+      if (!closed) fail(new Error(`embed worker exited (code ${String(code)})`));
+    });
+    child.on('error', (err) => fail(err as Error));
+    createInterface({ input: child.stdout }).on('line', handleLine);
+    if (child.stderr) {
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        const text = String(chunk).trim();
+        if (text) log.warn('embed worker stderr', { text: text.slice(0, 500) });
+      });
+    }
+  } catch (err) {
+    fail(err as Error);
+    child = null;
+  }
+
+  function embedTexts(texts: string[]): Promise<number[][]> {
+    if (!texts.length) return Promise.resolve([]);
+    if (!child || failed) return Promise.reject(new Error('embed worker unavailable'));
+    const id = ++seq;
+    return new Promise<number[][]>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        const err = new Error('embed worker request timeout');
+        try { child?.kill(); } catch { /* already gone */ }
+        fail(err);
+        reject(err);
+      }, REQUEST_TIMEOUT_MS);
+      pending.set(id, { resolve, reject, timer });
+      child.stdin.write(`${JSON.stringify({ type: 'embed', id, texts })}\n`);
+    });
+  }
+
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    clearTimeout(readyTimer);
+    fail(new Error('embed worker closed'));
+    if (child) {
+      try { child.kill(); } catch { /* already gone */ }
+      child = null;
+    }
+  }
+
+  return { ready, embedTexts, close };
+}

--- a/src/main/features/kb_embed_worker_entry.ts
+++ b/src/main/features/kb_embed_worker_entry.ts
@@ -1,0 +1,111 @@
+/**
+ * Embed 子进程入口（隔离的 ONNX 推理进程）。
+ *
+ * 背景：fastembed/onnxruntime 的推理是同步原生计算，跑在主进程里会成批
+ * 占用事件循环（大库回填/建索引期间界面卡顿）。worker_threads 方案曾
+ * SIGSEGV（两个线程同时初始化 onnxruntime 的原生资源），按规范改用
+ * 独立子进程隔离（AGENTS.md：child-process isolation）。
+ *
+ * 协议（stdin/stdout JSONL）：
+ *   → {"type":"ping","id":n}
+ *   ← {"type":"pong","id":n}
+ *   → {"type":"embed","id":n,"texts":["..."]}
+ *   ← {"type":"vectors","id":n,"vectors":[[...]]}
+ *   ← {"type":"error","id":n,"error":"..."}
+ * 启动完成后输出 {"type":"ready"}；模型初始化失败输出 {"type":"fatal",...} 并退出。
+ * 请求严格串行处理（单一 ONNX session 不允许并发推理）。
+ *
+ * 模型目录由父进程经 COGSEED_EMBED_MODEL_DIR 传入；本入口不 import 任何
+ * 应用模块（paths/logger 等），保持子进程依赖面最小。
+ */
+
+import { createInterface } from 'node:readline';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let embedder: any = null;
+
+const EMBED_BATCH_SIZE = 32;
+
+function respond(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+async function initEmbedder(): Promise<void> {
+  if (embedder) return;
+  const modelDir = process.env.COGSEED_EMBED_MODEL_DIR || '';
+  // 与主进程 kb_embed.ts 同口径：用 CJS 入口 require（fastembed 的 ESM
+  // 入口在 tar@7 下会坏）。
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { FlagEmbedding, EmbeddingModel } = require('fastembed') as typeof import('fastembed');
+  embedder = await FlagEmbedding.init({
+    model: EmbeddingModel.BGESmallZH,
+    cacheDir: modelDir,
+    showDownloadProgress: false,
+  });
+}
+
+async function embedTexts(texts: string[]): Promise<number[][]> {
+  await initEmbedder();
+  const out: number[][] = [];
+  const gen = embedder.embed(texts, EMBED_BATCH_SIZE);
+  for await (const batch of gen) {
+    for (const v of batch) {
+      out.push(Array.isArray(v) ? v : Array.from(v as ArrayLike<number>));
+    }
+  }
+  if (out.length !== texts.length) {
+    throw new Error(`embed count mismatch: ${out.length} vectors vs ${texts.length} texts`);
+  }
+  return out;
+}
+
+// 请求严格串行：readline 的 async handler 不会被等待，必须自己接链，
+// 否则并发推理会打到同一个 ONNX session 上（正是当年线程方案崩溃的形态）。
+let chain: Promise<void> = Promise.resolve();
+
+async function handleLine(line: string): Promise<void> {
+  let req: any;
+  try {
+    req = JSON.parse(line);
+  } catch {
+    respond({ type: 'error', id: null, error: 'invalid json' });
+    return;
+  }
+  if (!req || typeof req !== 'object') return;
+  if (req.type === 'ping') {
+    respond({ type: 'pong', id: req.id ?? null });
+    return;
+  }
+  if (req.type !== 'embed') {
+    respond({ type: 'error', id: req.id ?? null, error: `unknown request type: ${String(req.type)}` });
+    return;
+  }
+  const texts = Array.isArray(req.texts) ? req.texts.filter((t: unknown) => typeof t === 'string') : [];
+  try {
+    const vectors = await embedTexts(texts);
+    respond({ type: 'vectors', id: req.id ?? null, vectors });
+  } catch (err) {
+    respond({ type: 'error', id: req.id ?? null, error: (err as Error)?.message || String(err) });
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    await initEmbedder();
+    respond({ type: 'ready' });
+  } catch (err) {
+    respond({ type: 'fatal', error: (err as Error)?.message || String(err) });
+    process.exitCode = 1;
+    return;
+  }
+  const rl = createInterface({ input: process.stdin });
+  rl.on('line', (line: string) => {
+    chain = chain
+      .then(() => handleLine(line))
+      .catch((err) => {
+        respond({ type: 'error', id: null, error: (err as Error)?.message || String(err) });
+      });
+  });
+}
+
+void main();

--- a/src/main/features/project_files.ts
+++ b/src/main/features/project_files.ts
@@ -64,7 +64,11 @@ const MAX_BYTES_IMAGE = 20 * 1024 * 1024;
 const MAX_BYTES_PDF = 100 * 1024 * 1024;
 const MAX_BYTES_VIDEO = 200 * 1024 * 1024;
 const MAX_FILENAME_LEN = 200;
-const PROJECT_TREE_CACHE_TTL_MS = 30_000;
+/** 文件树「变更才扫」兜底窗口：指纹一致但缓存超过该时长仍重扫一次，
+ *  覆盖指纹感知不到的深层外部改动（如 Finder 往深层子目录放文件）。 */
+const SPACE_TREE_BACKSTOP_MS = 3 * 60_000;
+/** 遍历深度上限：保护极端目录树（导入的历史项目等）不触发超深递归。 */
+const SPACE_TREE_MAX_DEPTH = 24;
 
 export type SpaceFileKind = 'text' | 'pdf' | 'docx' | 'spreadsheet' | 'presentation' | 'image' | 'video';
 
@@ -244,14 +248,18 @@ async function _treeStat(absPath: string): Promise<fs.Stats | null> {
   catch { return null; }
 }
 
-async function walkSpaceTreeAsync(absDir: string, root: string): Promise<SpaceLibraryNode[]> {
+async function walkSpaceTreeAsync(absDir: string, root: string, depth = 0): Promise<SpaceLibraryNode[]> {
+  if (depth > SPACE_TREE_MAX_DEPTH) return [];
   const items = sortDirents(await _treeReadDir(absDir));
   const nodes = await Promise.all(items.map(async (entry): Promise<SpaceLibraryNode | null> => {
     if (entry.name.startsWith('.')) return null;
     const abs = path.join(absDir, entry.name);
     if (entry.isDirectory()) {
+      // 与产物兜底遍历同口径：依赖/缓存目录不进空间文件树（导入整包项目时
+      // 这些目录能把树撑到几万节点，且用户从不浏览）。
+      if (entry.name === 'node_modules' || entry.name === '__pycache__') return null;
       const [children, st] = await Promise.all([
-        walkSpaceTreeAsync(abs, root),
+        walkSpaceTreeAsync(abs, root, depth + 1),
         _treeStat(abs),
       ]);
       if (!st?.isDirectory()) return null;
@@ -304,6 +312,8 @@ async function filesUnderEntry(absPath: string, root: string): Promise<SpaceFile
 
 interface SpaceTreeCacheEntry {
   generation: number;
+  /** 空间文件根目录指纹（mtime:size）——外部直接改动根目录内容时立即失效。 */
+  stamp: string;
   expiresAt: number;
   tree: SpaceLibraryNode[];
 }
@@ -333,9 +343,24 @@ export function invalidateSpaceFileTree(userId: string, spaceId?: string): void 
     _spaceTreeInFlight.delete(key);
     _spaceTreeGeneration.set(key, (_spaceTreeGeneration.get(key) || 0) + 1);
   }
+  // 持久化表同源失效（fire-and-forget；表是派生缓存，失败无害）
+  void import('./workspace_meta').then((m) => {
+    if (spaceId) return m.dropEntry(userId, 'fileTrees', spaceId);
+    return m.dropSection(userId, 'fileTrees');
+  }).catch(() => { /* best-effort */ });
+}
+
+async function _spaceFilesRootStamp(dir: string): Promise<string> {
+  try {
+    const st = await _treeStat(dir);
+    return st ? `${st.mtimeMs}:${st.size}` : 'missing';
+  } catch {
+    return 'missing';
+  }
 }
 
 export async function listSpaceFileTree(userId: string, spaceId: string): Promise<SpaceLibraryNode[]> {
+  const startedAt = Date.now();
   let dir: string;
   let sid: string;
   try {
@@ -346,21 +371,48 @@ export async function listSpaceFileTree(userId: string, spaceId: string): Promis
   const key = _spaceTreeKey(userId, sid);
   const generation = _spaceTreeGeneration.get(key) || 0;
   const cached = _spaceTreeCache.get(key);
-  if (cached && cached.generation === generation && cached.expiresAt > Date.now()) {
-    return cached.tree;
+  if (cached && cached.generation === generation) {
+    // 「变更才扫」：根目录指纹一致且未过兜底窗口 → 直接返回缓存。
+    const stamp = await _spaceFilesRootStamp(dir);
+    if (cached.stamp === stamp && cached.expiresAt > Date.now()) {
+      // 性能埋点：缓存命中路径（诊断用，仅计数/时长）。
+      log.info('listSpaceFileTree cache hit', { nodes: cached.tree.length, ms: Date.now() - startedAt });
+      return cached.tree;
+    }
+  }
+  // 持久化元数据表：重启后冷启动直接查表（根目录指纹验证），不再全量递归。
+  const meta = await import('./workspace_meta');
+  const tableStamp = await _spaceFilesRootStamp(dir);
+  const tableEntry = await meta.getEntry<SpaceLibraryNode[]>(userId, 'fileTrees', sid);
+  if (tableEntry && tableEntry.stamp === tableStamp) {
+    _spaceTreeCache.set(key, {
+      generation,
+      stamp: tableStamp,
+      expiresAt: Date.now() + SPACE_TREE_BACKSTOP_MS,
+      tree: tableEntry.data,
+    });
+    log.info('listSpaceFileTree table hit', { nodes: tableEntry.data.length, ms: Date.now() - startedAt });
+    return tableEntry.data;
   }
   const existing = _spaceTreeInFlight.get(key);
   if (existing) return existing;
-  const run = walkSpaceTreeAsync(dir, dir).then((tree) => {
+  const run = (async () => {
+    const tree = await walkSpaceTreeAsync(dir, dir);
     if ((_spaceTreeGeneration.get(key) || 0) === generation) {
+      const stamp = await _spaceFilesRootStamp(dir);
       _spaceTreeCache.set(key, {
         generation,
-        expiresAt: Date.now() + PROJECT_TREE_CACHE_TTL_MS,
+        stamp,
+        expiresAt: Date.now() + SPACE_TREE_BACKSTOP_MS,
         tree,
       });
     }
+    try {
+      await meta.putEntry(userId, 'fileTrees', sid, await _spaceFilesRootStamp(dir), tree);
+    } catch { /* 表写入失败不阻断 */ }
+    log.info('listSpaceFileTree scanned', { nodes: tree.length, ms: Date.now() - startedAt });
     return tree;
-  });
+  })();
   _spaceTreeInFlight.set(key, run);
   try { return await run; }
   finally {

--- a/src/main/features/project_library_indexer.ts
+++ b/src/main/features/project_library_indexer.ts
@@ -111,9 +111,18 @@ interface Queue {
   running: boolean;
   scheduled: boolean;
   activeKeys: Map<string, number>;
+  /** 待处理 job 的复合键（jobKey|op → Job），enqueue 去重 O(1)。
+   *  与 jobs 数组同步维护；队列大时（整目录导入几千文件）原来的
+   *  q.jobs.find/some 线性查找会退化到 O(n²)。 */
+  pendingJobs: Map<string, Job>;
+  /** 每个 name 的待处理 job 计数（任意 op），reconcile 的占用判断 O(1)。 */
+  pendingNameCounts: Map<string, number>;
 }
 
 const _queues = new Map<string, Queue>();
+
+/** reconcile 进行中的去重：并发 search / status 查询共享同一次扫描。 */
+const _reconcileInFlight = new Map<string, Promise<SpaceLibraryReconcileResult>>();
 
 export const spaceLibraryEvents = new EventEmitter();
 spaceLibraryEvents.setMaxListeners(50);
@@ -171,10 +180,27 @@ function storeFor(uid: string, spaceId: string): vs.VecStore {
 function queueFor(uid: string): Queue {
   let q = _queues.get(uid);
   if (!q) {
-    q = { jobs: [], running: false, scheduled: false, activeKeys: new Map() };
+    q = { jobs: [], running: false, scheduled: false, activeKeys: new Map(), pendingJobs: new Map(), pendingNameCounts: new Map() };
     _queues.set(uid, q);
   }
   return q;
+}
+
+function pendingJobKey(spaceId: string, name: string, op: Job['op']): string {
+  return `${jobKey(spaceId, name)}|${op}`;
+}
+
+function addPendingJob(q: Queue, job: Job): void {
+  q.pendingJobs.set(pendingJobKey(job.spaceId, job.name, job.op), job);
+  q.pendingNameCounts.set(jobKey(job.spaceId, job.name), (q.pendingNameCounts.get(jobKey(job.spaceId, job.name)) || 0) + 1);
+}
+
+function removePendingJob(q: Queue, job: Job): void {
+  q.pendingJobs.delete(pendingJobKey(job.spaceId, job.name, job.op));
+  const key = jobKey(job.spaceId, job.name);
+  const count = q.pendingNameCounts.get(key) || 0;
+  if (count <= 1) q.pendingNameCounts.delete(key);
+  else q.pendingNameCounts.set(key, count - 1);
 }
 
 function retainActiveKey(q: Queue, key: string): void {
@@ -202,12 +228,12 @@ export function enqueue(
   } catch { return; }
   if (op === 'upsert' && !kindFor(safeName)) return;
   const q = queueFor(uid);
-  const existing = q.jobs.find((j) => j.spaceId === sid && j.name === safeName && j.op === op);
-  if (existing) {
-    if (opts.force) existing.force = true;
+  const duplicate = q.pendingJobs.get(pendingJobKey(sid, safeName, op));
+  if (duplicate) {
+    if (opts.force) duplicate.force = true;
     return;
   }
-  q.jobs.push({
+  const job: Job = {
     spaceId: sid,
     name: safeName,
     op,
@@ -215,7 +241,9 @@ export function enqueue(
     enqueuedAt: Date.now(),
     reason: opts.reason || (opts.force ? 'manual' : 'mutation'),
     attempt: Math.max(1, Math.round(opts.attempt || 1)),
-  });
+  };
+  q.jobs.push(job);
+  addPendingJob(q, job);
   if (op === 'upsert') {
     const kind = kindFor(safeName);
     if (kind) emit({ userId: uid, spaceId: sid, name: safeName, relPath: safeName, status: 'pending', kind });
@@ -241,6 +269,7 @@ async function runQueue(uid: string): Promise<void> {
   try {
     while (q.jobs.length) {
       const job = q.jobs.shift()!;
+      removePendingJob(q, job);
       const key = jobKey(job.spaceId, job.name);
       retainActiveKey(q, key);
       try {
@@ -525,6 +554,25 @@ async function describeImage(userId: string, sourceName: string, raw: Buffer): P
 }
 
 export async function reconcile(uid: string, spaceId: string): Promise<SpaceLibraryReconcileResult> {
+  const sid = safeSpaceId(spaceId);
+  const key = `${uid}:${sid}`;
+  const existing = _reconcileInFlight.get(key);
+  if (existing) return existing;
+  const run = reconcileImpl(uid, sid).then(
+    (result) => {
+      if (_reconcileInFlight.get(key) === run) _reconcileInFlight.delete(key);
+      return result;
+    },
+    (err) => {
+      if (_reconcileInFlight.get(key) === run) _reconcileInFlight.delete(key);
+      throw err;
+    },
+  );
+  _reconcileInFlight.set(key, run);
+  return run;
+}
+
+async function reconcileImpl(uid: string, spaceId: string): Promise<SpaceLibraryReconcileResult> {
   const startedAt = Date.now();
   const sid = safeSpaceId(spaceId);
   if (!await spaceExists(uid, sid)) return { enqueuedUpsert: 0, enqueuedDelete: 0, unchanged: 0 };
@@ -545,7 +593,7 @@ export async function reconcile(uid: string, spaceId: string): Promise<SpaceLibr
     const existing = indexedByPath.get(name);
     const key = jobKey(sid, name);
     const ownedByQueue = queue.activeKeys.has(key)
-      || queue.jobs.some((job) => jobKey(job.spaceId, job.name) === key);
+      || queue.pendingNameCounts.has(key);
     const orphanedProcessing = existing?.status === 'processing'
       && !ownedByQueue;
     if (
@@ -669,7 +717,11 @@ export async function search(
   queryVec: number[] | Float32Array,
   opts: vs.VecSearchOpts = {},
 ): Promise<vs.VecSearchHit[]> {
-  await reconcile(uid, spaceId);
+  // 搜索不再等待全量 reconcile：应用内写入已走 enqueue 即时入队，向量库
+  // 即为最新；外部直接改动的文件由后台 reconcile 收敛——本次调用顺手
+  // 触发（in-flight 合并），下一次搜索可见。避免每次检索都被目录遍历 +
+  // sha1 流式哈希挡在关键路径上。
+  void reconcile(uid, spaceId).catch(() => { /* 后台收敛失败不阻断搜索 */ });
   return storeFor(uid, spaceId).search(queryVec, opts);
 }
 
@@ -698,6 +750,7 @@ export async function drain(uid: string): Promise<void> {
 
 export function _resetQueuesForTests(): void {
   _queues.clear();
+  _reconcileInFlight.clear();
   spaceLibraryEvents.removeAllListeners();
   spaceLibraryEvents.setMaxListeners(50);
 }

--- a/src/main/features/recall/source-catalog.ts
+++ b/src/main/features/recall/source-catalog.ts
@@ -242,7 +242,7 @@ async function conversationSources(userId: string, query: Parameters<SourceAdapt
   ];
 }
 
-function contextFilesForUser(userId: string): ContextNode[] {
+async function contextFilesForUser(userId: string): Promise<ContextNode[]> {
   const files: ContextNode[] = [];
   const visit = (nodes: ContextNode[]): void => {
     for (const node of nodes) {
@@ -250,7 +250,7 @@ function contextFilesForUser(userId: string): ContextNode[] {
       if (node.children?.length) visit(node.children);
     }
   };
-  visit(listContextsTreeForUser(userId));
+  visit(await listContextsTreeForUser(userId));
   return files;
 }
 
@@ -270,7 +270,7 @@ async function contextFileStatuses(userId: string): Promise<Map<string, { status
 }
 
 async function artifactFileSources(userId: string, query: Parameters<SourceAdapter>[1]): Promise<DiscoveredSource[]> {
-  const files = contextFilesForUser(userId);
+  const files = await contextFilesForUser(userId);
   const statuses = await contextFileStatuses(userId);
   const contexts = files.slice(0, query.limit).map((node) => {
     const lifecycle = statuses.get(node.path) || { status: 'pending' as const, reason: 'file_index_pending' };
@@ -661,7 +661,7 @@ export async function retryCognitionSource(userId: string, kind: CognitionCatalo
     throw new Error('cognition source retry is not supported');
   }
   try {
-    const node = contextFilesForUser(userId).find((file) => cognitionContextFileSourceId(file.path) === source.id);
+    const node = (await contextFilesForUser(userId)).find((file) => cognitionContextFileSourceId(file.path) === source.id);
     if (!node) throw new Error('source_missing');
     const indexer = await import('../kb_indexer');
     indexer.enqueue(userId, node.path, 'upsert', { reason: 'manual' });

--- a/src/main/features/skills.ts
+++ b/src/main/features/skills.ts
@@ -1006,6 +1006,64 @@ async function _overlaySkillSecurity(list: SkillListing[]): Promise<SkillListing
   });
 }
 
+/** 外部技能目录（~/.claude/skills、~/.codex/skills/.system）扫描缓存：
+ *  目录 stamp（mtimeMs+size）不变且未过 TTL 时直接复用，避免每次
+ *  spaces.list / resources.catalog / runTurn 都同步扫一遍用户主目录。 */
+let _externalSkillCache: { at: number; stamp: string; items: SkillListing[] } | null = null;
+const EXTERNAL_SKILL_CACHE_TTL_MS = 15_000;
+
+function _externalSkillStamp(): string {
+  const roots = [
+    path.join(os.homedir(), '.claude', 'skills'),
+    path.join(os.homedir(), '.codex', 'skills', '.system'),
+  ];
+  let stamp = '';
+  for (const root of roots) {
+    try {
+      const st = fs.statSync(root);
+      stamp += `${root}:${st.mtimeMs}:${st.size};`;
+    } catch {
+      stamp += `${root}:missing;`;
+    }
+  }
+  return stamp;
+}
+
+async function _scanExternalSkills(): Promise<SkillListing[]> {
+  const external: SkillListing[] = [];
+  const roots = [
+    { root: path.join(os.homedir(), '.claude', 'skills'), prefix: 'claude', label: 'Claude' },
+    { root: path.join(os.homedir(), '.codex', 'skills', '.system'), prefix: 'codex', label: 'Codex' },
+  ];
+  for (const { root, prefix, label } of roots) {
+    let entries: import('node:fs').Dirent[];
+    try { entries = await fsp.readdir(root, { withFileTypes: true }); }
+    catch { continue; }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      const skillMdPath = path.join(root, entry.name, 'SKILL.md');
+      try {
+        const content = await fsp.readFile(skillMdPath, 'utf8');
+        const meta = parseSkillFrontmatter(content);
+        const displayName = (typeof meta.name === 'string' && meta.name.trim()) || entry.name;
+        const description = (typeof meta.description === 'string' && meta.description.trim()) || '';
+        external.push({
+          id: `${prefix}:${entry.name}`,
+          name: `[${label}] ${displayName}`,
+          source: 'custom',
+          description_en: description,
+          description_zh: description,
+          category: 'external',
+          enabled: true,
+        });
+      } catch (err) {
+        log.warn(`failed to read ${label} skill ${entry.name}:`, err);
+      }
+    }
+  }
+  return external;
+}
+
 /** Lightweight skill catalog for reference pickers and relationship indexes.
  *
  * This deliberately omits the deep security-receipt overlay. Callers may use
@@ -1017,78 +1075,13 @@ async function _overlaySkillSecurity(list: SkillListing[]): Promise<SkillListing
 export async function listSkillCatalog(): Promise<SkillListing[]> {
   const internal = _overlaySkillEnabled((await _allSkillListingsCached()).filter((s) => !s.ownerAgent));
 
-  // Auto-detect external skills from Claude Code and Codex
-  const external: SkillListing[] = [];
-
-  // Claude Code skills from ~/.claude/skills/
-  try {
-    const claudeSkillsRoot = path.join(os.homedir(), '.claude', 'skills');
-    if (fs.existsSync(claudeSkillsRoot)) {
-      const entries = fs.readdirSync(claudeSkillsRoot, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-        const skillDir = path.join(claudeSkillsRoot, entry.name);
-        const skillMdPath = path.join(skillDir, 'SKILL.md');
-        if (!fs.existsSync(skillMdPath)) continue;
-
-        try {
-          const content = fs.readFileSync(skillMdPath, 'utf8');
-          const meta = parseSkillFrontmatter(content);
-          const displayName = (typeof meta.name === 'string' && meta.name.trim()) || entry.name;
-          const description = (typeof meta.description === 'string' && meta.description.trim()) || '';
-
-          external.push({
-            id: `claude:${entry.name}`,
-            name: `[Claude] ${displayName}`,
-            source: 'custom',
-            description_en: description,
-            description_zh: description,
-            category: 'external',
-            enabled: true,
-          });
-        } catch (err) {
-          log.warn(`failed to read Claude skill ${entry.name}:`, err);
-        }
-      }
-    }
-  } catch (err) {
-    log.warn('failed to scan Claude Code skills:', err);
+  // Auto-detect external skills from Claude Code and Codex（带目录 stamp 缓存）
+  const stamp = _externalSkillStamp();
+  if (_externalSkillCache && _externalSkillCache.stamp === stamp && Date.now() - _externalSkillCache.at < EXTERNAL_SKILL_CACHE_TTL_MS) {
+    return [...internal, ..._externalSkillCache.items];
   }
-
-  // Codex skills from ~/.codex/skills/.system/
-  try {
-    const codexSkillsRoot = path.join(os.homedir(), '.codex', 'skills', '.system');
-    if (fs.existsSync(codexSkillsRoot)) {
-      const entries = fs.readdirSync(codexSkillsRoot, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-        const skillDir = path.join(codexSkillsRoot, entry.name);
-        const skillMdPath = path.join(skillDir, 'SKILL.md');
-        if (!fs.existsSync(skillMdPath)) continue;
-
-        try {
-          const content = fs.readFileSync(skillMdPath, 'utf8');
-          const meta = parseSkillFrontmatter(content);
-          const displayName = (typeof meta.name === 'string' && meta.name.trim()) || entry.name;
-          const description = (typeof meta.description === 'string' && meta.description.trim()) || '';
-
-          external.push({
-            id: `codex:${entry.name}`,
-            name: `[Codex] ${displayName}`,
-            source: 'custom',
-            description_en: description,
-            description_zh: description,
-            category: 'external',
-            enabled: true,
-          });
-        } catch (err) {
-          log.warn(`failed to read Codex skill ${entry.name}:`, err);
-        }
-      }
-    }
-  } catch (err) {
-    log.warn('failed to scan Codex skills:', err);
-  }
+  const external: SkillListing[] = await _scanExternalSkills();
+  _externalSkillCache = { at: Date.now(), stamp, items: external };
 
   return [...internal, ...external];
 }

--- a/src/main/features/spaces.ts
+++ b/src/main/features/spaces.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { userSpacesDir, spaceMetaFile, spaceContentDir, SPACE_DIR_MARKER, invalidateSpaceDirCache, sanitizeSpaceDirName } from '../paths';
+import { userSpacesDir, spaceMetaFile, spaceContentDir, SPACE_DIR_MARKER, invalidateSpaceDirCache, sanitizeSpaceDirName, userAgentsDir, userSkillsDir } from '../paths';
 import { nowIso, readJson, writeJson } from '../storage';
 import { createLogger } from '../logger';
 import { getRendererTable } from '../i18n';
@@ -517,6 +517,17 @@ function baseAgentToAgentId(agents: ReadonlyArray<{ agent_id?: string; runtime?:
  *  失效数用真实有效集合（listSkillCatalog/listAgents，均有磁盘缓存）：一次构造、
  *  全部空间复用，避免空集合导致「所有引用全失效」的假阳性。 */
 export async function listSpaces(uid: string): Promise<SpaceWithMeta[]> {
+  const startedAt = Date.now();
+  // 持久化元数据表路径：指纹命中 → 直接返回（重启后冷启动同样命中，
+  // 不再逐空间读 space.json + 最近会话）。
+  const meta = await import('./workspace_meta');
+  const tableEntry = await meta.getEntry<SpaceWithMeta[]>(uid, 'spaces', 'all');
+  if (tableEntry && Array.isArray(tableEntry.data)) {
+    if ((await _spacesStamp(uid)) === tableEntry.stamp) {
+      log.info('listSpaces table hit', { spaces: tableEntry.data.length, ms: Date.now() - startedAt });
+      return tableEntry.data.map((s) => ({ ...s }));
+    }
+  }
   const ids = await _listSpaceIds(uid);
   const [agents, skills] = await Promise.all([
     import('./agents').then((m) => m.listAgents()).catch(() => []),
@@ -542,10 +553,12 @@ export async function listSpaces(uid: string): Promise<SpaceWithMeta[]> {
     for (const id of baseAgentIds) {
       if (id && !usableAgents.includes(id)) usableAgents.push(id);
     }
-    // 最近活跃会话（列表「最近」展示 + 最近使用排序；chats 动态引入避免模块加载链）
+    // 最近活跃会话（列表「最近」展示 + 最近使用排序）。走轻量版：只合并
+    // 空间/全局索引取最新一行，跳过 members.json 读取与整份 jsonl 的
+    // commander 扫描 —— 否则 N 个空间会把全部消息字节读一遍再丢掉。
     let lastConv: { title?: string; updated_at?: string; created_at?: string } | undefined;
     try {
-      const convs = await import('./chats').then((m) => m.listSpaceConversations(uid, sid));
+      const convs = await import('./chats').then((m) => m.listSpaceConversationsLight(uid, sid));
       lastConv = convs[0];
     } catch (_) { /* 会话索引异常不阻断列表 */ }
     return {
@@ -564,7 +577,36 @@ export async function listSpaces(uid: string): Promise<SpaceWithMeta[]> {
   const out: SpaceWithMeta[] = metas.filter((m): m is NonNullable<typeof m> => Boolean(m));
   const collator = new Intl.Collator('zh', { sensitivity: 'base', numeric: true });
   out.sort((a, b) => collator.compare(a.name, b.name) || a.space_id.localeCompare(b.space_id));
+  try {
+    await meta.putEntry(uid, 'spaces', 'all', await _spacesStamp(uid), out);
+  } catch { /* 表写入失败不阻断 */ }
+  // 性能埋点：工作空间首屏核心路径耗时（诊断用，仅计数/时长）。
+  log.info('listSpaces done', { spaces: out.length, ms: Date.now() - startedAt });
   return out;
+}
+
+async function _entryStamp(dir: string): Promise<string> {
+  try {
+    const st = await fsp.stat(dir);
+    return `${st.mtimeMs}:${st.size}`;
+  } catch {
+    return 'missing';
+  }
+}
+
+/** 工作空间摘要的验证指纹：spaces 目录 + 会话索引全部根 + skills/agents
+ *  目录。任一变化（新建空间/会话、技能或智能体增删）即失配 → 实时重算。 */
+async function _spacesStamp(uid: string): Promise<string> {
+  const parts: string[] = [
+    `sd:${await _entryStamp(ensureSpacesDir(uid))}`,
+    `sk:${await _entryStamp(userSkillsDir(uid))}`,
+    `ag:${await _entryStamp(userAgentsDir(uid))}`,
+  ];
+  try {
+    const chats = await import('./chats');
+    parts.push(await chats.conversationIndexStamp(uid));
+  } catch { /* 索引不可用 → 失配兜底由 live 路径覆盖 */ }
+  return parts.join('|');
 }
 
 export async function getSpace(uid: string, spaceId: string): Promise<Space | null> {

--- a/src/main/features/spaces_artifacts.ts
+++ b/src/main/features/spaces_artifacts.ts
@@ -18,10 +18,11 @@ import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { chatArtifactCidDir, chatAttachmentDir, spaceChatAttachmentDir, spaceChatArtifactCidDir, spaceContentDir } from '../paths';
+import { chatArtifactCidDir, chatAttachmentDir, spaceChatAttachmentDir, spaceChatArtifactCidDir, spaceChatIndexFile, spaceContentDir } from '../paths';
+import { conversationMessageReadFile } from '../util/project-layout';
 import { safeId } from '../storage';
 import { ALLOWED_EXTENSIONS } from './chat_attachments';
-import { getMessages, listSpaceConversations } from './chats';
+import { getMessages, listSpaceConversations, listSpaceConversationsLight } from './chats';
 
 /** AI 产出文件宽扩展名：附件上传白名单之外，工作区产物额外放行的常见格式
  *  （旧 Office / 矢量图 / 压缩包 / 电子书 / 网页等），保证「产出的都能落位」。 */
@@ -134,19 +135,72 @@ export interface SpaceArtifactEntry {
 
 // ── 产物列表缓存 ─────────────────────────────────────────────────────────
 // 打开/切换空间详情时渲染端会反复请求 artifacts.list，而聚合是一次全量
-// 磁盘扫描（每个会话读消息 produced[] + 递归遍历工作区目录）。不加缓存时
-// 每次切空间都重扫，会话多/聊天长/产物多时延迟随数据量线性放大，且同步
-// 扫描会阻塞主进程（整个应用卡顿）。这里做空间级缓存：
-//   - TTL 内命中直接返回（切空间/反复进出秒回）；
+// 磁盘扫描（每个会话读消息 produced[] + 递归遍历工作区目录）。缓存策略：
+//   - 「变更才扫」：每次调用先算一个廉价指纹（空间会话索引 + 每个会话的
+//     附件/产物目录 + 消息文件 + imports 目录的 mtime:size），指纹与上次
+//     扫描时一致 → 直接返回缓存，无论隔了多久；
+//   - 兜底重扫：指纹一致但缓存超过 ARTIFACT_STAMP_BACKSTOP_MS 仍重扫一次，
+//     覆盖指纹感知不到的变更（如外部手动往工作区深层目录放文件），保证
+//     最坏情况下陈旧不超过该窗口；
 //   - 空间内新建会话时主动失效（invalidateSpaceArtifacts）；
 //   - 缓存值带 uid，多账号不会串数据。
-const ARTIFACT_CACHE_TTL_MS = 30_000;
-const _artifactCache = new Map<string, { uid: string; at: number; items: SpaceArtifactEntry[] }>();
+const ARTIFACT_STAMP_BACKSTOP_MS = 3 * 60_000;
+const _artifactCache = new Map<string, { uid: string; at: number; stamp: string; items: SpaceArtifactEntry[] }>();
 
 /** 空间产物缓存失效：空间内新建会话后调用，保证下次列表新鲜。 */
 export function invalidateSpaceArtifacts(spaceId: string): void {
   if (!spaceId) return;
   _artifactCache.delete(spaceId);
+  // 持久化表同源失效（fire-and-forget；表是派生缓存，失败无害）
+  const uid = (() => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const users = require('./users') as typeof import('./users');
+      return users.getActiveUserId();
+    } catch { return ''; }
+  })();
+  if (uid) {
+    void import('./workspace_meta').then((m) => m.dropEntry(uid, 'artifacts', spaceId)).catch(() => { /* best-effort */ });
+  }
+}
+
+async function _entryStamp(dir: string): Promise<string> {
+  try {
+    const st = await fsp.stat(dir);
+    return `${st.mtimeMs}:${st.size}`;
+  } catch {
+    return 'missing';
+  }
+}
+
+async function _fileStamp(file: string): Promise<string> {
+  try {
+    const st = await fsp.stat(file);
+    return `${st.mtimeMs}:${st.size}`;
+  } catch {
+    return 'missing';
+  }
+}
+
+/** 空间产物的廉价变更指纹：覆盖会话成员变化（空间会话索引）、附件/网页
+ *  产物增删（各自目录 mtime）、消息 produced[] 登记（消息文件 mtime）、
+ *  imports 增删（imports 根目录 mtime）。指纹一致即认为产物集合未变。 */
+async function _spaceArtifactsStamp(uid: string, spaceId: string): Promise<string> {
+  const parts: string[] = [];
+  parts.push(`chatidx:${await _fileStamp(spaceChatIndexFile(uid, spaceId))}`);
+  const conversations = await listSpaceConversationsLight(uid, spaceId);
+  for (const c of conversations) {
+    const cid = c.conversation_id;
+    if (!cid) continue;
+    parts.push([
+      `c:${cid}`,
+      `att:${await _entryStamp(spaceChatAttachmentDir(uid, spaceId, cid))},${await _entryStamp(chatAttachmentDir(uid, cid))}`,
+      `art:${await _entryStamp(spaceChatArtifactCidDir(uid, spaceId, cid))},${await _entryStamp(chatArtifactCidDir(uid, cid))}`,
+      `msg:${await _fileStamp(conversationMessageReadFile(uid, cid))}`,
+    ].join('|'));
+  }
+  parts.push(`imports:${await _entryStamp(path.join(spaceContentDir(uid, spaceId), 'imports'))}`);
+  return parts.join(';');
 }
 
 async function scanAttachments(uid: string, spaceId: string, cid: string, out: SpaceArtifactEntry[]): Promise<void> {
@@ -245,7 +299,13 @@ export function isUnsafeWorkspaceRoot(dir: string): boolean {
 /** 扫描 AI 产出文件：先走消息 produced[]（已登记），再兜底扫会话工作区目录
  *  （未登记进 produced 的产物，如部分工具直接写文件）。按文件名去重（附件优先）。
  *  COGSEED-16：产物无确认态——所有产出自动成为正式产物，直接可打开/引用/删除。 */
-async function scanProducedFiles(uid: string, spaceId: string, cid: string, out: SpaceArtifactEntry[]): Promise<void> {
+async function scanProducedFiles(
+  uid: string,
+  spaceId: string,
+  cid: string,
+  out: SpaceArtifactEntry[],
+  walkedWorkspaces?: Set<string>,
+): Promise<void> {
   const seen = new Set(out.map((o) => o.name));
   const add = async (abs: string, name: string): Promise<void> => {
     if (!name || seen.has(name)) return;
@@ -276,10 +336,14 @@ async function scanProducedFiles(uid: string, spaceId: string, cid: string, out:
   }
   // 2. 会话工作区目录兜底（部分工具直接写文件、未登记 produced；递归子目录防漏）
   //    护栏：异常根目录直接跳过；遍历计数超限中止并回滚本次兜底新增（见顶部注释）。
+  //    同一空间内所有会话共享同一工作区根（除非个别会话自定义 coding_project_dir），
+  //    逐会话重复遍历同一目录是 O(会话数 × 文件数) 的浪费——同一目录在一次
+  //    聚合中只遍历一次（walkedWorkspaces 记忆）。
   try {
     const { getConversationWorkspacePath } = await import('./group_chat/conv_workspace');
     const wsDir = await getConversationWorkspacePath(uid, cid);
-    if (wsDir && !isUnsafeWorkspaceRoot(wsDir)) {
+    if (wsDir && !isUnsafeWorkspaceRoot(wsDir) && !walkedWorkspaces?.has(wsDir)) {
+      walkedWorkspaces?.add(wsDir);
       const startLen = out.length;
       try {
         await fsp.stat(wsDir);
@@ -339,12 +403,31 @@ async function scanImportedFiles(uid: string, spaceId: string, out: SpaceArtifac
 }
 
 /** 空间产物聚合：附件 + artifact + AI 产出文件统一列表，按时间倒序。空空间返回空数组（不 mock）。
- *  空间级缓存：TTL 内命中直接返回；新建会话时由 invalidateSpaceArtifacts 失效。 */
+ *  空间级「变更才扫」缓存：指纹一致直接返回（见 _spaceArtifactsStamp），
+ *  指纹变化或超过兜底窗口才重扫；新建会话时由 invalidateSpaceArtifacts 失效。 */
 export async function listSpaceArtifacts(uid: string, spaceId: string): Promise<SpaceArtifactEntry[]> {
   if (!spaceId) return [];
+  const startedAt = Date.now();
+  const stamp = await _spaceArtifactsStamp(uid, spaceId);
   const cached = _artifactCache.get(spaceId);
-  if (cached && cached.uid === uid && Date.now() - cached.at < ARTIFACT_CACHE_TTL_MS) {
+  if (cached && cached.uid === uid && cached.stamp === stamp && Date.now() - cached.at < ARTIFACT_STAMP_BACKSTOP_MS) {
+    // 性能埋点：缓存命中路径（诊断用，仅计数/时长）。
+    try {
+      const perfLog = (await import('../logger')).createLogger('spaces_artifacts');
+      perfLog.info('listSpaceArtifacts cache hit', { items: cached.items.length, ms: Date.now() - startedAt });
+    } catch { /* best-effort */ }
     return [...cached.items];
+  }
+  // 持久化元数据表：重启后冷启动直接查表，不再全盘扫描。
+  const meta = await import('./workspace_meta');
+  const tableEntry = await meta.getEntry<SpaceArtifactEntry[]>(uid, 'artifacts', spaceId);
+  if (tableEntry && tableEntry.stamp === stamp) {
+    _artifactCache.set(spaceId, { uid, at: Date.now(), stamp, items: tableEntry.data });
+    try {
+      const perfLog = (await import('../logger')).createLogger('spaces_artifacts');
+      perfLog.info('listSpaceArtifacts table hit', { items: tableEntry.data.length, ms: Date.now() - startedAt });
+    } catch { /* best-effort */ }
+    return [...tableEntry.data];
   }
   // 触发一次附件/网页产物空间化迁移（幂等，进程内只跑一次）
   if (!_migratedSpaces.has(spaceId)) {
@@ -353,13 +436,23 @@ export async function listSpaceArtifacts(uid: string, spaceId: string): Promise<
   }
   const conversations = await listSpaceConversations(uid, spaceId);
   const out: SpaceArtifactEntry[] = [];
+  const walkedWorkspaces = new Set<string>();
   for (const c of conversations) {
     await scanAttachments(uid, spaceId, c.conversation_id, out);
     await scanArtifacts(uid, spaceId, c.conversation_id, out);
-    await scanProducedFiles(uid, spaceId, c.conversation_id, out);
+    await scanProducedFiles(uid, spaceId, c.conversation_id, out, walkedWorkspaces);
   }
   await scanImportedFiles(uid, spaceId, out);
   out.sort((a, b) => b.time - a.time);
-  _artifactCache.set(spaceId, { uid, at: Date.now(), items: out });
+  // 迁移可能搬动附件/产物目录——存缓存前按扫描后的状态重算指纹。
+  const finalStamp = await _spaceArtifactsStamp(uid, spaceId);
+  _artifactCache.set(spaceId, { uid, at: Date.now(), stamp: finalStamp, items: out });
+  try {
+    await meta.putEntry(uid, 'artifacts', spaceId, finalStamp, out);
+  } catch { /* 表写入失败不阻断列表 */ }
+  try {
+    const perfLog = (await import('../logger')).createLogger('spaces_artifacts');
+    perfLog.info('listSpaceArtifacts scanned', { items: out.length, convs: conversations.length, ms: Date.now() - startedAt });
+  } catch { /* best-effort */ }
   return [...out];
 }

--- a/src/main/features/vec_store.ts
+++ b/src/main/features/vec_store.ts
@@ -144,6 +144,10 @@ interface Handle {
 
 const _cache = new Map<string, Handle>();
 const _vacuumTimers = new Map<string, NodeJS.Timeout>();
+/** 多次删除合并为一次 VACUUM 的防抖窗口。 */
+const VACUUM_DEBOUNCE_MS = 5_000;
+/** 低于该字节数的库直接跳过 VACUUM（无空闲页可回收）。 */
+const VACUUM_MIN_BYTES = 2 * 1024 * 1024;
 
 function handleFor(dbDir: string): Handle {
   const cached = _cache.get(dbDir);
@@ -285,7 +289,7 @@ function scheduleVacuum(dbDir: string): void {
   _vacuumTimers.set(dbDir, setTimeout(() => {
     _vacuumTimers.delete(dbDir);
     runVacuum(dbDir).catch((err) => log.warn(`vacuum ${dbDir}: ${(err as Error).message}`));
-  }, 2000));
+  }, VACUUM_DEBOUNCE_MS));
 }
 
 async function runVacuum(dbDir: string): Promise<void> {
@@ -293,6 +297,8 @@ async function runVacuum(dbDir: string): Promise<void> {
   if (!h) return;
   return h.writeLock.runExclusive(() => {
     const before = dbSize(h.dbPath);
+    // 小库几乎没有空闲页，VACUUM 无收益；跳过省一次主线程全量重写。
+    if (before < VACUUM_MIN_BYTES) return;
     const started = Date.now();
     h.db.exec('VACUUM');
     const after = dbSize(h.dbPath);

--- a/src/main/features/workspace_meta.ts
+++ b/src/main/features/workspace_meta.ts
@@ -1,0 +1,163 @@
+/**
+ * 工作空间持久化元数据表 —— 对齐 Codex（SQLite 会话索引）与 DSH（storages/
+ * workspace.json + session_projcache.json）的"列表查表、内容按需"架构。
+ *
+ * 按分区落盘为多个小 JSON 文件（<uid>/local/workspace/meta-<section>.json）：
+ *   spaces / conversations / artifacts / fileTrees
+ * 每条 = { stamp, at, data }：stamp 是数据来源的廉价指纹（目录 mtime:size、
+ * 索引文件 mtime:size 等），读取路径"指纹命中 → 直接查表返回"，未命中才
+ * 实时计算并回写。表是纯派生缓存——可随时整表丢弃重建，不影响任何数据
+ * 正确性（真源仍是 cloud 域文件与扫描结果）。
+ *
+ * 为什么分区而不是单文件：单大文件里每写一条都要整表重读（实测 46 空间
+ * + 800 会话时 table hit 被整文件解析拖到 112ms）；分区后工作空间查询只
+ * 读 meta-spaces.json，会话查询只读 meta-conversations.json，加载成本与
+ * 各自数据量成正比，互不拖累（DSH 正是 workspace.json / projcache.json
+ * 分开放）。
+ *
+ * 写盘：原子写（tmp+rename）+ 300ms 防抖合并（按分区）；进程内内存表
+ * 同步维护，启动后按文件 mtime 热载。
+ */
+
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { workspaceMetaSectionFile } from '../paths';
+import { createLogger } from '../logger';
+
+const log = createLogger('workspace_meta');
+
+export interface WorkspaceMetaEntry<T = unknown> {
+  /** 数据来源指纹：读取侧用它决定"要不要信这张表"。 */
+  stamp: string;
+  /** 写入时间（epoch ms，诊断用）。 */
+  at: number;
+  data: T;
+}
+
+export type WorkspaceMetaSection = 'spaces' | 'conversations' | 'artifacts' | 'fileTrees';
+
+interface SectionFileShape {
+  version: 1;
+  entries: Record<string, WorkspaceMetaEntry>;
+}
+
+interface SectionState {
+  entries: Record<string, WorkspaceMetaEntry>;
+  fileMtimeMs: number;
+}
+
+const WRITE_DEBOUNCE_MS = 300;
+
+const _states = new Map<string, Map<WorkspaceMetaSection, SectionState>>();
+const _writeTimers = new Map<string, NodeJS.Timeout>();
+
+function sectionStateFor(uid: string, section: WorkspaceMetaSection): SectionState | undefined {
+  return _states.get(uid)?.get(section);
+}
+
+async function loadSection(uid: string, section: WorkspaceMetaSection): Promise<SectionState> {
+  const file = workspaceMetaSectionFile(uid, section);
+  let mtime = 0;
+  try { mtime = fs.statSync(file).mtimeMs; } catch { /* 不存在 → 空表 */ }
+  let perUid = _states.get(uid);
+  if (!perUid) {
+    perUid = new Map();
+    _states.set(uid, perUid);
+  }
+  const cached = perUid.get(section);
+  if (cached && cached.fileMtimeMs === mtime) return cached;
+  let entries: Record<string, WorkspaceMetaEntry> = {};
+  try {
+    const raw = await fsp.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<SectionFileShape>;
+    if (parsed && parsed.version === 1 && parsed.entries && typeof parsed.entries === 'object') {
+      entries = parsed.entries;
+    }
+  } catch { /* 首次或损坏 → 空表 */ }
+  const state: SectionState = { entries, fileMtimeMs: mtime };
+  perUid.set(section, state);
+  return state;
+}
+
+function scheduleWrite(uid: string): void {
+  if (_writeTimers.has(uid)) return;
+  const timer = setTimeout(() => {
+    _writeTimers.delete(uid);
+    void flush(uid);
+  }, WRITE_DEBOUNCE_MS);
+  _writeTimers.set(uid, timer);
+}
+
+/** 立即落盘全部已加载分区（防抖定时器到期时调用；测试/关停可用）。 */
+export async function flush(uid: string): Promise<void> {
+  const perUid = _states.get(uid);
+  if (!perUid) return;
+  for (const section of Array.from(perUid.keys())) {
+    const state = perUid.get(section);
+    if (!state) continue;
+    const file = workspaceMetaSectionFile(uid, section);
+    try {
+      await fsp.mkdir(path.dirname(file), { recursive: true });
+      const tmp = `${file}.${process.pid}.tmp`;
+      const shape: SectionFileShape = { version: 1, entries: state.entries };
+      await fsp.writeFile(tmp, JSON.stringify(shape), 'utf8');
+      await fsp.rename(tmp, file);
+      state.fileMtimeMs = fs.statSync(file).mtimeMs;
+    } catch (err) {
+      log.warn('workspace meta write failed', {
+        uid,
+        section,
+        error: (err as Error)?.message || String(err),
+      });
+    }
+  }
+}
+
+export async function getEntry<T>(
+  uid: string,
+  section: WorkspaceMetaSection,
+  key: string,
+): Promise<WorkspaceMetaEntry<T> | null> {
+  const state = await loadSection(uid, section);
+  const entry = state.entries[key];
+  if (!entry) return null;
+  return { stamp: entry.stamp, at: entry.at, data: entry.data as T };
+}
+
+export async function putEntry<T>(
+  uid: string,
+  section: WorkspaceMetaSection,
+  key: string,
+  stamp: string,
+  data: T,
+): Promise<void> {
+  const state = await loadSection(uid, section);
+  state.entries[key] = { stamp, at: Date.now(), data: data as unknown };
+  scheduleWrite(uid);
+}
+
+export async function dropEntry(uid: string, section: WorkspaceMetaSection, key: string): Promise<void> {
+  const state = await loadSection(uid, section);
+  if (state.entries[key]) {
+    delete state.entries[key];
+    scheduleWrite(uid);
+  }
+}
+
+export async function dropSection(uid: string, section: WorkspaceMetaSection): Promise<void> {
+  const state = await loadSection(uid, section);
+  const count = Object.keys(state.entries).length;
+  if (count) {
+    state.entries = {};
+    scheduleWrite(uid);
+  }
+}
+
+/** 测试用：清空内存表与防抖定时器。 */
+export function _resetForTests(): void {
+  for (const timer of _writeTimers.values()) clearTimeout(timer);
+  _writeTimers.clear();
+  _states.clear();
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -666,11 +666,11 @@ function _contextTreeHasPath(nodes: contexts.ContextNode[], relPath: string): bo
   return false;
 }
 
-function _uniqueContextImportPath(rawName: string): string {
+async function _uniqueContextImportPath(rawName: string): Promise<string> {
   const name = path.basename(String(rawName || '').trim() || 'artifact');
   const ext = path.extname(name);
   const stem = ext ? name.slice(0, -ext.length) : name;
-  const tree = contexts.listContextsTree();
+  const tree = await contexts.listContextsTree();
   if (!_contextTreeHasPath(tree, name)) return name;
   for (let i = 2; i < 1000; i += 1) {
     const candidate = `${stem}-${i}${ext}`;
@@ -736,7 +736,7 @@ async function _importProducedToLibrary(payload: any, ctx: IpcContext): Promise<
 
   const relPath = typeof payload?.targetPath === 'string' && payload.targetPath.trim()
     ? payload.targetPath.trim()
-    : _uniqueContextImportPath(targetName);
+    : await _uniqueContextImportPath(targetName);
   const result = contexts.uploadContextFile(relPath, buf);
   if (!result.ok) return result;
   return { ok: true, scope: 'global', path: result.path, bytes: result.bytes };
@@ -1035,7 +1035,7 @@ const invokeHandlers: Record<string, InvokeHandler> = {
         ? path.join(workspaceRoot, state.workspace_dir)
         : workspaceRoot;
     }
-    return conversationFiles.listWorkspaceFiles(root);
+    return await conversationFiles.listWorkspaceFiles(root);
   },
 
   // 引导「工作区目录已被移动或删除」→ 用户重新选择目录后固化到本会话。
@@ -1543,7 +1543,17 @@ const invokeHandlers: Record<string, InvokeHandler> = {
   'spaces.files.status': async ({ spaceId, skipReconcile }, ctx) => {
     if (!safeId(spaceId)) throw new Error('invalid spaceId');
     if (!await spaces.spaceExists(ctx.userId, spaceId)) throw new Error('not_found');
-    const reconcile = skipReconcile ? null : await spaceLibraryIndexer.reconcile(ctx.userId, spaceId);
+    // 快照先行：状态/文件列表直接读向量库（毫秒级），全量磁盘 reconcile
+    // 放后台补跑（in-flight 合并），不阻塞页签打开。状态变化经
+    // space.kb.events 实时推送，reconcile 结果并非首屏依赖。
+    if (!skipReconcile) {
+      void spaceLibraryIndexer.reconcile(ctx.userId, spaceId).catch((err) => {
+        log.warn('background space library reconcile failed', {
+          space_id: spaceId,
+          error: (err as Error)?.message || String(err),
+        });
+      });
+    }
     const summary = spaceLibraryIndexer.statusSummary(ctx.userId, spaceId);
     const files = spaceLibraryIndexer.listFiles(ctx.userId, spaceId).map((r) => ({
       name: r.rel_path,
@@ -1555,7 +1565,7 @@ const invokeHandlers: Record<string, InvokeHandler> = {
       mtime: r.mtime,
       error: r.error || undefined,
     }));
-    return { summary, files, reconcile };
+    return { summary, files, reconcile: null };
   },
 
   'spaces.files.reconcile': async ({ spaceId }, ctx) => {
@@ -3573,7 +3583,7 @@ const invokeHandlers: Record<string, InvokeHandler> = {
   'cache.clearAll': async () => ({ bytes_freed: await cacheClearable.clearAllClearable() }),
 
   // ── Contexts (user-owned directory tree; vectorized via kb_indexer) ──
-  'contexts.tree': async () => ({ tree: contexts.listContextsTree() }),
+  'contexts.tree': async () => ({ tree: await contexts.listContextsTree() }),
 
   'contexts.read': async ({ path }) => {
     return contexts.readContextFile(path || '');
@@ -5309,6 +5319,10 @@ const streamHandlers: Record<string, StreamHandler> = {
 
 interface StreamState { cancelled: boolean; controller: AbortController; sender: WebContents }
 const activeStreams = new Map<string, StreamState>();
+/** process 事件批量窗口：16ms 内相邻 delta 打包成一条 IPC 消息。 */
+const STREAM_BATCH_WINDOW_MS = 16;
+/** 单条批量消息最多携带的 process 事件数（防止长时间突发时包过大）。 */
+const STREAM_BATCH_MAX = 64;
 
 /**
  * Resolve the current user context for an IPC request. `user.init` must be
@@ -5449,8 +5463,36 @@ export function register(): void {
     const envelope = parseStreamEnvelope(request);
     if (!envelope) return;
     const { requestId, channel, payload } = envelope;
+    // 逐 token 的 process 事件每发一条都是一次 IPC 序列化 + 渲染层一次
+    // SSE 解析，流式高峰期（~50 事件/秒 × 若干并发流）会淹没主→渲染
+    // 通道。把相邻的 process 事件打包成数组一次发送，preload 拆包后
+    // 逐个回调 —— 渲染层事件语义与顺序完全不变，只减少消息数。
+    // 非 process 事件（message / turn_end / done / error 等结构事件）
+    // 立即发送，不引入可感知延迟。
+    const pending: unknown[] = [];
+    let flushTimer: NodeJS.Timeout | null = null;
+    const flushBatch = () => {
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      if (!pending.length) return;
+      if (event.sender.isDestroyed()) return;
+      const batch = pending.splice(0, pending.length);
+      event.sender.send(`stream:${requestId}`, batch);
+    };
     const out = (ev: unknown) => {
       if (event.sender.isDestroyed()) return;
+      if (ev && typeof ev === 'object' && (ev as { type?: string }).type === 'process') {
+        pending.push(ev);
+        if (pending.length >= STREAM_BATCH_MAX) {
+          flushBatch();
+        } else if (!flushTimer) {
+          flushTimer = setTimeout(flushBatch, STREAM_BATCH_WINDOW_MS);
+        }
+        return;
+      }
+      flushBatch();
       event.sender.send(`stream:${requestId}`, ev);
     };
 

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -558,6 +558,10 @@ export const userConnectorsConfigFile = (uid: string) => path.join(userCloudConf
 // activateUser(); both core-agent's auth store and the web-search provider
 // cache land in this same directory.
 export const userLocalConfigDir   = (uid: string) => path.join(userLocalRoot(uid), 'config');
+/** 工作空间持久化元数据表目录（列表查询的本地缓存；纯派生数据，可整表丢弃）。 */
+export const workspaceMetaDir     = (uid: string) => path.join(userLocalRoot(uid), 'workspace');
+/** 元数据表分区文件（spaces/conversations/artifacts/fileTrees 各一个，互不拖累）。 */
+export const workspaceMetaSectionFile = (uid: string, section: string) => path.join(workspaceMetaDir(uid), `meta-${section}.json`);
 export const userAuthProfilesFile = (uid: string) => path.join(userLocalConfigDir(uid), 'auth-profiles.json');
 export const userWebSearchCache   = (uid: string) => path.join(userLocalConfigDir(uid), 'web-search-cache.json');
 export const userReflectionStateFile = (uid: string) => path.join(userLocalConfigDir(uid), 'reflection-state.json');

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -374,6 +374,16 @@ function stream(channel, payload, onEvent) {
   let cancelled = false;
 
   const promise = new Promise((resolve, reject) => {
+    const deliver = (ev) => {
+      if (!ev || settled) return;
+      try { onEvent && onEvent(ev); }
+      catch (err) {
+        settled = true;
+        ipcRenderer.removeListener(channelKey, listener);
+        ipcRenderer.send('cogseed.streamCancel', requestId);
+        reject(err);
+      }
+    };
     const listener = (_evt, ev) => {
       if (!ev || settled) return;
       if (ev.type === 'done') {
@@ -383,13 +393,16 @@ function stream(channel, payload, onEvent) {
         else resolve();
         return;
       }
-      try { onEvent && onEvent(ev); }
-      catch (err) {
-        settled = true;
-        ipcRenderer.removeListener(channelKey, listener);
-        ipcRenderer.send('cogseed.streamCancel', requestId);
-        reject(err);
+      // 主进程批量打包的 process 事件（数组）——拆包后逐个回调，
+      // 事件语义与顺序不变。
+      if (Array.isArray(ev)) {
+        for (const item of ev) {
+          deliver(item);
+          if (settled) return;
+        }
+        return;
       }
+      deliver(ev);
     };
 
     ipcRenderer.on(channelKey, listener);

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -5324,18 +5324,35 @@ function startRelayActivitySubscription() {
 // Called whenever a non-internal message lands on a cid so the list stays
 // ordered by pin state first, then last activity (matches backend
 // listConversations sort on the next full reload).
+// rAF 合并（仅热路径）：多 agent turn 会在同一帧内连发多个 message 事件，
+// 每个事件都全量排序 + innerHTML 重建侧栏是流式期间卡顿主因。行已在
+// 列表中时数据（last_active_at）即时更新、排序与渲染每帧至多一次——
+// 视觉更新延迟 ≤16ms，不可感知。冷启动水合（缓存外新任务行）保持
+// 同步渲染：新任务需要立即可见。
+let _bumpScheduled = false;
 async function _bumpConvToTop(cid) {
   if (!cid) return;
   if (!Array.isArray(conversations)) conversations = [];
   let c = conversations.find((row) => row && row.conversation_id === cid);
+  const hydrated = !c;
   if (!c) {
     c = await _hydrateConversationRow(cid);
     if (!c) return;
   }
   _markConversationListLocallyChanged();
   c.last_active_at = new Date().toISOString();
-  _sortConversationCacheForSidebar();
-  renderConversationList();
+  if (hydrated) {
+    _sortConversationCacheForSidebar();
+    renderConversationList();
+    return;
+  }
+  if (_bumpScheduled) return;
+  _bumpScheduled = true;
+  requestAnimationFrame(() => {
+    _bumpScheduled = false;
+    _sortConversationCacheForSidebar();
+    renderConversationList();
+  });
 }
 
 function _compareConversationsForSidebar(a, b) {
@@ -14983,7 +15000,11 @@ function _handleGroupBusEvent(cid, streamingMsg, evData, { archive = false } = {
   // user's view; visible end-of-turn replies will bump shortly after).
   if (evData.type === 'message' && evData.msg && !evData.msg.dispatch) {
     _bumpConvToTop(cid);
-    if (window.ConversationInfo) window.ConversationInfo.refreshFiles(cid);
+    // 文件快照刷新统一走防抖（_scheduleConversationInfoFileRefresh）：
+    // 流式期间每个 message 事件都即时触发 conversations.files.list 会在
+    // 主进程叠加整树遍历（每次消息 → 一次全量快照），还会反复闪加载态。
+    // 180ms 合并一次 + silent 刷新，数据到达延迟不可感知，行为不变。
+    _scheduleConversationInfoFileRefresh(cid);
     // Mark commander as "in chat" the moment it speaks here, so the
     // sidebar/header badges add the commander avatar without waiting for
     // the next `listConversations` to re-derive it from <cid>.jsonl.
@@ -14997,7 +15018,6 @@ function _handleGroupBusEvent(cid, streamingMsg, evData, { archive = false } = {
         }
       }
     }
-    if (evData.msg.from !== 'user') _scheduleConversationInfoFileRefresh(cid);
     // Global cache refresh — must happen BEFORE the cross-cid early-return
     // below, since the agents/skills tabs are global UI surfaces. Without
     // this hop, creating a skill / agent from a background conv leaves
@@ -16275,12 +16295,14 @@ function _updateConvSidebarBadge(cid, _unused) {
 
 // Repaint badges on every visible conversation item. Called after re-render
 // of the sidebar list so previously-known pending/queued state is reapplied.
+// 每行徽标已空化：_updateConvSidebarBadge 对每行做的是同一个全局 chip 刷新 +
+// 当前会话头刷新（最多一行命中）。改成 O(1) 单次刷新，消除侧栏重建后
+// O(N×P) 的重复 pendingConvs 遍历。
 function _refreshAllConvBadges() {
-  document.querySelectorAll('.conv-item').forEach(el => {
-    const cid = el.dataset.cid;
-    if (cid) _updateConvSidebarBadge(cid);
-  });
   _refreshCommanderRunningChip();
+  if (currentCid) {
+    try { _refreshChatHeader(); } catch (_) { /* not yet bound */ }
+  }
 }
 
 // Right-aligned chip on the Commander sidebar button that surfaces "N in

--- a/src/renderer/modules/sidebar-resize.js
+++ b/src/renderer/modules/sidebar-resize.js
@@ -52,17 +52,33 @@
     let dragging = false;
     let startX = 0;
     let startWidth = 0;
+    // rAF 节流：每次 mousemove 写 --sidebar-width 会触发 sidebar 的
+    // container-query 同步重算布局，拖拽期间每帧写一次即可。
+    let pendingWidth = null;
+    let rafId = 0;
+
+    function flushWidth() {
+      rafId = 0;
+      if (pendingWidth == null) return;
+      applyWidth(pendingWidth);
+      pendingWidth = null;
+    }
 
     function onMove(e) {
       if (!dragging) return;
       const dx = e.clientX - startX;
       const next = clamp(startWidth + dx);
-      applyWidth(next);
+      pendingWidth = next;
+      if (!rafId) rafId = requestAnimationFrame(flushWidth);
     }
 
     function onUp() {
       if (!dragging) return;
       dragging = false;
+      if (pendingWidth != null) applyWidth(pendingWidth);
+      pendingWidth = null;
+      if (rafId) cancelAnimationFrame(rafId);
+      rafId = 0;
       document.body.classList.remove('is-sidebar-resizing');
       handle.classList.remove('is-active');
       window.removeEventListener('mousemove', onMove);

--- a/src/renderer/modules/workspace.js
+++ b/src/renderer/modules/workspace.js
@@ -1657,7 +1657,7 @@
       if (typeof uiToast === 'function') uiToast(_t('ws.delete_space_done', '空间已删除，任务已移到「最近任务」'), { variant: 'success' });
     }));
     const cs = root.querySelector('[data-ws="center-search"]');
-    if (cs) cs.addEventListener('input', () => { _centerSearch = cs.value; _reRender(); });
+    if (cs) cs.addEventListener('input', () => { _centerSearch = cs.value; _debouncedSearchReRender(); });
     const sortSel = root.querySelector('[data-ws="center-sort"]');
     if (sortSel) sortSel.addEventListener('change', () => { _centerSort = sortSel.value; _reRender(); });
 
@@ -1737,7 +1737,7 @@
     root.querySelectorAll('[data-ws="toggle-ref"]').forEach((el) => el.addEventListener('click', () => _toggleRef(el.dataset.kind, el.dataset.id)));
     root.querySelectorAll('[data-ws="save-ref"]').forEach((el) => el.addEventListener('click', () => _saveRefPicker()));
     const refSearch = root.querySelector('[data-ws="ref-search"]');
-    if (refSearch) refSearch.addEventListener('input', () => { _refSearch = refSearch.value; _reRender(); });
+    if (refSearch) refSearch.addEventListener('input', () => { _refSearch = refSearch.value; _debouncedSearchReRender(); });
     root.querySelectorAll('[data-ws="artifact-filter"]').forEach((el) => el.addEventListener('click', () => { _artifactFilter = el.dataset.type; _reRender(); }));
     root.querySelectorAll('[data-ws="asset-filter"]').forEach((el) => el.addEventListener('click', () => { _assetFilter = el.dataset.type; _reRender(); }));
     // 资产卡 × → 撤销（弹确认 → 撤销；撤销后资产从空间列表消失——listAbilityAssetsForSpace 过滤 revoked）
@@ -2001,9 +2001,25 @@
     _reRender();
   }
 
+  // 搜索输入防抖：每键全量 innerHTML 重建 N 张卡片很贵，合并成 ~120ms 一次。
+  let _searchDebounceTimer = null;
+  function _debouncedSearchReRender() {
+    if (_searchDebounceTimer) clearTimeout(_searchDebounceTimer);
+    _searchDebounceTimer = setTimeout(() => {
+      _searchDebounceTimer = null;
+      _reRender();
+    }, 120);
+  }
+
   function _reRender() {
     const root = document.getElementById('ws-view');
     if (!root) return;
+    // 重建前捕获搜索框焦点/光标：innerHTML 全量替换会销毁输入框。
+    // 搜索框在打字过程中触发的重建必须把焦点还给用户，否则每敲一次就失焦。
+    const active = document.activeElement instanceof HTMLInputElement ? document.activeElement : null;
+    const restoreSel = active && (active.matches('[data-ws="center-search"]') || active.matches('[data-ws="ref-search"]'))
+      ? { sel: active.dataset.ws, pos: typeof active.selectionStart === 'number' ? active.selectionStart : active.value.length }
+      : null;
     let html = _render();
     if (_createOpen) html += _renderCreateModal();
     if (_createAgentOpen) html += _renderCreateAgentModal();
@@ -2015,6 +2031,13 @@
     if (_refPickerOpen) html += _renderRefPicker();
     root.innerHTML = html;
     _bind(root);
+    if (restoreSel) {
+      const el = root.querySelector(`[data-ws="${restoreSel.sel}"]`);
+      if (el) {
+        el.focus();
+        try { el.setSelectionRange(restoreSel.pos, restoreSel.pos); } catch { /* 非文本输入不处理 */ }
+      }
+    }
   }
 
   async function _refreshForLanguageChange() {

--- a/test/main/conversation-files.test.ts
+++ b/test/main/conversation-files.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 });
 
 describe('conversation workspace file listing', () => {
-  it('returns a relative tree snapshot from the current workspace on disk', () => {
+  it('returns a relative tree snapshot from the current workspace on disk', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-conv-files-'));
     try {
       fs.mkdirSync(path.join(dir, 'agent_skill_review'), { recursive: true });
@@ -24,7 +24,7 @@ describe('conversation workspace file listing', () => {
       fs.writeFileSync(path.join(dir, 'agent_skill_review', 'skill_batch.md'), 'skill');
       fs.writeFileSync(path.join(dir, '.hidden.md'), 'hidden');
 
-      const result = listWorkspaceFiles(dir);
+      const result = await listWorkspaceFiles(dir);
 
       expect(result.root).toBe(path.resolve(dir));
       expect(result.rootExists).toBe(true);
@@ -44,13 +44,13 @@ describe('conversation workspace file listing', () => {
     }
   });
 
-  it('reports truncation instead of walking forever on huge workspaces', () => {
+  it('reports truncation instead of walking forever on huge workspaces', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-conv-files-'));
     try {
       fs.writeFileSync(path.join(dir, 'a.md'), 'a');
       fs.writeFileSync(path.join(dir, 'b.md'), 'b');
 
-      const result = listWorkspaceFiles(dir, { maxFiles: 1 });
+      const result = await listWorkspaceFiles(dir, { maxFiles: 1 });
 
       expect(result.items).toHaveLength(1);
       expect(result.truncated).toBe(true);
@@ -60,7 +60,7 @@ describe('conversation workspace file listing', () => {
     }
   });
 
-  it.runIf(process.platform === 'darwin')('reports a skipped scan for macOS privacy-protected workspace roots', () => {
+  it.runIf(process.platform === 'darwin')('reports a skipped scan for macOS privacy-protected workspace roots', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-conv-files-'));
     try {
       const home = path.join(dir, 'home');
@@ -70,7 +70,7 @@ describe('conversation workspace file listing', () => {
       process.env.HOME = home;
       process.env.COGSEED_TCC_GUARD_FORCE = '1';
 
-      const result = listWorkspaceFiles(downloads);
+      const result = await listWorkspaceFiles(downloads);
 
       expect(result.root).toBe(path.resolve(downloads));
       expect(result.rootExists).toBe(true);

--- a/test/main/features/chats.test.ts
+++ b/test/main/features/chats.test.ts
@@ -386,6 +386,52 @@ describe('chats › setConversationSpace (把已有会话绑定到空间)', () =
   });
 });
 
+describe('chats › listSpaceConversations commander_in_chat（懒补记）', () => {
+  const convJsonl = (cid: string) => path.join(tmpDir, TEST_UID, 'cloud', 'chats', `${cid}.jsonl`);
+  const membersJson = (cid: string) => path.join(tmpDir, TEST_UID, 'cloud', 'chats', cid, 'members.json');
+
+  it('老数据无标志：第一次扫描 jsonl 命中并回写 commander_spoken，之后 jsonl 删除仍为 true', async () => {
+    const chats = await loadChats();
+    const conv = await chats.createConversation(TEST_UID, { title: '补记', spaceId: 'sp_abc123' });
+    const cid = conv.conversation_id;
+    fs.mkdirSync(path.dirname(convJsonl(cid)), { recursive: true });
+    fs.writeFileSync(convJsonl(cid), [
+      JSON.stringify({ from: 'user', to: 'commander', text: 'hello', ts: '2026-01-01T00:00:00.000Z' }),
+      JSON.stringify({ from: 'commander', to: 'user', text: 'hi', ts: '2026-01-01T00:00:01.000Z' }),
+    ].join('\n') + '\n', 'utf-8');
+
+    const rows = await chats.listSpaceConversations(TEST_UID, 'sp_abc123');
+    const row = rows.find((c) => c.conversation_id === cid);
+    expect(row?.commander_in_chat).toBe(true);
+    // 懒补记：标志已落盘
+    const members = JSON.parse(fs.readFileSync(membersJson(cid), 'utf-8'));
+    expect(members.commander_spoken).toBe(true);
+
+    // 之后不再依赖 jsonl：删掉聊天记录，判断仍成立（标志命中）
+    fs.rmSync(convJsonl(cid));
+    const again = await chats.listSpaceConversations(TEST_UID, 'sp_abc123');
+    expect(again.find((c) => c.conversation_id === cid)?.commander_in_chat).toBe(true);
+  });
+
+  it('指挥官从未发言：保持 false，不写入任何假标志', async () => {
+    const chats = await loadChats();
+    const conv = await chats.createConversation(TEST_UID, { title: '无指挥官', spaceId: 'sp_abc123' });
+    const cid = conv.conversation_id;
+    fs.mkdirSync(path.dirname(convJsonl(cid)), { recursive: true });
+    fs.writeFileSync(convJsonl(cid), [
+      JSON.stringify({ from: 'user', to: 'agent-a', text: 'hi', ts: '2026-01-01T00:00:00.000Z' }),
+    ].join('\n') + '\n', 'utf-8');
+
+    const rows = await chats.listSpaceConversations(TEST_UID, 'sp_abc123');
+    expect(rows.find((c) => c.conversation_id === cid)?.commander_in_chat).toBe(false);
+    // 没有命中就不该写 members.json（或写出的文件不带假标志）
+    if (fs.existsSync(membersJson(cid))) {
+      const members = JSON.parse(fs.readFileSync(membersJson(cid), 'utf-8'));
+      expect(members.commander_spoken).toBeUndefined();
+    }
+  });
+});
+
 describe('chats › targeted conversation lookup', () => {
   it('uses a validated project/global hint without opening unrelated indexes', async () => {
     const chats = await loadChats();

--- a/test/main/features/contexts.test.ts
+++ b/test/main/features/contexts.test.ts
@@ -557,7 +557,7 @@ describe('contexts › listContextsTree', () => {
     writeFile('.kb/vector.db', 'bin');
     writeFile('_INDEX.md', '# idx');
     const c = await loadContexts();
-    const tree = c.listContextsTree();
+    const tree = await c.listContextsTree();
     const top = tree.map((n) => n.name).sort();
     expect(top).toEqual(['sub', 'a.md'].sort());
     const sub = tree.find((n) => n.name === 'sub')!;
@@ -571,8 +571,8 @@ describe('contexts › listContextsTree', () => {
     writeFile('active.md', '# active');
     const c = await loadContexts();
 
-    expect(c.listContextsTreeForUser('u2').map((node) => node.name)).toEqual(['other.md']);
-    expect(c.listContextsTree().map((node) => node.name)).toEqual(['active.md']);
+    expect((await c.listContextsTreeForUser('u2')).map((node) => node.name)).toEqual(['other.md']);
+    expect((await c.listContextsTree()).map((node) => node.name)).toEqual(['active.md']);
   });
 });
 

--- a/test/main/features/group_chat/state.test.ts
+++ b/test/main/features/group_chat/state.test.ts
@@ -101,7 +101,7 @@ describe('group_chat state › membership log privacy', () => {
   const actorId = 'privacy-agent-raw-abcdef';
   const actorName = 'SECRET_AGENT_DISPLAY_NAME';
   const secretError =
-    'SECRET_MEMBERSHIP_ERROR /Users/private/member-token.json token=raw';
+    'SECRET_MEMBERSHIP_ERROR /Users/tester/member-token.json token=raw';
 
   async function activatePrivacyUser(): Promise<void> {
     const users = await import('../../../../src/main/features/users');
@@ -167,7 +167,7 @@ describe('group_chat state › membership log privacy', () => {
       actorName,
       secretError,
       'SECRET_MEMBERSHIP_ERROR',
-      '/Users/private',
+      '/Users/tester',
       'token=raw',
     );
     expect(loggerMocks.warn).toHaveBeenCalledWith('members read failed', {
@@ -196,7 +196,7 @@ describe('group_chat state › membership log privacy', () => {
       actorName,
       secretError,
       'SECRET_MEMBERSHIP_ERROR',
-      '/Users/private',
+      '/Users/tester',
       'token=raw',
     );
     expect(loggerMocks.warn).toHaveBeenCalledWith(
@@ -247,7 +247,7 @@ describe('group_chat state › membership log privacy', () => {
       actorName,
       secretError,
       'SECRET_MEMBERSHIP_ERROR',
-      '/Users/private',
+      '/Users/tester',
       'token=raw',
     );
     expect(loggerMocks.warn).toHaveBeenCalledWith('member rename write failed', {
@@ -315,6 +315,28 @@ describe('group_chat state › addMember + ensureAgentMember', () => {
     expect(await s.ensureAgentMember(TEST_UID, TEST_CID, 'user')).toBe(false);
     expect(await s.ensureAgentMember(TEST_UID, TEST_CID, '../etc')).toBe(false);
     expect(await s.ensureAgentMember(TEST_UID, TEST_CID, 'writer', 'Writer')).toBe(true);
+  });
+});
+
+describe('group_chat state › markCommanderSpoken', () => {
+  it('sets the flag once and readMembers preserves it', async () => {
+    const s = await import('../../../../src/main/features/group_chat/state');
+    await s.seedReservedActors(TEST_UID, TEST_CID);
+    expect(await s.markCommanderSpoken(TEST_UID, TEST_CID)).toBe(true);
+    const m = await s.readMembers(TEST_UID, TEST_CID);
+    expect(m.commander_spoken).toBe(true);
+    expect(m.actors.map((a) => a.id).sort()).toEqual(['commander', 'user']);
+    // 幂等：第二次不再写盘（返回 false）
+    expect(await s.markCommanderSpoken(TEST_UID, TEST_CID)).toBe(false);
+  });
+
+  it('marks without clobbering a concurrent-looking existing roster', async () => {
+    const s = await import('../../../../src/main/features/group_chat/state');
+    await s.addMember(TEST_UID, TEST_CID, { kind: 'agent', id: 'writer', name: 'Writer' });
+    await s.markCommanderSpoken(TEST_UID, TEST_CID);
+    const m = await s.readMembers(TEST_UID, TEST_CID);
+    expect(m.commander_spoken).toBe(true);
+    expect(m.actors.find((a) => a.id === 'writer')).toBeTruthy();
   });
 });
 

--- a/test/main/features/kb_embed_bridge.test.ts
+++ b/test/main/features/kb_embed_bridge.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn } from 'node:child_process';
+
+import { createEmbedBridge } from '../../../src/main/features/kb_embed_bridge';
+
+const children: Array<ReturnType<typeof spawn>> = [];
+
+function fakeWorker(script: string, { ready = true, exitAfterMs = 0, noRespond = false } = {}): ReturnType<typeof spawn> {
+  const full = `
+    process.stdin.setEncoding('utf8');
+    ${ready ? 'process.stdout.write(JSON.stringify({ type: "ready" }) + "\\n");' : ''}
+    let buf = '';
+    process.stdin.on('data', (chunk) => {
+      buf += chunk;
+      let idx;
+      while ((idx = buf.indexOf('\\n')) >= 0) {
+        const line = buf.slice(0, idx);
+        buf = buf.slice(idx + 1);
+        if (!line.trim()) continue;
+        const req = JSON.parse(line);
+        if (req.type === 'embed'${noRespond ? ' && false' : ''}) {
+          process.stdout.write(JSON.stringify({ type: 'vectors', id: req.id, vectors: req.texts.map((t) => [t.length]) }) + '\\n');
+        }
+      }
+    });
+    ${exitAfterMs ? `setTimeout(() => process.exit(1), ${exitAfterMs});` : ''}
+  `;
+  const child = spawn(process.execPath, ['-e', full], { stdio: ['pipe', 'pipe', 'pipe'] });
+  children.push(child);
+  return child;
+}
+
+afterEach(() => {
+  for (const child of children.splice(0)) {
+    try { child.kill(); } catch { /* already gone */ }
+  }
+});
+
+describe('kb_embed_bridge › 子进程桥接协议', () => {
+  it('握手就绪后 round-trip 保持顺序与数量', async () => {
+    const bridge = createEmbedBridge({ spawnWorker: () => fakeWorker('') });
+    await expect(bridge.ready).resolves.toBeUndefined();
+    const vectors = await bridge.embedTexts(['hello', 'hi']);
+    expect(vectors).toEqual([[5], [2]]);
+    bridge.close();
+  });
+
+  it('spawn 抛错 → ready 拒绝，调用方据此回退', async () => {
+    const bridge = createEmbedBridge({
+      spawnWorker: () => { throw new Error('spawn denied'); },
+    });
+    await expect(bridge.ready).rejects.toThrow('spawn denied');
+    bridge.close();
+  });
+
+  it('未就绪/已失败状态下请求立即失败（不挂死）', async () => {
+    // 握手超时（20s）由 READY_TIMEOUT_MS 兜底，单测不等待真实超时——
+    // 这里验证 worker 静默时的失败路径：主动 close 等价 worker 死亡，
+    // 之后请求必须立即拒绝而不是挂起。
+    const bridge = createEmbedBridge({ spawnWorker: () => fakeWorker('', { ready: false }) });
+    bridge.close();
+    await expect(bridge.embedTexts(['x'])).rejects.toThrow();
+  });
+
+  it('worker 中途退出 → 挂起的请求全部拒绝', async () => {
+    const bridge = createEmbedBridge({ spawnWorker: () => fakeWorker('', { exitAfterMs: 60, noRespond: true }) });
+    await bridge.ready;
+    await expect(bridge.embedTexts(['a', 'b'])).rejects.toThrow(/exited/);
+    bridge.close();
+  });
+
+  it('fatal 消息 → 挂起请求拒绝', async () => {
+    const child = spawn(process.execPath, ['-e', 'process.stdout.write(JSON.stringify({ type: "fatal", error: "model load failed" }) + "\\n");'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    children.push(child);
+    const bridge = createEmbedBridge({ spawnWorker: () => child });
+    await expect(bridge.ready).rejects.toThrow('model load failed');
+    bridge.close();
+  });
+});

--- a/test/main/features/project_files.test.ts
+++ b/test/main/features/project_files.test.ts
@@ -124,19 +124,29 @@ describe('project_files › async project tree', () => {
     });
   });
 
-  it('reuses a warm tree and invalidates it after a supported write', async () => {
+  it('reuses a warm tree, sees root-level external writes via stamp, invalidates after a supported write', async () => {
     const projectFiles = await import('../../../src/main/features/project_files');
     await projectFiles.uploadSpaceFile('u1', 'p1', 'first.md', Buffer.from('first'));
     await projectFiles.listSpaceFileTree('u1', 'p1');
 
     const root = path.dirname((await projectFiles.listSpaceFileTree('u1', 'p1'))[0].path);
+    // 根目录外部写入 → 根指纹变化 → 下一次列表立即可见（「变更才扫」）
     fs.writeFileSync(path.join(root, 'out-of-band.md'), 'external');
     const warm = await projectFiles.listSpaceFileTree('u1', 'p1');
-    expect(warm.map((node) => node.name)).toEqual(['first.md']);
+    expect(warm.map((node) => node.name).sort()).toEqual(['first.md', 'out-of-band.md']);
+
+    // 深层外部写入不改根目录指纹 → 兜底窗口内热命中（陈旧由 SPACE_TREE_BACKSTOP_MS 兜底）
+    await projectFiles.createSpaceDir('u1', 'p1', 'deep');
+    await projectFiles.listSpaceFileTree('u1', 'p1');
+    const deepDir = path.join(root, 'deep');
+    fs.writeFileSync(path.join(deepDir, 'deep-file.md'), 'deep');
+    const deepWarm = await projectFiles.listSpaceFileTree('u1', 'p1');
+    expect(deepWarm.flatMap((n: any) => [n.name, ...(n.children || []).map((c: any) => c.name)]))
+      .not.toContain('deep-file.md');
 
     await projectFiles.uploadSpaceFile('u1', 'p1', 'second.md', Buffer.from('second'));
     const refreshed = await projectFiles.listSpaceFileTree('u1', 'p1');
-    expect(refreshed.map((node) => node.name)).toEqual(['first.md', 'out-of-band.md', 'second.md']);
+    expect(refreshed.map((node) => node.name).sort()).toEqual(['deep', 'first.md', 'out-of-band.md', 'second.md']);
   });
 });
 

--- a/test/main/features/spaces_artifacts.test.ts
+++ b/test/main/features/spaces_artifacts.test.ts
@@ -137,6 +137,52 @@ describe('spaces › 产物无确认态（COGSEED-16：产出即正式）', () =
   });
 });
 
+describe('spaces › 产物缓存「变更才扫」', () => {
+  it('无变化时列表稳定，新增附件后下一次列表立即可见', async () => {
+    const spaces = await import('../../../src/main/features/spaces');
+    const chats = await import('../../../src/main/features/chats');
+    const created = await spaces.createSpace(UID, { name: '缓存空间' });
+    if (!created.ok) throw new Error('create failed');
+    const sid = created.space.space_id;
+    const conv = await chats.createConversation(UID, { title: 'a', spaceId: sid });
+    const attDir = path.join(tmpDir, UID, 'cloud', 'chat_attachments', conv.conversation_id);
+    fs.mkdirSync(attDir, { recursive: true });
+    fs.writeFileSync(path.join(attDir, 'a.pdf'), 'x');
+
+    const mod = await import('../../../src/main/features/spaces_artifacts');
+    const first = await mod.listSpaceArtifacts(UID, sid);
+    expect(first.map((a) => a.name)).toContain('a.pdf');
+
+    // 无变化：列表一致（指纹命中缓存）
+    const second = await mod.listSpaceArtifacts(UID, sid);
+    expect(second.map((a) => a.name)).toEqual(first.map((a) => a.name));
+
+    // 新增附件 → 目录指纹变化 → 下一次列表立即可见
+    fs.writeFileSync(path.join(attDir, 'b.pdf'), 'y');
+    const third = await mod.listSpaceArtifacts(UID, sid);
+    expect(third.map((a) => a.name)).toContain('b.pdf');
+  });
+
+  it('删除附件后从列表消失', async () => {
+    const spaces = await import('../../../src/main/features/spaces');
+    const chats = await import('../../../src/main/features/chats');
+    const created = await spaces.createSpace(UID, { name: '删除空间' });
+    if (!created.ok) throw new Error('create failed');
+    const sid = created.space.space_id;
+    const conv = await chats.createConversation(UID, { title: 'a', spaceId: sid });
+    const attDir = path.join(tmpDir, UID, 'cloud', 'chat_attachments', conv.conversation_id);
+    fs.mkdirSync(attDir, { recursive: true });
+    const f = path.join(attDir, 'gone.pdf');
+    fs.writeFileSync(f, 'x');
+
+    const mod = await import('../../../src/main/features/spaces_artifacts');
+    expect((await mod.listSpaceArtifacts(UID, sid)).map((a) => a.name)).toContain('gone.pdf');
+    fs.rmSync(f);
+    const after = await mod.listSpaceArtifacts(UID, sid);
+    expect(after.map((a) => a.name)).not.toContain('gone.pdf');
+  });
+});
+
 describe('spaces › 工作区兜底扫描（未登记 produced 的产物文件）', () => {
   it('消息 produced 没记录、但存在于会话工作区的文件也进产物（md/html）', async () => {
     const spaces = await import('../../../src/main/features/spaces');

--- a/test/main/features/workspace_meta.test.ts
+++ b/test/main/features/workspace_meta.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+let tmpDir: string;
+let prevWs: string | undefined;
+const TEST_UID = 'u1';
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-wsmeta-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  const meta = await import('../../../src/main/features/workspace_meta');
+  meta._resetForTests();
+});
+
+afterEach(() => {
+  process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('workspace_meta › 持久化元数据表', () => {
+  it('put/get/drop 单节条目', async () => {
+    const meta = await import('../../../src/main/features/workspace_meta');
+    await meta.putEntry(TEST_UID, 'artifacts', 'sp_1', 'stamp-a', [{ name: 'a.pdf' }]);
+    const entry = await meta.getEntry<Array<{ name: string }>>(TEST_UID, 'artifacts', 'sp_1');
+    expect(entry?.stamp).toBe('stamp-a');
+    expect(entry?.data).toEqual([{ name: 'a.pdf' }]);
+    await meta.dropEntry(TEST_UID, 'artifacts', 'sp_1');
+    expect(await meta.getEntry(TEST_UID, 'artifacts', 'sp_1')).toBeNull();
+  });
+
+  it('flush 落盘后重启（内存表清空）仍可读到', async () => {
+    const meta = await import('../../../src/main/features/workspace_meta');
+    await meta.putEntry(TEST_UID, 'spaces', 'sp_1', 's1', { name: '空间一' });
+    await meta.flush(TEST_UID);
+
+    // 模拟进程重启：清内存表再读（load 按 mtime 重新加载）
+    meta._resetForTests();
+    const entry = await meta.getEntry<{ name: string }>(TEST_UID, 'spaces', 'sp_1');
+    expect(entry?.data).toEqual({ name: '空间一' });
+  });
+
+  it('损坏的 meta.json 容错为空表', async () => {
+    const pathsMod = await import('../../../src/main/paths');
+    const file = pathsMod.workspaceMetaSectionFile(TEST_UID, 'spaces');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, '{not json');
+
+    const meta = await import('../../../src/main/features/workspace_meta');
+    const entry = await meta.getEntry(TEST_UID, 'spaces', 'sp_1');
+    expect(entry).toBeNull();
+    // 修复：写入后应能正常落盘
+    await meta.putEntry(TEST_UID, 'spaces', 'sp_1', 's1', { name: 'ok' });
+    await meta.flush(TEST_UID);
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(raw.entries.sp_1.data).toEqual({ name: 'ok' });
+  });
+
+  it('dropSection 清空整个分区', async () => {
+    const meta = await import('../../../src/main/features/workspace_meta');
+    await meta.putEntry(TEST_UID, 'conversations', 'sp_1', 'a', [1]);
+    await meta.putEntry(TEST_UID, 'conversations', 'sp_2', 'b', [2]);
+    await meta.dropSection(TEST_UID, 'conversations');
+    expect(await meta.getEntry(TEST_UID, 'conversations', 'sp_1')).toBeNull();
+    expect(await meta.getEntry(TEST_UID, 'conversations', 'sp_2')).toBeNull();
+  });
+});

--- a/test/main/workspace-perf.stress.test.ts
+++ b/test/main/workspace-perf.stress.test.ts
@@ -1,0 +1,228 @@
+/**
+ * 工作空间大数据压测（opt-in）。
+ *
+ * 常规 CI 不跑（describe.skipIf 门控）；手动跑出数字：
+ *   COGSEED_PERF_STRESS=1 node scripts/run-tests.mjs run test/main/workspace-perf.stress.test.ts
+ *
+ * 场景：30 个空间 + 1 个大空间（40 个会话、200 个空间文件、30 个附件），
+ * 度量冷/热两次调用的耗时——验证「变更才扫」缓存与轻量化路径在大数据
+ * 形态下的数字（热路径应远低于冷路径）。只打印数字并做宽松断言，
+ * 不设硬性性能红线。
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+let tmpDir: string;
+let prevWs: string | undefined;
+const TEST_UID = 'u1';
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-perf-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  const users = await import('../../../src/main/features/users');
+  users.activateUser(TEST_UID);
+});
+
+afterEach(() => {
+  process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function msOf(start: [number, number]): number {
+  const diff = process.hrtime(start);
+  return Math.round(diff[0] * 1000 + diff[1] / 1e6);
+}
+
+function now(): [number, number] {
+  return process.hrtime();
+}
+
+describe.skipIf(!process.env.COGSEED_PERF_STRESS)('workspace 大数据压测', () => {
+  it('冷/热两次调用对比（打印数字）', async () => {
+    const spaces = await import('../../../src/main/features/spaces');
+    const chats = await import('../../../src/main/features/chats');
+    const projectFiles = await import('../../../src/main/features/project_files');
+    const artifacts = await import('../../../src/main/features/spaces_artifacts');
+    const pathsMod = await import('../../../src/main/paths');
+
+    // ── 种子：30 个普通空间 + 1 个大空间（40 会话 / 200 文件 / 30 附件）──
+    for (let i = 0; i < 30; i += 1) {
+      await spaces.createSpace(TEST_UID, { name: `普通空间${i}` });
+    }
+    const big = await spaces.createSpace(TEST_UID, { name: '大空间' });
+    if (!big.ok) throw new Error('big space create failed');
+    const sid = big.space.space_id;
+
+    for (let i = 0; i < 40; i += 1) {
+      const conv = await chats.createConversation(TEST_UID, { title: `任务${i}`, spaceId: sid });
+      const cid = conv.conversation_id;
+      // members.json：commander + 2 agents，已标记发言
+      const membersDir = path.join(pathsMod.userChatsDir(TEST_UID), cid);
+      fs.mkdirSync(membersDir, { recursive: true });
+      fs.writeFileSync(path.join(membersDir, 'members.json'), JSON.stringify({
+        version: 1,
+        commander_spoken: true,
+        actors: [
+          { kind: 'commander', id: 'commander', name: 'Commander', joined_at: '2026-01-01T00:00:00.000Z' },
+          { kind: 'agent', id: 'agent-a', name: 'A', joined_at: '2026-01-01T00:00:00.000Z' },
+          { kind: 'agent', id: 'agent-b', name: 'B', joined_at: '2026-01-01T00:00:00.000Z' },
+        ],
+      }));
+      // 50 行聊天记录（约 4KB）
+      const lines: string[] = [];
+      for (let k = 0; k < 50; k += 1) {
+        lines.push(JSON.stringify({
+          from: k % 2 === 0 ? 'commander' : 'user',
+          to: k % 2 === 0 ? 'user' : 'commander',
+          ts: `2026-01-01T00:00:${String(k % 60).padStart(2, '0')}.000Z`,
+          text: `第 ${i} 会话第 ${k} 条消息，用于压测聊天记录体积。`,
+        }));
+      }
+      fs.writeFileSync(path.join(pathsMod.userChatsDir(TEST_UID), `${cid}.jsonl`), `${lines.join('\n')}\n`);
+      // 附件：前 30 个会话各放 1 个
+      if (i < 30) {
+        const attDir = path.join(tmpDir, TEST_UID, 'cloud', 'chat_attachments', cid);
+        fs.mkdirSync(attDir, { recursive: true });
+        fs.writeFileSync(path.join(attDir, `资料${i}.pdf`), 'x');
+      }
+    }
+
+    // 空间文件：200 个文件分布在 20 个子目录
+    const filesRoot = pathsMod.spaceFilesDir(TEST_UID, sid);
+    for (let d = 0; d < 20; d += 1) {
+      const dir = path.join(filesRoot, `dir-${d}`);
+      fs.mkdirSync(dir, { recursive: true });
+      for (let f = 0; f < 10; f += 1) {
+        fs.writeFileSync(path.join(dir, `file-${f}.md`), `# ${d}-${f}`);
+      }
+    }
+    // 共享工作区：40 个会话共享同一工作区根（产物兜底遍历的真实形态）
+    const wsRoot = pathsMod.spaceWorkspaceDir(TEST_UID, sid);
+    for (let d = 0; d < 20; d += 1) {
+      const dir = path.join(wsRoot, `out-${d}`);
+      fs.mkdirSync(dir, { recursive: true });
+      for (let f = 0; f < 10; f += 1) {
+        fs.writeFileSync(path.join(dir, `产出-${f}.md`), `# ${d}-${f}`);
+      }
+    }
+
+    // ── 度量 ──
+    const results: Record<string, { cold: number; warm: number }> = {};
+
+    let t = now();
+    await spaces.listSpaces(TEST_UID);
+    results['spaces.list'] = { cold: msOf(t), warm: 0 };
+    t = now();
+    await spaces.listSpaces(TEST_UID);
+    results['spaces.list'].warm = msOf(t);
+
+    t = now();
+    await chats.listSpaceConversations(TEST_UID, sid);
+    results['listSpaceConversations(40会话)'] = { cold: msOf(t), warm: 0 };
+    t = now();
+    await chats.listSpaceConversations(TEST_UID, sid);
+    results['listSpaceConversations(40会话)'].warm = msOf(t);
+
+    t = now();
+    await artifacts.listSpaceArtifacts(TEST_UID, sid);
+    results['listSpaceArtifacts(40会话)'] = { cold: msOf(t), warm: 0 };
+    t = now();
+    await artifacts.listSpaceArtifacts(TEST_UID, sid);
+    results['listSpaceArtifacts(40会话)'].warm = msOf(t);
+
+    t = now();
+    await projectFiles.listSpaceFileTree(TEST_UID, sid);
+    results['listSpaceFileTree(200文件)'] = { cold: msOf(t), warm: 0 };
+    t = now();
+    await projectFiles.listSpaceFileTree(TEST_UID, sid);
+    results['listSpaceFileTree(200文件)'].warm = msOf(t);
+
+    // eslint-disable-next-line no-console
+    console.log('\n[perf-stress] 冷/热对比（ms）:');
+    for (const [name, r] of Object.entries(results)) {
+      // eslint-disable-next-line no-console
+      console.log(`  ${name.padEnd(34)} cold=${String(r.cold).padStart(5)} warm=${String(r.warm).padStart(5)}  (${r.warm < r.cold ? '↓' : '='} 热路径${r.warm <= r.cold ? '不慢于' : '慢于'}冷路径)`);
+      // 宽松断言：热路径不得慢于冷路径（缓存生效的底线）
+      expect(r.warm).toBeLessThanOrEqual(r.cold + 20);
+    }
+  }, 300_000);
+});
+
+describe.skipIf(!process.env.COGSEED_PERF_STRESS)('workspace 元数据表 · 重启后冷启动', () => {
+  it('表命中路径：重启（模块重载）后首次调用直接查表', async () => {
+    const users = await import('../../../src/main/features/users');
+    users.activateUser(TEST_UID);
+    const spaces = await import('../../../src/main/features/spaces');
+    const chats = await import('../../../src/main/features/chats');
+    const artifacts = await import('../../../src/main/features/spaces_artifacts');
+    const projectFiles = await import('../../../src/main/features/project_files');
+    const meta = await import('../../../src/main/features/workspace_meta');
+    const pathsMod = await import('../../../src/main/paths');
+
+    // 种子：10 空间 + 1 大空间（20 会话）
+    for (let i = 0; i < 10; i += 1) {
+      await spaces.createSpace(TEST_UID, { name: `表空间${i}` });
+    }
+    const big = await spaces.createSpace(TEST_UID, { name: '表大空间' });
+    if (!big.ok) throw new Error('create failed');
+    const sid = big.space.space_id;
+    for (let i = 0; i < 20; i += 1) {
+      const conv = await chats.createConversation(TEST_UID, { title: `表任务${i}`, spaceId: sid });
+      const membersDir = path.join(pathsMod.userChatsDir(TEST_UID), conv.conversation_id);
+      fs.mkdirSync(membersDir, { recursive: true });
+      fs.writeFileSync(path.join(membersDir, 'members.json'), JSON.stringify({
+        version: 1, commander_spoken: true,
+        actors: [{ kind: 'commander', id: 'commander', joined_at: 'x' }, { kind: 'agent', id: 'a', joined_at: 'x' }],
+      }));
+      fs.writeFileSync(path.join(pathsMod.userChatsDir(TEST_UID), `${conv.conversation_id}.jsonl`), '{"from":"commander"}\n');
+    }
+    const filesRoot = pathsMod.spaceFilesDir(TEST_UID, sid);
+    fs.mkdirSync(filesRoot, { recursive: true });
+    for (let f = 0; f < 50; f += 1) fs.writeFileSync(path.join(filesRoot, `f${f}.md`), '# x');
+
+    // 首轮：实时计算并写表
+    await spaces.listSpaces(TEST_UID);
+    await chats.listSpaceConversations(TEST_UID, sid);
+    await artifacts.listSpaceArtifacts(TEST_UID, sid);
+    await projectFiles.listSpaceFileTree(TEST_UID, sid);
+    await meta.flush(TEST_UID);
+
+    // 模拟进程重启：清空整个模块注册表（内存缓存/内存表全部消失），
+    // 只留磁盘上的 meta.json
+    vi.resetModules();
+    const users2 = await import('../../../src/main/features/users');
+    users2.activateUser(TEST_UID);
+    const spaces2 = await import('../../../src/main/features/spaces');
+    const chats2 = await import('../../../src/main/features/chats');
+    const artifacts2 = await import('../../../src/main/features/spaces_artifacts');
+    const projectFiles2 = await import('../../../src/main/features/project_files');
+
+    const results: Record<string, number> = {};
+    let t = now();
+    await spaces2.listSpaces(TEST_UID);
+    results['spaces.list（重启后首次）'] = msOf(t);
+    t = now();
+    await chats2.listSpaceConversations(TEST_UID, sid);
+    results['listSpaceConversations（重启后首次）'] = msOf(t);
+    t = now();
+    await artifacts2.listSpaceArtifacts(TEST_UID, sid);
+    results['listSpaceArtifacts（重启后首次）'] = msOf(t);
+    t = now();
+    await projectFiles2.listSpaceFileTree(TEST_UID, sid);
+    results['listSpaceFileTree（重启后首次）'] = msOf(t);
+
+    // eslint-disable-next-line no-console
+    console.log('\n[perf-stress] 重启后冷启动（表命中，ms）:');
+    for (const [name, ms] of Object.entries(results)) {
+      // eslint-disable-next-line no-console
+      console.log(`  ${name.padEnd(34)} ${String(ms).padStart(5)}`);
+    }
+    // 宽松断言：表命中路径应显著快于实时扫描（< 100ms 量级）
+    expect(results['spaces.list（重启后首次）']).toBeLessThan(200);
+    expect(results['listSpaceConversations（重启后首次）']).toBeLessThan(200);
+  }, 300_000);
+});


### PR DESCRIPTION
## 背景
工作空间相关界面在数据量增大后出现间歇卡顿（打开工作空间、空间任务列表、产物页签、长对话期间）。经深度审查定位到主进程数据路径、渲染层全量重建、逐 token IPC 洪泛、ONNX 推理占用主循环等多处根因，本轮逐一修复。

## 主要改动
1. **持久化元数据表**（对齐 Codex/DSH「列表查表、内容按需」架构）：`<uid>/local/workspace/meta-*.json` 分区文件，spaces/conversations/artifacts/fileTrees 四类条目带指纹+时间戳；四个列表路径「指纹命中直接查表，未命中实时计算并写回」。纯派生缓存，可整表丢弃重建
2. **列表路径轻量化**：spaces.list 只读索引；commander_in_chat 走 members.json 的 commander_spoken 标志（落盘写入+老数据懒补记），不再扫描 jsonl 全文；bus 忙时仍走实时读取保证名单一致性
3. **「变更才扫」**：产物/文件树按目录指纹失效 + 3 分钟兜底；搜索与文件状态快照先行、reconcile 后台收敛；共享工作区兜底遍历一次聚合只走一次
4. **渲染层**：流式消息侧栏重建 rAF 合并、徽标 O(N×P)→O(1)、搜索防抖+焦点恢复、拖拽节流
5. **IPC**：process 事件批量打包（16ms/64 条），preload 拆包，事件语义不变
6. **向量化迁移独立子进程**（bin/cogseed-embed-worker.cjs，JSONL 协议），进程内自动回退，功能不因 worker 缺失丢失
7. 其他：reconcile 并发合并、队列去重 O(n²)→O(1)、VACUUM 防抖、外部技能目录扫描缓存、members 指纹缓存、同步遍历异步化、耗时埋点 + 压测脚本

## 测试
- typecheck 通过；全量测试 **9330 通过**（唯一失败 session_import 为上游既有问题，与本次改动无关，已在干净 develop 上复现确认）
- 新增测试：workspace_meta 存储、commander_spoken 懒补记、桥接协议、产物/文件树「变更才扫」等
- 压测（opt-in，`COGSEED_PERF_STRESS=1`）：30 空间 + 40 会话 + 200 文件场景
  - 打开工作空间：实时扫描 160ms → 表命中 6ms（重启后冷启动）
  - 任务列表：226ms → 0ms；产物 40ms → 1ms；文件树 4ms → 0ms
- 实机验证：重启后首次打开工作空间 `listSpaces table hit { ms: 0 }`

## 备注
- sbom.cdx.json 缺 9 个依赖是上游既有问题（本 PR 未触碰），建议单独提 PR 重新生成 SBOM