### PR TITLE
feat(kb): material_search hybrid retrieval tool for grounded Q&A (COGSEED-39 ① Phase 2)

### DIFF
--- a/src/core-agent/src/index.ts
+++ b/src/core-agent/src/index.ts
@@ -85,6 +85,7 @@ export type { MemorySearchManager, MemorySearchResult } from "./memory/index.js"
 export { createOpenAIEmbeddingProvider, createGeminiEmbeddingProvider } from "./memory/index.js";
 export type { EmbeddingProvider } from "./memory/index.js";
 export { createMemorySearchTool, createMemoryReadTool } from "./memory/index.js";
+export { bm25Score } from "./memory/index.js";
 
 // Auth (OAuth & credential management)
 export type { AuthCredential, ApiKeyCredential, OAuthCredential, AuthStore } from "./auth/index.js";

--- a/src/main/model/core-agent/kb-tools.ts
+++ b/src/main/model/core-agent/kb-tools.ts
@@ -24,6 +24,7 @@ import * as kb from '../../features/kb_vector';
 import * as kbEmbed from '../../features/kb_embed';
 import * as spaceLibrary from '../../features/project_library_indexer';
 import { logErrorRef, maskId } from '../../util/log-redact';
+import { searchMaterials, type MaterialSearchOptions } from './material-search';
 
 const log = createLogger('kb-tools');
 
@@ -463,5 +464,97 @@ function createKbReadTool(opts: KbToolsOpts): AgentTool {
 
 /** Build the KB tools for one runner. */
 export function createKbTools(opts: KbToolsOpts): AgentTool[] {
-  return [createKbListTool(opts), createKbSearchTool(opts), createKbReadTool(opts)];
+  return [
+    createKbListTool(opts),
+    createKbSearchTool(opts),
+    createKbReadTool(opts),
+    createMaterialSearchTool(opts),
+  ];
+}
+
+/**
+ * `material_search` — hybrid (vector + BM25 keyword) retrieval over the
+ * Library, fusing both signals with RRF. Same read-only posture as
+ * kb_search, but returns a unified hit shape (scope/path/chunkIdx + snippet)
+ * that doubles as the citation anchor for grounded answering
+ * (COGSEED-39 ① Phase 2).
+ */
+function createMaterialSearchTool(opts: KbToolsOpts): AgentTool {
+  const hasSpace = !!opts.spaceId;
+  return {
+    name: 'material_search',
+    executionMode: 'parallel',
+    description:
+      'Hybrid search over the user Library (semantic vector + BM25 keyword, fused)'
+      + (hasSpace ? ' (current space + global by default)' : '')
+      + '. Use for grounded Q&A about imported materials: returns the top-k most\n'
+      + 'relevant chunks with a citation anchor (scope + path + chunk index) and a\n'
+      + 'short snippet. Preferred over `kb_search` when the question mixes exact\n'
+      + 'terms/ids (which keyword matching catches) with meaning (which vectors\n'
+      + 'catch). After picking hits, read full chunks with `kb_read` using the\n'
+      + 'returned scope + path.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Free-text query. Natural language works; exact terms/ids help the keyword side.',
+        },
+        k: {
+          type: 'number',
+          description: 'Top-k result count. Default 8, max 30.',
+        },
+        dir: {
+          type: 'string',
+          description: 'Optional: limit search to files under this relative subdirectory.',
+        },
+        path: {
+          type: 'string',
+          description: 'Optional: limit search to one exact Library-relative file path.',
+        },
+        kind: {
+          type: 'string',
+          enum: [...KB_KIND_VALUES],
+          description: 'Optional: restrict to one file kind.',
+        },
+        scope: {
+          type: 'string',
+          enum: hasSpace ? ['all', 'space', 'global'] : ['global'],
+          description: hasSpace
+            ? 'Search scope. Default all = current space Library plus global Library.'
+            : 'Search scope. Only global is available outside a space.',
+        },
+      },
+      required: ['query'],
+    },
+    async execute(input) {
+      const query = String(input.query ?? '').trim();
+      if (!query) return { content: 'material_search: `query` is required', isError: true };
+      const searchOpts: MaterialSearchOptions = {
+        userId: opts.userId,
+        ...(opts.spaceId ? { spaceId: opts.spaceId } : {}),
+        query,
+        ...(input.k !== undefined ? { k: Number(input.k) } : {}),
+        ...(typeof input.dir === 'string' && input.dir.trim() ? { dir: input.dir.trim() } : {}),
+        ...(typeof input.path === 'string' && input.path.trim() ? { path: input.path.trim() } : {}),
+        ...(parseKbKind(input.kind) ? { kind: parseKbKind(input.kind)! } : {}),
+        ...(hasSpace && input.scope !== undefined ? { scope: input.scope as MaterialSearchOptions['scope'] } : {}),
+      };
+
+      const res = await searchMaterials(searchOpts);
+      const lines = [`Material search hits (${res.summary.join('; ')}):`];
+      if (!res.hits.length) {
+        lines.push('No relevant material found for this query.');
+        return { content: lines.join('\n') };
+      }
+      for (const h of res.hits) {
+        const anchor = `[${h.scope}] ${h.path}#chunk ${h.chunkIdx}`;
+        const scores = `score=${h.score.toFixed(3)}`
+          + (h.vectorScore !== undefined ? ` vec=${h.vectorScore.toFixed(3)}` : '')
+          + (h.keywordScore !== undefined ? ` kw=${h.keywordScore.toFixed(3)}` : '');
+        lines.push(`- ${anchor} ${scores}${h.title ? ` · ${h.title}` : ''}\n  ${h.snippet}`);
+      }
+      return { content: lines.join('\n') };
+    },
+  };
 }

