### PR TITLE
feat(kb): material boundary model, material_list tool, cross-source kb_read (COGSEED-39 ① Phase 3)

### DIFF
--- a/src/main/model/core-agent/kb-tools.ts
+++ b/src/main/model/core-agent/kb-tools.ts
@@ -25,12 +25,16 @@ import * as kbEmbed from '../../features/kb_embed';
 import * as spaceLibrary from '../../features/project_library_indexer';
 import { logErrorRef, maskId } from '../../util/log-redact';
 import { searchMaterials, type MaterialSearchOptions } from './material-search';
+import { resolveMaterialSet } from './material-boundary';
+import * as chatAttachments from '../../features/chat_attachments';
+import * as fileIndexer from '../../features/file_indexer';
 
 const log = createLogger('kb-tools');
 
 export interface KbToolsOpts {
   userId: string;
   spaceId?: string;
+  cid?: string;
 }
 
 const PREVIEW_CHARS = 400;
@@ -377,6 +381,15 @@ function createKbReadTool(opts: KbToolsOpts): AgentTool {
       type: 'object',
       properties: {
         path: { type: 'string', description: 'Library-relative path (as returned by kb_search hits).' },
+        source: {
+          type: 'string',
+          enum: ['library', 'attachment'],
+          description: 'Source to read from. Default library. Use "attachment" with `name` to read a conversation attachment.',
+        },
+        name: {
+          type: 'string',
+          description: 'Attachment filename (only when source="attachment"). Use names from `material_list`.',
+        },
         scope: {
           type: 'string',
           enum: hasSpace ? ['all', 'space', 'global'] : ['global'],
@@ -393,6 +406,30 @@ function createKbReadTool(opts: KbToolsOpts): AgentTool {
       required: ['path'],
     },
     async execute(input) {
+      const src = input.source === 'attachment' ? 'attachment' : 'library';
+      if (src === 'attachment') {
+        const name = String(input.name ?? '').trim();
+        if (!name) return { content: 'kb_read: `name` is required when source="attachment"', isError: true };
+        if (!opts.cid) return { content: 'kb_read: no conversation context (cid) to read attachments from', isError: true };
+        const resolved = chatAttachments.resolveAttachmentAbsPath(opts.userId, opts.cid, name);
+        if (!resolved.ok) {
+          const why = 'error' in resolved ? resolved.error : 'unknown';
+          return { content: `kb_read: attachment not accessible — ${why}`, isError: true };
+        }
+        const { absPath, kind } = resolved;
+        let text: string;
+        try {
+          ({ text } = await fileIndexer.getExtractedText(opts.userId, absPath));
+        } catch (err) {
+          return {
+            content: `kb_read: attachment extraction failed — ${(err as Error).message}`,
+            isError: true,
+          };
+        }
+        const meta = await fileIndexer.statFile(opts.userId, absPath);
+        const header = `<attachment name="${name}" kind="${kind}" bytes="${meta.bytes}">`;
+        return { content: `${header}\n${text}\n</attachment>` };
+      }
       const relPath = String(input.path ?? '').trim();
       if (!relPath) return { content: 'kb_read: `path` is required', isError: true };
       const scope = parseReadScope(input.scope, hasSpace);
@@ -469,7 +506,92 @@ export function createKbTools(opts: KbToolsOpts): AgentTool[] {
     createKbSearchTool(opts),
     createKbReadTool(opts),
     createMaterialSearchTool(opts),
+    createMaterialListTool(opts),
   ];
+}
+
+/**
+ * `material_list` — inventory the full material boundary for the current
+ * conversation: Library files (global + space) plus conversation
+ * attachments and space artifacts, each marked in-scope or not
+ * (COGSEED-39 ① Phase 3). Read-only.
+ */
+function createMaterialListTool(opts: KbToolsOpts): AgentTool {
+  const hasSpace = !!opts.spaceId;
+  return {
+    name: 'material_list',
+    executionMode: 'parallel',
+    description:
+      'List everything in the current material boundary for grounded Q&A: Library files'
+      + (hasSpace ? ' (global + current space)' : '')
+      + ', this conversation\'s attachments'
+      + (hasSpace ? ', and space artifacts' : '')
+      + '. Each entry is marked in-scope or out-of-scope. Use before asking '
+      + '"what materials can you answer from?" or when a question\'s scope is unclear.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Maximum entries per section. Default 50, max 200.',
+        },
+      },
+    },
+    async execute(input) {
+      const limit = Math.min(200, Math.max(1, Math.floor(Number(input.limit ?? 50))));
+      const boundary = await resolveMaterialSet({
+        userId: opts.userId,
+        ...(opts.spaceId ? { spaceId: opts.spaceId } : {}),
+        ...(opts.cid ? { cid: opts.cid } : {}),
+      });
+
+      const lines: string[] = [];
+      lines.push(`Material boundary (history=${boundary.history}, library global=${boundary.library.global} space=${boundary.library.space}):`);
+
+      const library: Array<{ scope: string; path: string; status: string; chunks: number }> = [];
+      if (boundary.library.global) {
+        for (const row of kb.listFiles(opts.userId)) {
+          library.push({ scope: 'global', path: row.rel_path, status: row.status, chunks: row.chunks });
+        }
+      }
+      if (boundary.library.space && opts.spaceId) {
+        for (const row of spaceLibrary.listFiles(opts.userId, opts.spaceId)) {
+          library.push({ scope: 'space', path: row.rel_path, status: row.status, chunks: row.chunks });
+        }
+      }
+      if (library.length) {
+        lines.push('Library:');
+        for (const f of library.slice(0, limit)) {
+          lines.push(`- [library/${f.scope}] ${f.path} (status=${f.status}, chunks=${f.chunks})`);
+        }
+        if (library.length > limit) lines.push(`... ${library.length - limit} more library file(s)`);
+      } else {
+        lines.push('Library: (empty)');
+      }
+
+      if (boundary.attachments.length) {
+        lines.push('Attachments:');
+        for (const a of boundary.attachments.slice(0, limit)) {
+          lines.push(`- [attachment] ${a.name} (${a.kind}, ${formatBytes(a.bytes)}, ${a.inScope ? 'in-scope' : 'OUT-OF-SCOPE'})`);
+        }
+        if (boundary.attachments.length > limit) lines.push(`... ${boundary.attachments.length - limit} more attachment(s)`);
+      } else {
+        lines.push('Attachments: (none)');
+      }
+
+      if (boundary.artifacts.length) {
+        lines.push('Space artifacts:');
+        for (const ar of boundary.artifacts.slice(0, limit)) {
+          lines.push(`- [artifact] ${ar.name} (${ar.type}${ar.ext}, ${ar.inScope ? 'in-scope' : 'OUT-OF-SCOPE'})`);
+        }
+        if (boundary.artifacts.length > limit) lines.push(`... ${boundary.artifacts.length - limit} more artifact(s)`);
+      } else {
+        lines.push('Space artifacts: (none)');
+      }
+
+      return { content: lines.join('\n') };
+    },
+  };
 }
 
 /**

--- a/src/main/model/core-agent/material-boundary.ts
+++ b/src/main/model/core-agent/material-boundary.ts
@@ -1,0 +1,125 @@
+/**
+ * Material-set boundary model (COGSEED-39 ① Phase 3).
+ *
+ * Defines what counts as "material" for a conversation and resolves the
+ * current material set from live app state:
+ *
+ *   MaterialSet = Library (global + optional space slice)
+ *               + conversation attachments (when a cid is known)
+ *               + space artifacts (when a spaceId is known)
+ *               + history scope (project vs none)
+ *
+ * Every non-Library entry carries an `inScope` flag computed against the
+ * path sandbox: an entry whose resolved absolute path escapes its allowed
+ * root is reported but marked out-of-scope, so downstream retrieval/reads
+ * can reject it — "out of scope == not in the material set".
+ *
+ * The boundary is resolved on demand (per call), so attachment uploads /
+ * deletions and artifact writes are reflected immediately without any
+ * index to maintain. Read-only; never writes user data.
+ */
+
+import * as path from 'node:path';
+import { createLogger } from '../../logger';
+import * as chatAttachments from '../../features/chat_attachments';
+import * as spaceArtifacts from '../../features/spaces_artifacts';
+import { spaceContentDir } from '../../paths';
+import { isPathAllowed } from '../../util/path-sandbox';
+import { maskId } from '../../util/log-redact';
+
+const log = createLogger('material-boundary');
+
+export type MaterialHistoryScope = 'project' | 'none';
+
+export interface MaterialLibrarySlice {
+  global: boolean;
+  space: boolean;
+}
+
+export interface MaterialAttachment {
+  name: string;
+  kind: string;
+  bytes: number;
+  mtime: number;
+  /** True when the resolved path stays inside the conversation's attachment root. */
+  inScope: boolean;
+}
+
+export interface MaterialArtifact {
+  name: string;
+  type: string;
+  ext: string;
+  sourceSessionId: string;
+  /** True when the artifact path stays inside the space content root. */
+  inScope: boolean;
+}
+
+export interface MaterialSet {
+  library: MaterialLibrarySlice;
+  attachments: MaterialAttachment[];
+  artifacts: MaterialArtifact[];
+  history: MaterialHistoryScope;
+}
+
+export interface MaterialSetOptions {
+  userId: string;
+  spaceId?: string;
+  /** Conversation id — resolves this conversation's attachments into scope. */
+  cid?: string;
+  projectId?: string;
+}
+
+/**
+ * Resolve the current material set for a conversation. Attachment upload /
+ * delete and artifact writes take effect on the next call (no persisted
+ * boundary state).
+ */
+export async function resolveMaterialSet(opts: MaterialSetOptions): Promise<MaterialSet> {
+  const { userId, spaceId, cid, projectId } = opts;
+
+  const attachments: MaterialAttachment[] = [];
+  if (cid) {
+    const cidRoot = path.resolve(chatAttachments.attachmentDirForCid(userId, cid));
+    for (const a of chatAttachments.listAttachments(userId, cid)) {
+      const abs = path.resolve(cidRoot, a.name);
+      attachments.push({
+        name: a.name,
+        kind: a.kind,
+        bytes: a.bytes,
+        mtime: a.mtime,
+        inScope: isPathAllowed(abs, [cidRoot]),
+      });
+    }
+  }
+
+  const artifacts: MaterialArtifact[] = [];
+  if (spaceId) {
+    const spaceRoot = path.resolve(spaceContentDir(userId, spaceId));
+    let entries: spaceArtifacts.SpaceArtifactEntry[] = [];
+    try {
+      entries = await spaceArtifacts.listSpaceArtifacts(userId, spaceId);
+    } catch (err) {
+      log.warn('material_boundary: listSpaceArtifacts failed', {
+        user_id: maskId(userId),
+        space_id: maskId(spaceId),
+        error: (err as Error).message,
+      });
+    }
+    for (const e of entries) {
+      artifacts.push({
+        name: e.name,
+        type: e.type,
+        ext: e.ext,
+        sourceSessionId: e.sourceSessionId,
+        inScope: e.path ? isPathAllowed(path.resolve(e.path), [spaceRoot]) : false,
+      });
+    }
+  }
+
+  return {
+    library: { global: true, space: !!spaceId },
+    attachments,
+    artifacts,
+    history: projectId ? 'project' : 'none',
+  };
+}

