### PR TITLE
feat(sidebar): group channel conversations under collapsible per-channel sections

### DIFF
--- a/src/main/features/chats.ts
+++ b/src/main/features/chats.ts
@@ -114,9 +114,14 @@ export interface Conversation {
   space_id?: string;
   /** Set when this conversation was created by an auto-task fire (sidebar
    *  "Automation" tab). Used by the renderer to render the clock icon next
-   *  to the title and to group the conv under its originating task in the
-   *  auto-tab expand panel. Stable id; survives task deletion. */
+   * to the title and to group the conv under its originating task in the
+   * auto-tab expand panel. Stable id; survives task deletion. */
   origin_auto_task_id?: string;
+  /** Messaging channel this conversation was created by (e.g. `feishu_lark`,
+   *  `wechat_personal`). Set once at binding creation; the renderer groups
+   *  such conversations under a collapsible per-channel sidebar section.
+   *  Absent → ordinary in-app conversation. */
+  channel_platform?: string;
   /** Optional sidebar pin timestamp. Pinned conversations sort to the top of
    *  whichever sidebar list currently contains them (project or unprojected). */
   pinned_at?: string;
@@ -292,6 +297,7 @@ function _normaliseConversation(raw: any, fallbackCid = ''): Conversation | null
   if (typeof raw.project_id === 'string' && raw.project_id) out.project_id = raw.project_id;
   if (typeof raw.space_id === 'string' && raw.space_id) out.space_id = raw.space_id;
   if (typeof raw.origin_auto_task_id === 'string' && raw.origin_auto_task_id) out.origin_auto_task_id = raw.origin_auto_task_id;
+  if (typeof raw.channel_platform === 'string' && raw.channel_platform) out.channel_platform = raw.channel_platform;
   if (typeof raw.pinned_at === 'string' && raw.pinned_at) out.pinned_at = raw.pinned_at;
   if (typeof raw.pin_state_updated_at === 'string' && raw.pin_state_updated_at) out.pin_state_updated_at = raw.pin_state_updated_at;
   if (raw.title_manually_set === true) out.title_manually_set = true;
@@ -2022,6 +2028,10 @@ export interface CreateConversationOptions {
    *  a back-link to the task that spawned it. Used by the renderer for the
    *  clock-icon prefix and the auto-tab expand-panel grouping. */
   originAutoTaskId?: string;
+  /** Messaging channel platform id (e.g. `feishu_lark`), set by
+   *  `features/messaging/bindings.ts` when a channel conversation is
+   *  created. Renderer groups channel conversations per platform. */
+  channelPlatform?: string;
   /** True if this conversation was imported from another agent (Claude Code,
    *  Codex, etc.) during onboarding. Used to identify imported sessions for
    *  special handling. */
@@ -2041,7 +2051,7 @@ function normaliseConversationTitle(raw: unknown): string {
 
 export async function createConversation(userId: string, {
   kind = 'normal', agentId = '', skillId = '', title = '', projectId = '', spaceId = '', conversationId = '', originAutoTaskId = '',
-  imported = false, needs_welcome = false,
+  channelPlatform = '', imported = false, needs_welcome = false,
 }: CreateConversationOptions = {}): Promise<Conversation> {
   const explicitCid = conversationId && safeId(conversationId) ? conversationId : '';
   const outcome = await _withConversationIndexStore(userId, async (store) => {
@@ -2066,6 +2076,7 @@ export async function createConversation(userId: string, {
           ...(projectId ? { project_id: projectId } : {}),
           ...(spaceId ? { space_id: spaceId } : {}),
           ...(originAutoTaskId ? { origin_auto_task_id: originAutoTaskId } : {}),
+          ...(channelPlatform ? { channel_platform: channelPlatform } : {}),
           ...(imported ? { imported: true } : {}),
           ...(needs_welcome ? { needs_welcome: true } : {}),
           updated_at: now,
@@ -2099,6 +2110,7 @@ export async function createConversation(userId: string, {
       ...(projectId ? { project_id: projectId } : {}),
       ...(spaceId ? { space_id: spaceId } : {}),
       ...(originAutoTaskId ? { origin_auto_task_id: originAutoTaskId } : {}),
+      ...(channelPlatform ? { channel_platform: channelPlatform } : {}),
       ...(imported ? { imported: true } : {}),
       ...(needs_welcome ? { needs_welcome: true } : {}),
       created_at: now,

--- a/src/main/features/messaging/bindings.ts
+++ b/src/main/features/messaging/bindings.ts
@@ -293,6 +293,7 @@ export async function resolveOrCreateBinding(
     const conversation = await chats.createConversation(uid, {
       title,
       ...(spaceId ? { spaceId } : {}),
+      channelPlatform: instance.platform,
     });
     const now = nowIso();
     const binding: MessagingBinding = {

--- a/src/main/features/messaging/channel-annotation.ts
+++ b/src/main/features/messaging/channel-annotation.ts
@@ -1,0 +1,88 @@
+/**
+ * Channel annotation for conversation lists — 纯函数层。
+ *
+ * 渠道会话（飞书/微信等绑定创建）在侧栏按渠道分组展示。分组依据：
+ *  - 首选会话自身的持久化字段 `channel_platform`（bindings 创建时写入）；
+ *  - 兜底：会话缺字段时经 messaging binding（cid → instanceId → instance）
+ *    动态补标（存量会话、字段引入前创建的会话），不回写磁盘；
+ *  - 显示名 `channel_name` 是列表响应的派生字段（不落盘）：实例
+ *    displayName 的实时值，拿不到时退化为内置渠道名映射。
+ */
+
+import type { MessagingPlatform } from './types';
+
+/** Fallback display names when no live instance supplies one (deleted
+ *  instance, cross-device sync of a channel conversation, etc.). */
+export const CHANNEL_DISPLAY_NAMES: Record<MessagingPlatform, string> = {
+  feishu_lark: '飞书',
+  wechat_personal: '微信',
+  wecom: '企业微信',
+  telegram: 'Telegram',
+};
+
+export interface ChannelBindingRef {
+  cid: string;
+  instanceId: string;
+}
+
+export interface ChannelInstanceRef {
+  id: string;
+  platform: MessagingPlatform;
+  displayName?: string;
+}
+
+export interface ChannelAnnotatable {
+  conversation_id: string;
+  channel_platform?: string;
+}
+
+function isKnownPlatform(value: string): value is MessagingPlatform {
+  return value === 'feishu_lark' || value === 'wechat_personal' || value === 'wecom' || value === 'telegram';
+}
+
+/**
+ * Returns a new array with `channel_platform` back-filled (binding join, no
+ * disk write) and `channel_name` injected on every channel conversation.
+ * Non-channel conversations pass through unchanged (same object reference).
+ */
+export function annotateChannelConversations<T extends ChannelAnnotatable>(
+  conversations: readonly T[],
+  bindings: readonly ChannelBindingRef[],
+  instances: readonly ChannelInstanceRef[],
+): T[] {
+  const platformByInstance = new Map<string, MessagingPlatform>();
+  // First live display name per platform (used for `channel_name`; multiple
+  // instances of one platform share the sidebar group).
+  const liveNameByPlatform = new Map<MessagingPlatform, string>();
+  for (const instance of instances) {
+    if (!instance?.id || !isKnownPlatform(instance.platform)) continue;
+    platformByInstance.set(instance.id, instance.platform);
+    const name = typeof instance.displayName === 'string' && instance.displayName.trim()
+      ? instance.displayName.trim()
+      : '';
+    if (name && !liveNameByPlatform.has(instance.platform)) {
+      liveNameByPlatform.set(instance.platform, name);
+    }
+  }
+  // Last binding wins — mirrors resolveOrCreateBinding replacing stale keys.
+  const channelByCid = new Map<string, MessagingPlatform>();
+  for (const binding of bindings) {
+    if (!binding?.cid || !binding?.instanceId) continue;
+    const platform = platformByInstance.get(binding.instanceId);
+    if (platform) channelByCid.set(binding.cid, platform);
+  }
+  return conversations.map((conversation) => {
+    if (!conversation?.conversation_id) return conversation;
+    const persisted = typeof conversation.channel_platform === 'string' && isKnownPlatform(conversation.channel_platform)
+      ? conversation.channel_platform
+      : '';
+    const platform = persisted || channelByCid.get(conversation.conversation_id) || '';
+    if (!platform) return conversation;
+    const channelName = liveNameByPlatform.get(platform) || CHANNEL_DISPLAY_NAMES[platform];
+    return {
+      ...conversation,
+      channel_platform: platform,
+      channel_name: channelName,
+    };
+  });
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -118,6 +118,9 @@ import {
 import { invokeHandlers as qualityHandlers } from './quality';
 import { invokeHandlers as connectorsHandlers } from './connectors';
 import { invokeHandlers as messagingHandlers } from './messaging';
+import * as messagingBindings from '../features/messaging/bindings';
+import * as messagingRegistry from '../features/messaging/registry';
+import { annotateChannelConversations } from '../features/messaging/channel-annotation';
 import { invokeHandlers as personalContextHandlers } from './personal-context';
 import { invokeHandlers as touchpointHandlers } from './touchpoints';
 import { invokeHandlers as desktopWorkbenchHandlers } from './desktop-workbench';
@@ -920,6 +923,17 @@ const invokeHandlers: Record<string, InvokeHandler> = {
   },
 
   'conversations.list': async ({ mode, active_cid, expanded_projects, project_id, task_id, bucket, offset }, ctx) => {
+    // Channel conversations get their sidebar grouping fields (platform
+    // back-fill via bindings + live display name) on every list response;
+    // persisted fields stay authoritative, the join is display-only.
+    const annotate = async <T extends { conversation_id: string; channel_platform?: string }>(rows: readonly T[]): Promise<T[]> => {
+      if (!rows.length) return [...rows];
+      const [bindings, instances] = await Promise.all([
+        messagingBindings.listBindings(ctx.userId).catch(() => []),
+        messagingRegistry.listInstances(ctx.userId).catch(() => []),
+      ]);
+      return annotateChannelConversations(rows, bindings, instances);
+    };
     if (mode === 'startup') {
       const expandedProjectIds = String(expanded_projects || '')
         .split(',')
@@ -928,21 +942,40 @@ const invokeHandlers: Record<string, InvokeHandler> = {
         activeConversationId: safeId(active_cid) ? active_cid : undefined,
         expandedProjectIds,
       });
+      if (Array.isArray((result as { conversations?: unknown }).conversations)) {
+        (result as { conversations: Awaited<ReturnType<typeof annotate>> }).conversations =
+          await annotate((result as { conversations: Array<{ conversation_id: string; channel_platform?: string }> }).conversations);
+      }
       return result;
     }
     if (mode === 'project') {
       if (!safeId(project_id)) throw new Error('invalid project id');
-      return chats.listProjectConversationPage(ctx.userId, project_id, offset);
+      const page = await chats.listProjectConversationPage(ctx.userId, project_id, offset);
+      if (Array.isArray((page as { conversations?: unknown }).conversations)) {
+        (page as { conversations: Awaited<ReturnType<typeof annotate>> }).conversations =
+          await annotate((page as { conversations: Array<{ conversation_id: string; channel_platform?: string }> }).conversations);
+      }
+      return page;
     }
     if (mode === 'auto_task') {
       if (!safeId(task_id)) throw new Error('invalid auto task id');
-      return chats.listAutoTaskConversationPage(ctx.userId, task_id, offset);
+      const page = await chats.listAutoTaskConversationPage(ctx.userId, task_id, offset);
+      if (Array.isArray((page as { conversations?: unknown }).conversations)) {
+        (page as { conversations: Awaited<ReturnType<typeof annotate>> }).conversations =
+          await annotate((page as { conversations: Array<{ conversation_id: string; channel_platform?: string }> }).conversations);
+      }
+      return page;
     }
     if (mode === 'old_unprojected') {
       if (bucket !== 'last30' && bucket !== 'older') throw new Error('invalid conversation bucket');
-      return chats.listOldUnprojectedConversationPage(ctx.userId, bucket, offset);
+      const page = await chats.listOldUnprojectedConversationPage(ctx.userId, bucket, offset);
+      if (Array.isArray((page as { conversations?: unknown }).conversations)) {
+        (page as { conversations: Awaited<ReturnType<typeof annotate>> }).conversations =
+          await annotate((page as { conversations: Array<{ conversation_id: string; channel_platform?: string }> }).conversations);
+      }
+      return page;
     }
-    return { conversations: await chats.listConversations(ctx.userId) };
+    return { conversations: await annotate(await chats.listConversations(ctx.userId)) };
   },
 
   'conversations.autoTaskCounts': async ({ task_ids } = {}, ctx) => {
@@ -955,7 +988,22 @@ const invokeHandlers: Record<string, InvokeHandler> = {
     if (!safeId(cid)) throw new Error('invalid cid');
     const conv = await chats.getConversation(ctx.userId, cid, conversationProjectHint(args));
     if (!conv) throw new Error('conversation not found');
-    return { conversation: conv };
+    // Same channel annotation as the list endpoints — a freshly hydrated
+    // sidebar row (e.g. external inbound to a brand-new conversation) must
+    // land in its channel group immediately.
+    if (!conv.channel_platform) {
+      const [bindings, instances] = await Promise.all([
+        messagingBindings.listBindings(ctx.userId).catch(() => []),
+        messagingRegistry.listInstances(ctx.userId).catch(() => []),
+      ]);
+      const [annotated] = annotateChannelConversations([conv], bindings, instances);
+      return { conversation: annotated || conv };
+    }
+    const [instances] = await Promise.all([
+      messagingRegistry.listInstances(ctx.userId).catch(() => []),
+    ]);
+    const [annotated] = annotateChannelConversations([conv], [], instances);
+    return { conversation: annotated || conv };
   },
 
   'conversations.history': async (args, ctx) => {

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -54,10 +54,11 @@ function _loadSidebarCollapse() {
         spaces: raw.spaces === true,
         recent: raw.recent === true,
         spaceGroups: (raw.spaceGroups && typeof raw.spaceGroups === 'object') ? raw.spaceGroups : {},
+        channelGroups: (raw.channelGroups && typeof raw.channelGroups === 'object') ? raw.channelGroups : {},
       };
     }
   } catch (_) {}
-  return { pinned: false, spaces: false, recent: false, spaceGroups: {} };
+  return { pinned: false, spaces: false, recent: false, spaceGroups: {}, channelGroups: {} };
 }
 function _saveSidebarCollapse() {
   try { localStorage.setItem(_SIDEBAR_COLLAPSE_KEY, JSON.stringify(_sidebarCollapse)); } catch (_) {}
@@ -6777,6 +6778,20 @@ function _bindConversationSidebarItems(container, opts = {}) {
       renderConversationList();
     });
   });
+  // 侧栏「消息渠道」折叠组切换（飞书/微信等；状态持久化 localStorage）
+  container.querySelectorAll('[data-conv-channel-toggle="1"]').forEach((btn) => {
+    if (btn.dataset.channelBound === '1') return;
+    btn.dataset.channelBound = '1';
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const platform = btn.dataset.convChannel || '';
+      if (!platform) return;
+      _sidebarCollapse.channelGroups[platform] = !_sidebarCollapse.channelGroups[platform];
+      _saveSidebarCollapse();
+      renderConversationList();
+    });
+  });
   // 侧栏空间行 ⋯ 菜单（置顶/重命名/在访达中显示/删除）
   container.querySelectorAll('[data-conv-space-more]').forEach((el) => {
     if (el.dataset.moreBound === '1') return;
@@ -7015,6 +7030,67 @@ function _renderSpaceSidebarGroup(sp, convs) {
     })).join('')}`;
 }
 
+// ── 消息渠道分组（飞书/微信等渠道会话在「最近任务」tab 的聚合展示）──
+// 渠道会话 = conversations 列表里带 channel_platform 的行（主进程列表响应
+// 标注：新会话创建时落盘 + 存量经 binding join 兜底）。分组只收非置顶的
+// 渠道会话（用户置顶 = 想常驻顶部，不进组）。折叠状态持久化
+// _sidebarCollapse.channelGroups[platform]，默认展开。
+const CHANNEL_SIDEBAR_ICONS = {
+  feishu_lark: 'feishu',
+  wechat_personal: 'wechat',
+  wecom: 'wecom',
+  telegram: 'telegram',
+};
+const CHANNEL_SIDEBAR_NAMES = {
+  feishu_lark: '飞书',
+  wechat_personal: '微信',
+  wecom: '企业微信',
+  telegram: 'Telegram',
+};
+function _channelGroupLabel(platform, convs) {
+  const first = (convs || []).find(Boolean);
+  const live = first && typeof first.channel_name === 'string' && first.channel_name.trim();
+  return live || CHANNEL_SIDEBAR_NAMES[platform] || platform;
+}
+function _channelGroupIcon(platform) {
+  return CHANNEL_SIDEBAR_ICONS[platform] || 'message-square';
+}
+/** 渠道分组区：每组一个可折叠组头（图标+渠道名+会话数）+ 组内会话行。
+ *  组间按组内最新活跃倒序；组内排序复用置顶/最近的比较器。 */
+function _renderChannelSidebarGroups(channelConvs) {
+  if (!channelConvs.length) return '';
+  const byPlatform = new Map();
+  for (const conv of channelConvs) {
+    const platform = conv.channel_platform;
+    if (!platform) continue;
+    if (!byPlatform.has(platform)) byPlatform.set(platform, []);
+    byPlatform.get(platform).push(conv);
+  }
+  const groups = Array.from(byPlatform.entries())
+    .map(([platform, convs]) => ({ platform, convs }))
+    .sort((a, b) => {
+      const latest = (list) => list.reduce((acc, c) => {
+        const at = (c && (c.last_active_at || c.updated_at)) || '';
+        return at > acc ? at : acc;
+      }, '');
+      return latest(b.convs).localeCompare(latest(a.convs));
+    });
+  return groups.map(({ platform, convs }) => {
+    const collapsed = !!_sidebarCollapse.channelGroups[platform];
+    const label = _channelGroupLabel(platform, convs);
+    return `
+    <button type="button" class="conv-list-section-header conv-channel-group is-collapsible${collapsed ? ' is-collapsed' : ''}"
+      data-conv-channel-toggle="1" data-conv-channel="${escapeHtml(platform)}"
+      aria-expanded="${collapsed ? 'false' : 'true'}">
+      <span class="conv-list-section-caret" aria-hidden="true">${_uiIconHtml(collapsed ? 'chevron-right' : 'chevron-down', 'conv-list-section-caret-icon')}</span>
+      <span class="conv-channel-group-icon" aria-hidden="true">${_uiIconHtml(_channelGroupIcon(platform), 'conv-channel-group-icon-svg')}</span>
+      <span class="conv-list-section-label" title="${escapeHtml(label)}">${escapeHtml(label)}</span>
+      <span class="conv-list-section-count">${convs.length}</span>
+    </button>
+    ${collapsed ? '' : _renderConversationFlatList(convs, { bucketScope: `channel:${platform}`, nested: true })}`;
+  }).join('');
+}
+
 /** 分区标题行：可折叠（data-sidebar-fold）+ 可选右侧操作按钮（data-sidebar-action）。 */
 function _renderSidebarSectionHeader(section, label, opts = {}) {
   const collapsed = !!_sidebarCollapse[section];
@@ -7167,8 +7243,16 @@ function renderConversationList() {
         parts.push(_renderConversationFlatList(pinned, { bucketScope: 'pinned' }));
       }
     }
+    // ② 渠道分组区（飞书/微信等渠道会话；置顶的渠道会话留在置顶区不进组）
+    const channelConvs = recent.filter((c) => c && typeof c.channel_platform === 'string' && c.channel_platform);
+    const plainRecent = channelConvs.length
+      ? recent.filter((c) => !(c && typeof c.channel_platform === 'string' && c.channel_platform))
+      : recent;
+    if (channelConvs.length) {
+      parts.push(_renderChannelSidebarGroups(channelConvs));
+    }
     // ③ 最近任务区（平铺，无时间桶标题）
-    if (recent.length || hasDeferredRecent) {
+    if (plainRecent.length || hasDeferredRecent) {
       parts.push(_renderSidebarSectionHeader('recent', t('sidebar.recent_tasks'), {
         action: 'new-task',
         actionTitle: t('sidebar.new_task', '新建任务'),
@@ -7176,7 +7260,7 @@ function renderConversationList() {
       }));
       if (!_sidebarCollapse.recent) {
         if (_sidebarNewTaskOpen) parts.push(_renderSidebarNewTaskComposer());
-        parts.push(_renderConversationFlatList(recent, {
+        parts.push(_renderConversationFlatList(plainRecent, {
           bucketScope: 'sidebar',
           loadMore: _sidebarHasMoreOld(),
           loadMoreBucket: 'last30',

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -7078,15 +7078,20 @@ function _renderChannelSidebarGroups(channelConvs) {
   return groups.map(({ platform, convs }) => {
     const collapsed = !!_sidebarCollapse.channelGroups[platform];
     const label = _channelGroupLabel(platform, convs);
+    // 与「最近任务」等分区头同构（conv-list-space-title + fold 按钮 +
+    // 渐变线 + 计数徽章），保证侧栏所有标题行视觉一致；渠道差异只保留
+    // 标签前的渠道图标与组内会话数徽章。
     return `
-    <button type="button" class="conv-list-section-header conv-channel-group is-collapsible${collapsed ? ' is-collapsed' : ''}"
-      data-conv-channel-toggle="1" data-conv-channel="${escapeHtml(platform)}"
-      aria-expanded="${collapsed ? 'false' : 'true'}">
-      <span class="conv-list-section-caret" aria-hidden="true">${_uiIconHtml(collapsed ? 'chevron-right' : 'chevron-down', 'conv-list-section-caret-icon')}</span>
-      <span class="conv-channel-group-icon" aria-hidden="true">${_uiIconHtml(_channelGroupIcon(platform), 'conv-channel-group-icon-svg')}</span>
-      <span class="conv-list-section-label" title="${escapeHtml(label)}">${escapeHtml(label)}</span>
+    <div class="conv-list-section-header conv-list-space-title${collapsed ? ' is-collapsed' : ''}">
+      <button type="button" class="conv-list-section-fold" data-conv-channel-toggle="1" data-conv-channel="${escapeHtml(platform)}"
+        aria-expanded="${collapsed ? 'false' : 'true'}">
+        <span class="conv-list-section-caret" aria-hidden="true">${_uiIconHtml(collapsed ? 'chevron-right' : 'chevron-down', 'conv-list-section-caret-icon')}</span>
+        <span class="conv-channel-group-icon" aria-hidden="true">${_uiIconHtml(_channelGroupIcon(platform), 'conv-channel-group-icon-svg')}</span>
+        <span class="conv-list-section-label">${escapeHtml(label)}</span>
+      </button>
       <span class="conv-list-section-count">${convs.length}</span>
-    </button>
+      <span class="conv-list-section-rule" aria-hidden="true"></span>
+    </div>
     ${collapsed ? '' : _renderConversationFlatList(convs, { bucketScope: `channel:${platform}`, nested: true })}`;
   }).join('');
 }

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -321,6 +321,17 @@ function bindStaticHandlers() {
     if (typeof cid !== 'string' || !cid) return;
     const tracker = window.__cogseedLiveBusTracker;
     if (msgId && tracker && typeof tracker.has === 'function' && tracker.has(msgId)) return;
+    // A message landing in a collapsed channel group re-opens that group —
+    // external-channel traffic is push-visible by design.
+    const conv = (typeof conversations !== 'undefined' && Array.isArray(conversations))
+      ? conversations.find((c) => c && c.conversation_id === cid)
+      : null;
+    if (conv && typeof conv.channel_platform === 'string' && conv.channel_platform
+      && typeof _sidebarCollapse !== 'undefined' && _sidebarCollapse
+      && _sidebarCollapse.channelGroups && _sidebarCollapse.channelGroups[conv.channel_platform]) {
+      _sidebarCollapse.channelGroups[conv.channel_platform] = false;
+      try { _saveSidebarCollapse(); } catch (_) { /* best-effort persistence */ }
+    }
     if (cid === (typeof currentCid === 'string' ? currentCid : '')) {
       const lastStreamAt = (typeof _lastGroupWorkEventAt !== 'undefined' && _lastGroupWorkEventAt && typeof _lastGroupWorkEventAt.get === 'function')
         ? (_lastGroupWorkEventAt.get(cid) || 0)

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -2771,25 +2771,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   line-height: 18px;
   text-align: center;
 }
-/* 消息渠道分组（飞书/微信等）：组头复用空间组样式骨架，渠道图标与文字同行 */
-.conv-list-section-header.conv-channel-group {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  width: 100%;
-  padding: 10px 8px 5px 8px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  appearance: none;
-  font-size: 11.5px;
-  font-weight: 600;
-  color: #7c8a99;
-  letter-spacing: 0.02em;
-  cursor: pointer;
-  text-align: left;
-}
-.conv-list-section-header.conv-channel-group:hover { background: rgba(148, 163, 184, 0.1); }
+/* 消息渠道分组（飞书/微信等）：标题行完全复用 conv-list-space-title 分区头
+   样式（字体/行高/折叠箭头/渐变线同款），渠道差异只有标签前的图标位。 */
 .conv-channel-group-icon {
   flex: 0 0 auto;
   display: inline-flex;
@@ -2803,13 +2786,6 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 15px;
   height: 15px;
   display: block;
-}
-.conv-list-section-header.conv-channel-group .conv-list-section-label {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 /* 侧栏「置顶 / 空间 / 最近」分区标题（分区级标签，比时间桶标题更醒目）。
    大厂风格：克制的分组标签 —— 小字号、中字重、中性灰，无分隔线，靠留白分区。 */

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -2771,6 +2771,46 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   line-height: 18px;
   text-align: center;
 }
+/* 消息渠道分组（飞书/微信等）：组头复用空间组样式骨架，渠道图标与文字同行 */
+.conv-list-section-header.conv-channel-group {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  padding: 10px 8px 5px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  appearance: none;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: #7c8a99;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  text-align: left;
+}
+.conv-list-section-header.conv-channel-group:hover { background: rgba(148, 163, 184, 0.1); }
+.conv-channel-group-icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  width: 15px;
+  height: 15px;
+}
+.conv-channel-group-icon .ui-icon,
+.conv-channel-group-icon svg,
+.conv-channel-group-icon img {
+  width: 15px;
+  height: 15px;
+  display: block;
+}
+.conv-list-section-header.conv-channel-group .conv-list-section-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 /* 侧栏「置顶 / 空间 / 最近」分区标题（分区级标签，比时间桶标题更醒目）。
    大厂风格：克制的分组标签 —— 小字号、中字重、中性灰，无分隔线，靠留白分区。 */
 .conv-list-section-header.conv-list-space-title {

--- a/test/main/features/chats-channel-platform.test.ts
+++ b/test/main/features/chats-channel-platform.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Conversation.channel_platform —— 渠道会话标记的持久化往返。
+ *
+ * 覆盖：
+ *   - createConversation({channelPlatform}) 落盘 channel_platform
+ *   - getConversation 读回字段（normalize 白名单放行）
+ *   - 未传 platform 的普通会话不产生该字段
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+vi.mock('../../../src/main/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+let tmpDir: string;
+let prevWs: string | undefined;
+const TEST_UID = 'u1';
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-chats-channel-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+  const users = await import('../../../src/main/features/users');
+  users.activateUser(TEST_UID);
+});
+
+afterEach(() => {
+  if (prevWs === undefined) delete process.env.COGSEED_WORKSPACE_ROOT;
+  else process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+describe('chats — channel_platform persistence', () => {
+  it('createConversation persists channelPlatform and reads it back', async () => {
+    const chats = await import('../../../src/main/features/chats');
+    const created = await chats.createConversation(TEST_UID, {
+      title: '飞书 · 张三',
+      channelPlatform: 'feishu_lark',
+    });
+    expect(created.channel_platform).toBe('feishu_lark');
+    const read = await chats.getConversation(TEST_UID, created.conversation_id);
+    expect(read?.channel_platform).toBe('feishu_lark');
+  });
+
+  it('ordinary conversations stay unmarked', async () => {
+    const chats = await import('../../../src/main/features/chats');
+    const created = await chats.createConversation(TEST_UID, { title: '普通任务' });
+    expect(created.channel_platform).toBeUndefined();
+    const read = await chats.getConversation(TEST_UID, created.conversation_id);
+    expect(read?.channel_platform).toBeUndefined();
+  });
+
+  it('listConversations returns the field for channel conversations', async () => {
+    const chats = await import('../../../src/main/features/chats');
+    const created = await chats.createConversation(TEST_UID, {
+      title: '微信 · 李四',
+      channelPlatform: 'wechat_personal',
+    });
+    const list = await chats.listConversations(TEST_UID);
+    const row = list.find((c) => c.conversation_id === created.conversation_id);
+    expect(row?.channel_platform).toBe('wechat_personal');
+  });
+});

--- a/test/main/features/messaging-channel-annotation.test.ts
+++ b/test/main/features/messaging-channel-annotation.test.ts
@@ -1,0 +1,92 @@
+/**
+ * 消息渠道会话注记（channel-annotation）——侧栏渠道分组的数据核心。
+ *
+ * 覆盖（纯函数，无 IO）：
+ *   - 持久化 channel_platform 优先，binding join 兜底补标（存量会话）
+ *   - channel_name 派生：实例 displayName 实时值 → 内置渠道名映射 → platform 原值
+ *   - 非渠道会话原样透传（同引用，不复制）
+ *   - 实例缺失/未知平台不产生注记；binding 指向已删实例时兜底映射仍可用
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  annotateChannelConversations,
+  CHANNEL_DISPLAY_NAMES,
+  type ChannelBindingRef,
+  type ChannelInstanceRef,
+} from '../../../src/main/features/messaging/channel-annotation';
+
+const instances: ChannelInstanceRef[] = [
+  { id: 'inst_feishu', platform: 'feishu_lark', displayName: '飞书' },
+  { id: 'inst_wechat', platform: 'wechat_personal', displayName: '我的微信' },
+];
+const bindings: ChannelBindingRef[] = [
+  { cid: 'c1', instanceId: 'inst_feishu' },
+  { cid: 'c2', instanceId: 'inst_wechat' },
+];
+
+describe('messaging/channel-annotation — annotateChannelConversations', () => {
+  it('binding join 补标存量会话并注入实时显示名', () => {
+    const [feishu, wechat] = annotateChannelConversations(
+      [{ conversation_id: 'c1' }, { conversation_id: 'c2' }],
+      bindings,
+      instances,
+    );
+    expect(feishu).toMatchObject({ conversation_id: 'c1', channel_platform: 'feishu_lark', channel_name: '飞书' });
+    expect(wechat).toMatchObject({ conversation_id: 'c2', channel_platform: 'wechat_personal', channel_name: '我的微信' });
+  });
+
+  it('持久化 channel_platform 优先于 binding；channel_name 仍取实时名', () => {
+    const [conv] = annotateChannelConversations(
+      [{ conversation_id: 'cx', channel_platform: 'feishu_lark' }],
+      [],
+      instances,
+    );
+    expect(conv).toMatchObject({ channel_platform: 'feishu_lark', channel_name: '飞书' });
+  });
+
+  it('非渠道会话原样透传（引用不变、不加字段）', () => {
+    const plain = { conversation_id: 'plain', title: 'x' };
+    const [out] = annotateChannelConversations([plain], bindings, instances);
+    expect(out).toBe(plain);
+    expect(out.channel_platform).toBeUndefined();
+  });
+
+  it('实例被删后兜底到内置渠道名映射', () => {
+    const [conv] = annotateChannelConversations(
+      [{ conversation_id: 'c1' }],
+      [{ cid: 'c1', instanceId: 'inst_gone' }],
+      [],
+    );
+    // binding 指向不存在的实例：平台无从解析 → 不注记
+    expect(conv.channel_platform).toBeUndefined();
+    const [persisted] = annotateChannelConversations(
+      [{ conversation_id: 'c1', channel_platform: 'wechat_personal' }],
+      [],
+      [],
+    );
+    expect(persisted.channel_name).toBe(CHANNEL_DISPLAY_NAMES.wechat_personal);
+  });
+
+  it('未知平台值不透传（防脏数据）', () => {
+    const [conv] = annotateChannelConversations(
+      [{ conversation_id: 'c1', channel_platform: 'sms_magic' }],
+      [{ cid: 'c1', instanceId: 'inst_feishu' }],
+      instances,
+    );
+    // 未知持久化值被忽略，但 binding join 仍给出合法平台
+    expect(conv).toMatchObject({ channel_platform: 'feishu_lark' });
+  });
+
+  it('同会话多条 binding 时以最后一条为准（模拟换绑）', () => {
+    const [conv] = annotateChannelConversations(
+      [{ conversation_id: 'c1' }],
+      [
+        { cid: 'c1', instanceId: 'inst_feishu' },
+        { cid: 'c1', instanceId: 'inst_wechat' },
+      ],
+      instances,
+    );
+    expect(conv.channel_platform).toBe('wechat_personal');
+  });
+});


### PR DESCRIPTION
## 背景

渠道消息（飞书/微信等）建立的会话此前散落在「最近任务」列表里，与普通会话混排，无法统一管理。本 PR 让渠道会话在侧栏按渠道分组：飞书的聊天收进「飞书」条目下，点击展开/收起，没有会话的渠道不占位。

> **依赖说明**：本分支基于 #64（fix/feishu-desktop-three-fixes）之上，包含其 3 个提交；「新消息自动展开收起的渠道组」依赖 #64 的 conversations:updated 广播机制。建议先合 #64 再合本 PR（合并后本 PR 差异将只剩本功能）。

## 功能说明

- **分组展示**：「最近任务」tab 新增渠道分组区（置顶区之后）：每渠道一个可折叠组头（渠道图标 + 名称 + 会话数徽章 + 渐变线，复用分区头样式），组内为普通会话行；组间按组内最新活跃排序。
- **边界规则**：用户手动置顶的渠道会话留在置顶区不进组；没有会话的渠道不出现分组；「空间」tab 本次不动。
- **实时性**：外部渠道新消息到达时，收起的渠道组自动展开并置顶（依赖 #64 的推送）。
- **折叠记忆**：每组展开/收起状态持久化 localStorage，默认展开。

## 实现

- 数据层：`Conversation` 新增持久化字段 `channel_platform`（`bindings.resolveOrCreateBinding` 创建渠道会话时写入）。
- 兜底标注：`conversations.list`（全 5 种 mode）与 `conversations.get` 响应经 messaging binding + instance 内存 join 给存量会话补标（不回写磁盘），并注入派生字段 `channel_name`（实例 displayName 实时值 → 内置渠道名映射兜底）。join 为纯函数 `channel-annotation.ts`。
- 渲染层：`renderConversationList` recent 分支按渠道拆分渲染；组头样式与「最近任务」分区头同构。

## 测试

- 新增 `messaging-channel-annotation.test.ts` 6 用例（补标/优先级/非渠道透传/实例缺失兜底/未知平台防透传/换绑语义）；
- 新增 `chats-channel-platform.test.ts` 3 用例（字段创建/读回/列表往返、普通会话不标记）；
- 回归：messaging 181 + chats 75 全过；typecheck 干净；
- 真机验证：存量飞书会话经 join 进入「飞书」组、组头渲染/折叠/持久化/新消息自动展开均实测通过。

## 已知边界（本轮不做）

- 已被换绑的历史游离会话不主动归组（binding 已指向新会话）；
- 未读数徽标、空渠道占位、空间 tab 渠道分组留作后续增强。