--- a/src/main/model/core-agent/material-search.ts
+++ b/src/main/model/core-agent/material-search.ts
@@ -1,0 +1,297 @@
+/**
+ * Material-boundary hybrid search (COGSEED-39 ① Phase 2).
+ *
+ * Retrieval entry for the "reliable Q&A within a material set" workstream:
+ * fuses Library vector search (semantic, via the existing sqlite-vec KB)
+ * with a keyword side (BM25 over chunk text, reusing the core-agent scorer)
+ * using reciprocal rank fusion (RRF).
+ *
+ * Why hybrid: vector search alone misses exact terms / ids / filenames that
+ * the embedding blurs (e.g. "COGSEED-39", "IPC 0012"), and keyword-only
+ * misses synonyms. The fusion keeps both signals and returns a unified hit
+ * shape — `{source, scope, path, chunkIdx, snippet, score}` — that later
+ * phases (material-boundary model, answer verification) consume as the
+ * citation anchor.
+ *
+ * Design notes / reused utilities:
+ *   - Vector side mirrors `kb-tools.ts::kb_search` (embed → kb.search on
+ *     global + space Library), so behavior stays consistent with the
+ *     existing tool.
+ *   - Keyword side reuses `bm25Score` from the core-agent memory hybrid
+ *     (loaded dynamically through `#core-agent`, per the dynamic-import
+ *     rule); no new scoring implementation.
+ *   - No writes: read-only over the KB vector store and the space library.
+ *   - `#core-agent` is imported dynamically only (static import is
+ *     forbidden in main).
+ */
+
+import { createLogger } from '../../logger';
+import * as kb from '../../features/kb_vector';
+import * as kbEmbed from '../../features/kb_embed';
+import * as spaceLibrary from '../../features/project_library_indexer';
+import { logErrorRef, maskId } from '../../util/log-redact';
+
+const log = createLogger('material-search');
+
+/** RRF rank-offset constant, matching the core-agent memory hybrid. */
+const RRF_K = 60;
+const DEFAULT_VECTOR_WEIGHT = 0.7;
+const DEFAULT_KEYWORD_WEIGHT = 0.3;
+const DEFAULT_K = 8;
+const MAX_K = 30;
+const SNIPPET_CHARS = 600;
+/** Cap on keyword candidates scanned per query (prevents unbounded BM25). */
+const KEYWORD_FILE_CAP = 200;
+const KEYWORD_CHUNK_CAP = 800;
+
+export type MaterialScope = 'global' | 'space' | 'all';
+
+export interface MaterialHit {
+  source: 'library';
+  scope: 'global' | 'space';
+  path: string;
+  chunkIdx: number;
+  title: string | null;
+  /** Truncated chunk text for citation grounding. */
+  snippet: string;
+  /** Fused relevance (RRF), 0..1-ish. */
+  score: number;
+  vectorScore?: number;
+  keywordScore?: number;
+}
+
+export interface MaterialSearchOptions {
+  userId: string;
+  spaceId?: string;
+  query: string;
+  k?: number;
+  scope?: MaterialScope;
+  dir?: string;
+  path?: string;
+  kind?: kb.KbKind;
+  vectorWeight?: number;
+  keywordWeight?: number;
+}
+
+export interface MaterialSearchResult {
+  hits: MaterialHit[];
+  /** Human-readable per-scope summary (mirrors kb_search's counters). */
+  summary: string[];
+}
+
+interface RankedHit {
+  hit: MaterialHit;
+  vectorRank?: number;
+  keywordRank?: number;
+  vectorScore?: number;
+  keywordScore?: number;
+}
+
+function parseScope(raw: string | undefined, hasSpace: boolean): MaterialScope {
+  if (raw === 'global') return 'global';
+  if (raw === 'space' && hasSpace) return 'space';
+  if (raw === 'all' && hasSpace) return 'all';
+  return hasSpace ? 'all' : 'global';
+}
+
+function hitKey(scope: string, path: string, chunkIdx: number): string {
+  return `${scope}\u0000${path}\u0000${chunkIdx}`;
+}
+
+function snippetOf(text: string): string {
+  const s = (text || '').trim();
+  return s.length <= SNIPPET_CHARS ? s : `${s.slice(0, SNIPPET_CHARS)}…`;
+}
+
+/** Vector side: embed the query once, search global + space Library. */
+async function vectorCandidates(
+  opts: Required<Pick<MaterialSearchOptions, 'userId'>> & MaterialSearchOptions,
+  scope: MaterialScope,
+  vec: number[],
+): Promise<Array<{ key: string; rank: number; score: number; hit: MaterialHit }>> {
+  const kbOpts: kb.KbSearchOpts = { k: opts.k };
+  if (opts.dir) kbOpts.dir = opts.dir;
+  if (opts.path) kbOpts.path = opts.path;
+  if (opts.kind) kbOpts.kind = opts.kind;
+
+  const collected: Array<{ scope: 'global' | 'space'; row: kb.KbSearchHit }> = [];
+  if (scope === 'global' || scope === 'all') {
+    collected.push(...kb.search(opts.userId, vec, kbOpts).map((h) => ({ scope: 'global' as const, row: h })));
+  }
+  if ((scope === 'space' || scope === 'all') && opts.spaceId) {
+    collected.push(...(await spaceLibrary.search(opts.userId, opts.spaceId, vec, kbOpts))
+      .map((h) => ({ scope: 'space' as const, row: h })));
+  }
+  // Dedupe (scope,path,chunkIdx) keeping the max score, then rank by score.
+  const byKey = new Map<string, { scope: 'global' | 'space'; row: kb.KbSearchHit }>();
+  for (const item of collected) {
+    const key = hitKey(item.scope, item.row.rel_path, item.row.chunk_idx);
+    const prev = byKey.get(key);
+    if (!prev || item.row.score > prev.row.score) byKey.set(key, item);
+  }
+  const entries = [...byKey.values()].sort((a, b) => b.row.score - a.row.score);
+  return entries.map((item, i) => ({
+    key: hitKey(item.scope, item.row.rel_path, item.row.chunk_idx),
+    rank: i,
+    score: item.row.score,
+    hit: {
+      source: 'library' as const,
+      scope: item.scope,
+      path: item.row.rel_path,
+      chunkIdx: item.row.chunk_idx,
+      title: item.row.title,
+      snippet: snippetOf(item.row.content),
+      score: 0, // filled during fusion
+    },
+  }));
+}
+
+/** Keyword side: BM25 over chunk text of ready files (reuses core-agent scorer). */
+async function keywordCandidates(
+  opts: Required<Pick<MaterialSearchOptions, 'userId'>> & MaterialSearchOptions,
+  scope: MaterialScope,
+  query: string,
+  bm25Score: (q: string, doc: string) => number,
+): Promise<Array<{ key: string; rank: number; score: number; hit: MaterialHit }>> {
+  const files: Array<{ scope: 'global' | 'space'; row: kb.KbFileRow }> = [];
+  if (scope === 'global' || scope === 'all') {
+    files.push(...kb.listFiles(opts.userId)
+      .filter((row) => row.status === 'ready')
+      .map((row) => ({ scope: 'global' as const, row })));
+  }
+  if ((scope === 'space' || scope === 'all') && opts.spaceId) {
+    files.push(...spaceLibrary.listFiles(opts.userId, opts.spaceId)
+      .filter((row) => row.status === 'ready')
+      .map((row) => ({ scope: 'space' as const, row })));
+  }
+
+  // Apply the same dir/path/kind filters as the vector side.
+  const rawDir = opts.dir?.trim() ?? '';
+  const dir = rawDir ? (rawDir.endsWith('/') ? rawDir : `${rawDir}/`) : '';
+  const filtered = files.filter(({ row }) =>
+    (!dir || row.rel_path === rawDir || row.rel_path.startsWith(dir))
+    && (!opts.path || row.rel_path === opts.path)
+    && (!opts.kind || row.kind === opts.kind),
+  );
+
+  const candidates: Array<{ scope: 'global' | 'space'; path: string; chunkIdx: number; title: string | null; content: string; score: number }> = [];
+  let scannedFiles = 0;
+  for (const { scope: fileScope, row } of filtered) {
+    if (scannedFiles >= KEYWORD_FILE_CAP) break;
+    scannedFiles += 1;
+    const chunks = fileScope === 'global'
+      ? kb.readFileChunks(opts.userId, row.rel_path)
+      : spaceLibrary.readFileChunks(opts.userId, opts.spaceId!, row.rel_path);
+    for (const chunk of chunks) {
+      if (candidates.length >= KEYWORD_CHUNK_CAP) break;
+      const s = bm25Score(query, chunk.content);
+      if (s <= 0) continue;
+      candidates.push({
+        scope: fileScope,
+        path: row.rel_path,
+        chunkIdx: chunk.chunk_idx,
+        title: chunk.title,
+        content: chunk.content,
+        score: s,
+      });
+    }
+  }
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates.map((c, i) => ({
+    key: hitKey(c.scope, c.path, c.chunkIdx),
+    rank: i,
+    score: c.score,
+    hit: {
+      source: 'library' as const,
+      scope: c.scope,
+      path: c.path,
+      chunkIdx: c.chunkIdx,
+      title: c.title,
+      snippet: snippetOf(c.content),
+      score: 0,
+    },
+  }));
+}
+
+/**
+ * Hybrid material search over the Library (global + optional space).
+ * Returns fused, top-k hits ordered by RRF score, each with a citation
+ * anchor (`scope + path + chunkIdx`) for grounded answering.
+ */
+export async function searchMaterials(opts: MaterialSearchOptions): Promise<MaterialSearchResult> {
+  const query = (opts.query ?? '').trim();
+  if (!query) return { hits: [], summary: ['material_search: `query` is required'] };
+  const hasSpace = !!opts.spaceId;
+  const scope = parseScope(opts.scope, hasSpace);
+  const k = Math.min(MAX_K, Math.max(1, Math.floor(Number(opts.k ?? DEFAULT_K))));
+  const vectorWeight = Number(opts.vectorWeight ?? DEFAULT_VECTOR_WEIGHT);
+  const keywordWeight = Number(opts.keywordWeight ?? DEFAULT_KEYWORD_WEIGHT);
+
+  let vec: number[];
+  try {
+    vec = await kbEmbed.embedQuery(query);
+  } catch (err) {
+    const msg = (err as Error).message;
+    log.warn('material_search embed failed', {
+      user_id: maskId(opts.userId),
+      space_id: maskId(opts.spaceId),
+      query_chars: query.length,
+      error: logErrorRef(err),
+    });
+    return { hits: [], summary: [`material_search: embedding failed — ${msg}`] };
+  }
+
+  let vectorCands: Awaited<ReturnType<typeof vectorCandidates>> = [];
+  let keywordCands: Awaited<ReturnType<typeof keywordCandidates>> = [];
+  try {
+    vectorCands = await vectorCandidates(opts, scope, vec);
+    // core-agent is dynamic-import-only in main; load the scorer lazily.
+    const { bm25Score } = await import('#core-agent');
+    keywordCands = await keywordCandidates(opts, scope, query, bm25Score);
+  } catch (err) {
+    const msg = (err as Error).message;
+    log.warn('material_search query failed', {
+      user_id: maskId(opts.userId),
+      space_id: maskId(opts.spaceId),
+      error: logErrorRef(err),
+    });
+    return { hits: [], summary: [`material_search: search failed — ${msg}`] };
+  }
+
+  // ── RRF fusion ───────────────────────────────────────────────────────────
+  const fused = new Map<string, RankedHit>();
+  for (const c of vectorCands) {
+    fused.set(c.key, { hit: c.hit, vectorRank: c.rank + 1, vectorScore: c.score });
+  }
+  for (const c of keywordCands) {
+    const prev = fused.get(c.key);
+    if (prev) {
+      prev.keywordRank = c.rank + 1;
+      prev.keywordScore = c.score;
+    } else {
+      fused.set(c.key, { hit: c.hit, keywordRank: c.rank + 1, keywordScore: c.score });
+    }
+  }
+  const ranked = [...fused.values()].map((r) => {
+    let score = 0;
+    if (r.vectorRank) score += vectorWeight / (RRF_K + r.vectorRank);
+    if (r.keywordRank) score += keywordWeight / (RRF_K + r.keywordRank);
+    r.hit.score = score;
+    r.hit.vectorScore = r.vectorScore;
+    r.hit.keywordScore = r.keywordScore;
+    return r.hit;
+  }).sort((a, b) => b.score - a.score).slice(0, k);
+
+  const globalSummary = kb.statusSummary(opts.userId);
+  const spaceSummary = opts.spaceId ? spaceLibrary.statusSummary(opts.userId, opts.spaceId) : null;
+  const summary = [
+    `global total=${globalSummary.total} ready=${globalSummary.ready} processing=${globalSummary.processing} pending=${globalSummary.pending} failed=${globalSummary.failed}`,
+  ];
+  if (spaceSummary) {
+    summary.push(
+      `space total=${spaceSummary.total} ready=${spaceSummary.ready} processing=${spaceSummary.processing} pending=${spaceSummary.pending} failed=${spaceSummary.failed}`,
+    );
+  }
+
+  return { hits: ranked, summary };
+}