--- a/src/main/model/core-agent/runner.ts
+++ b/src/main/model/core-agent/runner.ts
@@ -733,6 +733,7 @@ export async function buildRunner(params: BuildRunnerParams): Promise<{
   const kbTools = uid && !params.disableTools ? createKbTools({
     userId: uid,
     ...(params.spaceId ? { spaceId: params.spaceId } : {}),
+    ...(params.cid ? { cid: params.cid } : {}),
   }) : [];
 
   // Recall ability-asset search tool (search_ability_assets). Read-only, no

--- a/src/main/model/core-agent/tool-catalog.ts
+++ b/src/main/model/core-agent/tool-catalog.ts
@@ -126,6 +126,7 @@ export const TOOL_CATALOG: ToolCatalogEntry[] = [
   { name: 'kb_search',     group: 'kb', summary: 'Semantic search over the user\'s Library.' },
   { name: 'kb_read',       group: 'kb', summary: 'Read source-text chunks from a Library file that kb_search has hit.' },
   { name: 'material_search', group: 'kb', summary: 'Hybrid (vector + BM25) search over the user Library; returns fused hits with citation anchors (scope/path/chunk).' },
+  { name: 'material_list', group: 'kb', summary: 'List the full material boundary for the conversation (Library + attachments + space artifacts), each marked in-scope or out-of-scope.' },
   { name: 'research_rerank', group: 'kb', ownerAgent: DEEP_RESEARCH_AGENT_IDS, summary: 'Semantically rerank candidate research passages against a sub-question by local embedding similarity — the second stage after the deep-research compress skill\'s lexical filter, surfacing on-topic passages that share no keywords. Read-only, local, no Tool Execution Access. Owned by the deep-research + data-research agents (hidden from the commander).' },
 
   // Recall ability assets

--- a/test/main/model/core-agent/kb-tools.test.ts
+++ b/test/main/model/core-agent/kb-tools.test.ts
@@ -299,10 +299,10 @@ describe('kb-tools › kb_read', () => {
 });
 
 describe('kb-tools › shape', () => {
-  it('createKbTools returns list + search + read + material_search', async () => {
+  it('createKbTools returns list + search + read + material_search + material_list', async () => {
     const { createKbTools } = await import('../../../../src/main/model/core-agent/kb-tools');
     const tools = createKbTools({ userId: TEST_UID });
-    expect(tools.map((t) => t.name)).toEqual(['kb_list', 'kb_search', 'kb_read', 'material_search']);
+    expect(tools.map((t) => t.name)).toEqual(['kb_list', 'kb_search', 'kb_read', 'material_search', 'material_list']);
   });
 
   it('material_search has a query-required schema', async () => {

--- a/test/main/model/core-agent/material-boundary.test.ts
+++ b/test/main/model/core-agent/material-boundary.test.ts
@@ -1,0 +1,102 @@
+/**
+ * material-boundary (COGSEED-39 ① Phase 3) — material set resolution.
+ *
+ * Hermetic tests with a temp workspace root:
+ *   - attachments of a conversation land in the set with inScope computed
+ *     against the attachment root;
+ *   - absent cid / spaceId / projectId yields an empty boundary with the
+ *     right library slices and history scope;
+ *   - space artifacts are included when a spaceId is present (empty space
+ *     returns an empty artifacts list, no throw).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+vi.mock('../../../../src/main/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+let tmpDir: string;
+let prevWs: string | undefined;
+const TEST_UID = 'matboundary';
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-mb-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+  const users = await import('../../../../src/main/features/users');
+  users.activateUser(TEST_UID);
+});
+
+afterEach(async () => {
+  process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function loadBoundary() {
+  return import('../../../../src/main/model/core-agent/material-boundary');
+}
+
+describe('material_boundary › resolveMaterialSet', () => {
+  it('lists conversation attachments with inScope=true under their cid root', async () => {
+    const mod = await loadBoundary();
+    const { attachmentDirForCid } = await import('../../../../src/main/features/chat_attachments');
+    const dir = attachmentDirForCid(TEST_UID, 'conv-1');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'notes.pdf'), 'pdf bytes');
+    fs.writeFileSync(path.join(dir, 'slides.pptx'), 'pptx bytes');
+
+    const set = await mod.resolveMaterialSet({ userId: TEST_UID, cid: 'conv-1' });
+
+    expect(set.library).toEqual({ global: true, space: false });
+    expect(set.history).toBe('none');
+    expect(set.artifacts).toEqual([]);
+    const names = set.attachments.map((a) => a.name).sort();
+    expect(names).toEqual(['notes.pdf', 'slides.pptx']);
+    for (const a of set.attachments) expect(a.inScope).toBe(true);
+    expect(set.attachments.every((a) => a.bytes > 0)).toBe(true);
+  });
+
+  it('attachment upload after resolution is picked up immediately (no cache)', async () => {
+    const mod = await loadBoundary();
+    const { attachmentDirForCid } = await import('../../../../src/main/features/chat_attachments');
+    const dir = attachmentDirForCid(TEST_UID, 'conv-2');
+    fs.mkdirSync(dir, { recursive: true });
+
+    const before = await mod.resolveMaterialSet({ userId: TEST_UID, cid: 'conv-2' });
+    expect(before.attachments).toEqual([]);
+
+    fs.writeFileSync(path.join(dir, 'new.pdf'), 'new');
+    const after = await mod.resolveMaterialSet({ userId: TEST_UID, cid: 'conv-2' });
+    expect(after.attachments.map((a) => a.name)).toEqual(['new.pdf']);
+  });
+
+  it('empty boundary when no cid/space/project is provided', async () => {
+    const mod = await loadBoundary();
+    const set = await mod.resolveMaterialSet({ userId: TEST_UID });
+    expect(set).toEqual({
+      library: { global: true, space: false },
+      attachments: [],
+      artifacts: [],
+      history: 'none',
+    });
+  });
+
+  it('space + project set space slice and history scope', async () => {
+    const mod = await loadBoundary();
+    const set = await mod.resolveMaterialSet({ userId: TEST_UID, spaceId: 'space-x', projectId: 'proj-1' });
+    expect(set.library.space).toBe(true);
+    expect(set.history).toBe('project');
+    // Empty space: no artifacts thrown, empty list.
+    expect(set.artifacts).toEqual([]);
+  });
+});

--- a/test/main/model/core-agent/parallel-safety.test.ts
+++ b/test/main/model/core-agent/parallel-safety.test.ts
@@ -35,7 +35,7 @@ const CID = 'c0a1b2c3d4e5';
 // (concurrent embed on the shared ONNX session is safe — see header).
 const PARALLEL_ALLOWLIST = [
   'chat_read', 'chat_search',
-  'grep_files', 'kb_list', 'kb_read', 'kb_search', 'list_files', 'material_search', 'read_file', 'search_files',
+  'grep_files', 'kb_list', 'kb_read', 'kb_search', 'list_files', 'material_list', 'material_search', 'read_file', 'search_files',
 ].sort();
 
 let tmpDir: string;


### PR DESCRIPTION
## Why
COGSEED-39 核心要点① Phase 3：定义资料集合边界（哪些文档/空间内容算‘资料’）。Phase 1/2（#85/#86）已合入；本 PR 让「聊天附件 + 空间产物」进入资料边界，并给模型一个边界清单工具，为后续检索/答案核验提供统一的 MaterialSet。

## What
- 新增 material-boundary.ts：MaterialSet 模型 + resolveMaterialSet()——Library（global+space）+ 会话附件（cid 即时扫描，无缓存）+ 空间产物（listSpaceArtifacts）+ history 作用域；每个非 Library 条目经 path-sandbox 计算 inScope（越界=不在资料集合）
- kb-tools.ts：新增只读工具 material_list（边界清单：Library/附件/产物，各带 in-scope）；kb_read 支持 source=attachment + name 跨源读取附件文本（file_indexer.getExtractedText，resolveAttachmentAbsPath 防穿越）
- runner.ts：createKbTools 传入 cid；tool-catalog 注册 material_list；parallel-safety allowlist 与 shape 测试同步
- 测试：material-boundary.test.ts 4 用例；相关契约测试同步

## How
- npm run typecheck / lint 通过；新增与受影响测试 43/43；全量 9371 passed
- 仅剩 2 个基线失败：cogseed-residual-identifiers（本地 AGENTS.md 内部手册替换所致，CI 不受影响）、session_import（干净基线同样失败）

## 关联
- Issue: COGSEED-39 核心要点① Phase 3

## Checklist
- [x] Conventional Commits / noreply 邮箱
- [x] 未新增 npm 依赖（无 SBOM 变更）
- [x] 工具契约同步（tool-catalog / parallel-safety / shape）
- [x] 只读工具；附件路径经 resolveAttachmentAbsPath + sandbox