--- a/src/main/model/core-agent/tool-catalog.ts
+++ b/src/main/model/core-agent/tool-catalog.ts
@@ -125,6 +125,7 @@ export const TOOL_CATALOG: ToolCatalogEntry[] = [
   { name: 'kb_list',       group: 'kb', summary: 'List Library files and indexing status before choosing what to search or read.' },
   { name: 'kb_search',     group: 'kb', summary: 'Semantic search over the user\'s Library.' },
   { name: 'kb_read',       group: 'kb', summary: 'Read source-text chunks from a Library file that kb_search has hit.' },
+  { name: 'material_search', group: 'kb', summary: 'Hybrid (vector + BM25) search over the user Library; returns fused hits with citation anchors (scope/path/chunk).' },
   { name: 'research_rerank', group: 'kb', ownerAgent: DEEP_RESEARCH_AGENT_IDS, summary: 'Semantically rerank candidate research passages against a sub-question by local embedding similarity — the second stage after the deep-research compress skill\'s lexical filter, surfacing on-topic passages that share no keywords. Read-only, local, no Tool Execution Access. Owned by the deep-research + data-research agents (hidden from the commander).' },
 
   // Recall ability assets

--- a/test/main/model/core-agent/kb-tools.test.ts
+++ b/test/main/model/core-agent/kb-tools.test.ts
@@ -299,10 +299,17 @@ describe('kb-tools › kb_read', () => {
 });
 
 describe('kb-tools › shape', () => {
-  it('createKbTools returns exactly three tools (list + search + read)', async () => {
+  it('createKbTools returns list + search + read + material_search', async () => {
     const { createKbTools } = await import('../../../../src/main/model/core-agent/kb-tools');
     const tools = createKbTools({ userId: TEST_UID });
-    expect(tools.map((t) => t.name)).toEqual(['kb_list', 'kb_search', 'kb_read']);
+    expect(tools.map((t) => t.name)).toEqual(['kb_list', 'kb_search', 'kb_read', 'material_search']);
+  });
+
+  it('material_search has a query-required schema', async () => {
+    const { createKbTools } = await import('../../../../src/main/model/core-agent/kb-tools');
+    const [, , , materialSearch] = createKbTools({ userId: TEST_UID });
+    expect(materialSearch.name).toBe('material_search');
+    expect(materialSearch.inputSchema?.required).toContain('query');
   });
 
   it('tools have required JSON schema fields', async () => {

--- a/test/main/model/core-agent/material-search.test.ts
+++ b/test/main/model/core-agent/material-search.test.ts
@@ -1,0 +1,155 @@
+/**
+ * material-search (COGSEED-39 ① Phase 2) — hybrid vector + BM25 fusion.
+ *
+ * Inserts Library files with known fake embeddings (no real embedder), mocks
+ * the query embedder to a fixed vector, then asserts:
+ *   - fusion: keyword-only term matches still surface (keywordScore set)
+ *   - ranking: fused score beats vector-only for an exact-term query
+ *   - anchors: scope/path/chunkIdx are populated and correct
+ *   - guards: empty query, empty store, k limit
+ *
+ * Space-scoped retrieval follows the same code path as kb_search (production
+ * covered); this unit test keeps global scope to stay hermetic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+vi.mock('../../../../src/main/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Deterministic embedder: the query always embeds to vec(1,0,0), which is
+// closest to the "alpha" file's embedding (see fakeVec below).
+vi.mock('../../../../src/main/features/kb_embed', () => {
+  const q = new Array(512).fill(0);
+  q[0] = 1;
+  return {
+    embedQuery: async () => q,
+    embed: async () => [] as number[],
+  };
+});
+
+// 512-dim vector aligned with `seed` in the first 3 dims (sqlite-vec uses L2).
+function fakeVec(a: number, b = 0, c = 0): number[] {
+  const v = new Array(512).fill(0);
+  v[0] = a;
+  v[1] = b;
+  v[2] = c;
+  return v;
+}
+
+let tmpDir: string;
+let prevWs: string | undefined;
+const TEST_UID = 'matsearch';
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-mat-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+  const users = await import('../../../../src/main/features/users');
+  users.activateUser(TEST_UID);
+});
+
+afterEach(async () => {
+  try {
+    const kb = await import('../../../../src/main/features/kb_vector');
+    kb.closeAllKb();
+  } catch { /* ignore */ }
+  process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function insertFile(relPath: string, chunks: Array<{ title: string; content: string; embedding: number[] }>) {
+  const kb = await import('../../../../src/main/features/kb_vector');
+  await kb.upsertFile(TEST_UID, {
+    relPath,
+    kind: 'text',
+    bytes: 100,
+    mtime: 1,
+    sha1: relPath,
+    chunks,
+  });
+}
+
+describe('material_search › hybrid fusion', () => {
+  it('surfaces an exact-term match (keyword side) that pure vector ranking would miss', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/material-search');
+    // alpha: vector-closest to the query embedding, but lacks the exact term.
+    await insertFile('notes/alpha.md', [
+      { title: 'a1', content: 'The alpha protocol handles authentication tokens for the service.', embedding: fakeVec(1) },
+    ]);
+    // beta: vector-far, but the only file containing the exact term ZQX-4421.
+    await insertFile('notes/beta.md', [
+      { title: 'b1', content: 'Beta covers the ZQX-4421 revision of the parser grammar end to end.', embedding: fakeVec(9) },
+    ]);
+
+    const res = await mod.searchMaterials({ userId: TEST_UID, query: 'ZQX-4421', k: 10 });
+
+    const alpha = res.hits.find((h) => h.path === 'notes/alpha.md');
+    const beta = res.hits.find((h) => h.path === 'notes/beta.md');
+    expect(alpha).toBeTruthy();
+    expect(alpha!.vectorScore).toBeDefined();
+    expect(beta).toBeTruthy();
+    expect(beta!.keywordScore).toBeDefined();
+    // RRF: beta (keyword rank 1 + vector rank 2) outranks alpha (vector rank 1 only).
+    expect(beta!.score).toBeGreaterThan(alpha!.score);
+  });
+
+  it('populates citation anchors (scope/path/chunkIdx) on every hit', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/material-search');
+    await insertFile('notes/alpha.md', [
+      { title: 'a1', content: 'alpha one', embedding: fakeVec(1) },
+      { title: 'a2', content: 'alpha two', embedding: fakeVec(0, 1) },
+    ]);
+
+    const res = await mod.searchMaterials({ userId: TEST_UID, query: 'alpha', k: 5 });
+
+    expect(res.hits.length).toBeGreaterThan(0);
+    for (const h of res.hits) {
+      expect(h.source).toBe('library');
+      expect(h.scope).toBe('global');
+      expect(h.path).toMatch(/^notes\/.+\.md$/);
+      expect(typeof h.chunkIdx).toBe('number');
+      expect(h.snippet.length).toBeGreaterThan(0);
+    }
+    expect(res.summary.join(' ')).toContain('global total=1 ready=1');
+  });
+
+  it('honours the k limit', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/material-search');
+    await insertFile('notes/alpha.md', [
+      { title: 'a1', content: 'alpha one protocol', embedding: fakeVec(1) },
+      { title: 'a2', content: 'alpha two protocol', embedding: fakeVec(0, 1) },
+    ]);
+
+    const res = await mod.searchMaterials({ userId: TEST_UID, query: 'protocol', k: 1 });
+    expect(res.hits.length).toBe(1);
+  });
+
+  it('returns no hits for an empty query', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/material-search');
+    await insertFile('notes/alpha.md', [
+      { title: 'a1', content: 'alpha one', embedding: fakeVec(1) },
+    ]);
+
+    const res = await mod.searchMaterials({ userId: TEST_UID, query: '   ' });
+    expect(res.hits).toEqual([]);
+    expect(res.summary.join(' ')).toContain('required');
+  });
+
+  it('returns empty hits on an empty store', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/material-search');
+    const res = await mod.searchMaterials({ userId: TEST_UID, query: 'anything' });
+    expect(res.hits).toEqual([]);
+    expect(res.summary.join(' ')).toContain('total=0');
+  });
+});

--- a/test/main/model/core-agent/parallel-safety.test.ts
+++ b/test/main/model/core-agent/parallel-safety.test.ts
@@ -35,7 +35,7 @@ const CID = 'c0a1b2c3d4e5';
 // (concurrent embed on the shared ONNX session is safe — see header).
 const PARALLEL_ALLOWLIST = [
   'chat_read', 'chat_search',
-  'grep_files', 'kb_list', 'kb_read', 'kb_search', 'list_files', 'read_file', 'search_files',
+  'grep_files', 'kb_list', 'kb_read', 'kb_search', 'list_files', 'material_search', 'read_file', 'search_files',
 ].sort();
 
 let tmpDir: string;


### PR DESCRIPTION
## Why
COGSEED-39 核心要点①「可靠问答」Phase 2：资料集合边界内的混合检索入口。Phase 1（prompt 答案约束，#85）已合入；本 PR 给模型提供「向量+关键词融合、带引用锚点」的检索工具，让可靠问答有真正的检索底座。

## What
- 新增 `src/main/model/core-agent/material-search.ts`：`searchMaterials()`——向量侧复用 kb.search（global+space），关键词侧复用 core-agent `bm25Score`（动态 import #core-agent），RRF 融合（0.7/0.3，K=60），统一命中结构 `{source, scope, path, chunkIdx, snippet, score, vectorScore?, keywordScore?}`
- `kb-tools.ts`：新增只读工具 `material_search`（与 kb_list/kb_search/kb_read 同组注入每个会话；executionMode=parallel，与 kb_search 同理由——共享 ONNX 会话并发 embed 安全）
- `core-agent/src/index.ts`：导出 bm25Score（复用现有工具，不新写打分器）
- `tool-catalog.ts`：注册 material_search（anti-drift 契约）
- 测试：material-search.test.ts 5 用例（关键词捞回纯向量会漏的精确词命中/锚点/k 限制/空查询/空库）；同步 kb-tools shape 与 parallel-safety allowlist

## How
- `npm run typecheck` ✅ / `npm run lint` ✅
- 新增与受影响测试 44/44 ✅；全量 9366 passed
- 全量仅剩 2 个基线失败：cogseed-residual-identifiers（本地 AGENTS.md 被内部手册替换所致，CI 用公开版不受影响）、session_import（干净基线同样失败，环境性）

## 关联
- Issue: COGSEED-39 核心要点①（资料边界可靠问答）Phase 2

## Checklist
- [x] Conventional Commits / noreply 邮箱（email-gate 可过）
- [x] 未新增 npm 依赖（无 SBOM 变更）
- [x] 工具契约同步（tool-catalog / parallel-safety / shape 测试）
- [x] 只读工具，无 localExec 权限