### PR TITLE
feat(kb): 知识库模块 S1–S4 — 入口/工作台/可靠问答/库解析/笔记与发现

### DIFF
--- a/src/main/features/anchor.ts
+++ b/src/main/features/anchor.ts
@@ -1,0 +1,61 @@
+/**
+ * Anchor resolution feature (COGSEED-39 ② P1) — IPC-facing entry for
+ * `cogseed.anchor.resolve`.
+ *
+ * Lives in the features layer (not cogseed_backend) because it calls the
+ * in-process model layer (`model/core-agent/anchor-resolver`), which the
+ * cogseed runtime backend must not import (separation boundary).
+ *
+ * Validates the payload here (bounded strings, integer chunk), then delegates
+ * to the resolver. Read-only.
+ */
+
+import { createLogger } from '../logger';
+import { resolveAnchor } from '../model/core-agent/anchor-resolver';
+
+const log = createLogger('anchor');
+
+function boundedString(value: unknown, field: string, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const s = value.trim();
+  if (s.length === 0 || s.length > max) return undefined;
+  return s;
+}
+
+export async function anchorResolveIpc(userId: string, payload: unknown): Promise<unknown> {
+  const raw = (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>;
+  const scopeRaw = boundedString(raw.scope, 'scope', 32) ?? '';
+  const scope = scopeRaw === 'space' ? 'space'
+    : scopeRaw === 'conversation' ? 'conversation' : 'global';
+  const source = raw.source === 'attachment' ? 'attachment' : 'library';
+
+  const pathValue = boundedString(raw.path, 'path', 500);
+  if (!pathValue) {
+    log.warn('anchor.resolve: missing path', { user_id: String(userId).slice(0, 8) });
+    return { resolved: false, reason: 'bad_input' };
+  }
+
+  const chunkNum = Number(raw.chunkIdx);
+  if (!Number.isFinite(chunkNum) || chunkNum < 0) {
+    return { resolved: false, reason: 'bad_input' };
+  }
+
+  try {
+    return await resolveAnchor({
+      userId,
+      source,
+      scope,
+      path: pathValue,
+      chunkIdx: Math.floor(chunkNum),
+      ...(typeof raw.quote === 'string' && raw.quote.trim() ? { quote: boundedString(raw.quote, 'quote', 2000)! } : {}),
+      ...(typeof raw.cid === 'string' && raw.cid.trim() ? { cid: boundedString(raw.cid, 'cid', 200)! } : {}),
+      ...(typeof raw.spaceId === 'string' && raw.spaceId.trim() ? { spaceId: boundedString(raw.spaceId, 'spaceId', 200)! } : {}),
+    });
+  } catch (err) {
+    log.warn('anchor.resolve failed', {
+      user_id: String(userId).slice(0, 8),
+      error: (err as Error).message,
+    });
+    return { resolved: false, reason: 'no_text' };
+  }
+}

--- a/src/main/features/kb_qa.ts
+++ b/src/main/features/kb_qa.ts
@@ -1,0 +1,140 @@
+/**
+ * KB grounded Q&A (知识库模块 S2，计划书 v1.3 §S2).
+ *
+ * One-call stream for "基于知识库提问": runs `askMaterials` (COGSEED-39 ①
+ * hybrid retrieval + threshold), then either streams an LLM answer grounded
+ * ONLY in the returned evidence (each claim carries a `path#chunk N`
+ * citation anchor), or says plainly that the material set has nothing —
+ * no fabrication, no web fallback (same protocol as ask_materials).
+ *
+ * Read-only pipeline: never writes to chats / conversation bus, mirrors the
+ * aside pattern (`streamChatWithModel` injected via deps, so this module is
+ * unit-testable without a live provider).
+ */
+
+import { createLogger } from '../logger';
+import { maskId } from '../util/log-redact';
+import { askMaterials, formatEvidence } from '../model/core-agent/ask-materials';
+import type { MaterialHit } from '../model/core-agent/material-search';
+
+const log = createLogger('kb-qa');
+
+export interface KbAskInput {
+  /** 空 = 全局（用户个人资料库）；非空 = 空间库。 */
+  spaceId?: string | null;
+  question: string;
+  k?: number;
+}
+
+export interface KbAskDeps {
+  /** Injected model call — keeps this module testable without a live provider. */
+  stream: (opts: {
+    userId: string;
+    message: string;
+    systemPrompt: string;
+    sessionId: string;
+  }) => AsyncIterable<{ type: string; text?: string }>;
+}
+
+/** 渲染层引用 chip 需要的精简证据条目（与 `path#chunk N` 锚点一一对应）。 */
+export interface KbEvidenceRef {
+  source: MaterialHit['source'];
+  scope: MaterialHit['scope'];
+  path: string;
+  chunkIdx: number;
+  snippet: string;
+  score: number;
+}
+
+export interface KbAskEvent {
+  type: 'delta' | 'final' | 'error';
+  text?: string;
+  /** 证据包：final 时携带，渲染层据此绘制引用 chip（点击回跳原文）。 */
+  evidence?: KbEvidenceRef[];
+  noMaterial?: boolean;
+  reason?: 'no_material' | 'low_confidence';
+}
+
+const KB_SYSTEM_PROMPT = `你是知识库问答助手。只依据提供的 ask_materials 证据回答；
+每一条结论都必须标注引用 \`path#chunk N\`；资料中没有的内容明确说「资料中未找到」，
+不要编造，不要切换联网搜索，除非用户明确要求。`;
+
+function toEvidenceRefs(hits: MaterialHit[]): KbEvidenceRef[] {
+  return hits.map((h) => ({
+    source: h.source,
+    scope: h.scope,
+    path: h.path,
+    chunkIdx: h.chunkIdx,
+    snippet: h.snippet,
+    score: h.score,
+  }));
+}
+
+export async function* kbAskStream(
+  userId: string,
+  input: KbAskInput,
+  deps: KbAskDeps,
+): AsyncGenerator<KbAskEvent, void, unknown> {
+  const question = String(input.question ?? '').trim();
+  if (!question) {
+    yield { type: 'error', text: 'empty question' };
+    return;
+  }
+
+  let res;
+  try {
+    res = await askMaterials({
+      userId,
+      query: question,
+      scope: input.spaceId ? 'space' : 'global',
+      spaceId: input.spaceId || undefined,
+      k: typeof input.k === 'number' && input.k > 0 ? input.k : undefined,
+    });
+  } catch (err) {
+    log.warn('ask_materials failed', { user_id: maskId(userId), error: (err as Error).message });
+    yield { type: 'error', text: (err as Error).message };
+    return;
+  }
+
+  const evidence = toEvidenceRefs(res.hits);
+
+  if (!res.hasEvidence) {
+    const text = res.reason === 'no_material'
+      ? '资料中未找到与问题相关的内容。可以补充资料后再问，或换个问法。'
+      : '找到的相关资料很弱，无法给出可靠回答。建议换个问法或补充资料。';
+    yield { type: 'final', text, noMaterial: true, reason: res.reason, evidence };
+    return;
+  }
+
+  const systemPrompt = `${KB_SYSTEM_PROMPT}\n\n${formatEvidence(res)}`;
+  let answer = '';
+  try {
+    for await (const event of deps.stream({
+      userId,
+      message: question,
+      systemPrompt,
+      sessionId: `kb-${userId}`,
+    })) {
+      if (event.type === 'delta' && event.text) {
+        answer += event.text;
+        yield { type: 'delta', text: event.text };
+      } else if (event.type === 'error') {
+        yield { type: 'error', text: event.text || 'kb answer failed' };
+        return;
+      }
+    }
+  } catch (err) {
+    log.warn('kb stream failed', { user_id: maskId(userId), error: (err as Error).message });
+    yield { type: 'error', text: (err as Error).message };
+    return;
+  }
+
+  if (!answer.trim()) {
+    yield { type: 'error', text: 'empty answer' };
+    return;
+  }
+
+  yield { type: 'final', text: answer, evidence };
+}
+
+export const _internals = { toEvidenceRefs };

--- a/src/main/features/kb_summary.ts
+++ b/src/main/features/kb_summary.ts
@@ -1,0 +1,180 @@
+/**
+ * KB library summary (知识库模块 S3，计划书 v1.3 §S3).
+ *
+ * Lazily produces, per library, per-document key points + a one-liner summary
+ * (+ a mind-map skeleton) from the ready chunks in the vector store. The work
+ * is guarded by a library fingerprint (sorted rel_path + mtime + chunk count),
+ * so re-entry with an unchanged library hits an in-memory cache instead of a
+ * fresh LLM call; any model failure degrades to a plain file list instead of
+ * an error page (the renderer keeps the library usable).
+ *
+ * Read-only: never writes to chats / artifacts; one non-streaming LLM call.
+ */
+
+import { createHash } from 'node:crypto';
+import { createLogger } from '../logger';
+import { maskId } from '../util/log-redact';
+import * as kbVector from './kb_vector';
+import * as spaceLibrary from './project_library_indexer';
+
+const log = createLogger('kb-summary');
+
+export interface KbDocPoint {
+  /** 文档名（文件名）。 */
+  name: string;
+  /** 相对路径（引用 chip 的 path）。 */
+  file: string;
+  /** 一句话要点。 */
+  text: string;
+}
+
+export interface KbSummaryResult {
+  docs: KbDocPoint[];
+  oneLiner: string;
+  mindmap: { root: string; kids: string[] };
+  source: 'generated' | 'cached' | 'degraded';
+  /** 库指纹（渲染层可据此判断是否过期）。 */
+  fingerprint: string;
+}
+
+export interface KbSummaryDeps {
+  /** Injected model call — keeps this module testable without a live provider. */
+  complete: (opts: {
+    userId: string;
+    message: string;
+    systemPrompt: string;
+    sessionId: string;
+  }) => Promise<{ ok: boolean; text: string; error: string }>;
+}
+
+const CHUNKS_PER_FILE = 3;
+const CHUNK_CHAR_CAP = 400;
+const DOC_CHAR_CAP = 1200;
+const FILES_CAP = 12;
+const CACHE_MAX = 50;
+
+const SUMMARY_SYSTEM_PROMPT = `你是知识库整理助手。根据提供的各文档要点，只输出一个 JSON 对象（不要任何额外文字）：
+{"docs":[{"name":"文档名","file":"相对路径","text":"一句话要点"}],"oneLiner":"整个知识库的一句话总结","mindmap":{"root":"中心主题","kids":["分支1","分支2","分支3"]}}`;
+
+const cache = new Map<string, KbSummaryResult>();
+
+function fingerprint(files: Array<{ path: string; mtime: number; chunks: number }>): string {
+  const h = createHash('sha256');
+  for (const f of [...files].sort((a, b) => a.path.localeCompare(b.path))) {
+    h.update(`${f.path}\u0000${f.mtime}\u0000${f.chunks}\u0000`);
+  }
+  return h.digest('hex').slice(0, 16);
+}
+
+export function parseSummaryJson(text: string): { docs: KbDocPoint[]; oneLiner: string; mindmap: { root: string; kids: string[] } } {
+  const m = String(text || '').match(/\{[\s\S]*\}/);
+  const data = m ? JSON.parse(m[0]) : {};
+  const docs = Array.isArray(data.docs)
+    ? data.docs
+        .map((d: any) => ({
+          name: String(d?.name ?? ''),
+          file: String(d?.file ?? ''),
+          text: String(d?.text ?? ''),
+        }))
+        .filter((d: KbDocPoint) => d.file)
+    : [];
+  const oneLiner = typeof data.oneLiner === 'string' ? data.oneLiner : '';
+  const kids = Array.isArray(data?.mindmap?.kids) ? data.mindmap.kids.map(String).filter(Boolean) : [];
+  const root = typeof data?.mindmap?.root === 'string' ? data.mindmap.root : '';
+  return { docs, oneLiner, mindmap: { root, kids } };
+}
+
+export async function kbSummarize(
+  userId: string,
+  opts: { dir?: string | null; spaceId?: string | null },
+  deps: KbSummaryDeps,
+): Promise<KbSummaryResult> {
+  const dir = opts?.dir || null;
+  const spaceId = opts?.spaceId || null;
+  const isSpace = !!spaceId;
+  let ready;
+  if (isSpace) {
+    ready = spaceLibrary
+      .listFiles(userId, spaceId)
+      .filter((f) => f.status === 'ready')
+      .slice(0, FILES_CAP);
+  } else {
+    ready = kbVector
+      .listFiles(userId)
+      .filter((f) => f.status === 'ready')
+      .filter((f) => !dir || f.rel_path === dir || f.rel_path.startsWith(`${dir}/`))
+      .slice(0, FILES_CAP);
+  }
+  const fp = fingerprint(
+    ready.map((f) => ({ path: f.rel_path, mtime: f.mtime || 0, chunks: f.chunks || 0 })),
+  );
+
+  const hit = cache.get(fp);
+  if (hit) return { ...hit, source: 'cached' };
+
+  if (!ready.length) {
+    const degraded: KbSummaryResult = {
+      docs: [],
+      oneLiner: '资料库还没有已索引的文档。',
+      mindmap: { root: '', kids: [] },
+      source: 'degraded',
+      fingerprint: fp,
+    };
+    return degraded;
+  }
+
+  const docLines: string[] = [];
+  for (const f of ready) {
+    const chunks = isSpace
+      ? spaceLibrary.readFileChunks(userId, spaceId, f.rel_path)
+      : kbVector.readFileChunks(userId, f.rel_path);
+    const head = (chunks || [])
+      .slice(0, CHUNKS_PER_FILE)
+      .map((c) => (c.title ? `${c.title}：` : '') + String(c.content || '').slice(0, CHUNK_CHAR_CAP))
+      .join('\n');
+    docLines.push(`## ${f.rel_path}\n${head.slice(0, DOC_CHAR_CAP)}`);
+  }
+
+  try {
+    const res = await deps.complete({
+      userId,
+      message: `请整理以下知识库文档要点：\n\n${docLines.join('\n\n')}`,
+      systemPrompt: SUMMARY_SYSTEM_PROMPT,
+      sessionId: `kb-summary-${userId}`,
+    });
+    if (!res.ok) throw new Error(res.error || 'model failed');
+    const parsed = parseSummaryJson(res.text);
+    const result: KbSummaryResult = {
+      docs: parsed.docs,
+      oneLiner: parsed.oneLiner || '（未生成总结）',
+      mindmap: parsed.mindmap,
+      source: 'generated',
+      fingerprint: fp,
+    };
+    cache.set(fp, result);
+    if (cache.size > CACHE_MAX) {
+      const first = cache.keys().next().value;
+      if (first) cache.delete(first);
+    }
+    return result;
+  } catch (err) {
+    log.warn('kb summary failed, degrading to file list', {
+      user_id: maskId(userId),
+      dir: dir || null,
+      error: (err as Error).message,
+    });
+    return {
+      docs: ready.map((f) => ({
+        name: f.rel_path.split('/').pop() || f.rel_path,
+        file: f.rel_path,
+        text: '',
+      })),
+      oneLiner: 'AI 解析失败，已降级为文件清单。',
+      mindmap: { root: '', kids: [] },
+      source: 'degraded',
+      fingerprint: fp,
+    };
+  }
+}
+
+export const _internals = { fingerprint, parseSummaryJson, clearCacheForTests: () => cache.clear() };

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -22,6 +22,7 @@ import * as conversationAside from '../features/conversation_aside';
 import * as modelClient from '../model/client';
 import * as spaces from '../features/spaces';
 import * as spacesArtifacts from '../features/spaces_artifacts';
+import * as anchorFeature from '../features/anchor';
 import * as spaceImport from '../features/space_import';
 import * as spaceFiles from '../features/project_files';
 import * as spaceLibraryIndexer from '../features/project_library_indexer';
@@ -960,6 +961,7 @@ const invokeHandlers: Record<string, InvokeHandler> = {
   'cogseed.kb.index': async (payload, ctx) => cogseedBackend.cogseedIpcService.kbIndex(ctx.userId, payload),
   'cogseed.kb.search': async (payload, ctx) => cogseedBackend.cogseedIpcService.kbSearch(ctx.userId, payload),
   'cogseed.kb.read': async (payload, ctx) => cogseedBackend.cogseedIpcService.kbRead(ctx.userId, payload),
+  'cogseed.anchor.resolve': async (payload, ctx) => anchorFeature.anchorResolveIpc(ctx.userId, payload),
   'cogseed.kb.sources': async (_payload, ctx) => cogseedBackend.cogseedIpcService.kbSources(ctx.userId),
   'cogseed.connector.tools': async (payload, ctx) => cogseedBackend.cogseedIpcService.connectorTools(ctx.userId, payload),
   'cogseed.session.list': async (_payload, ctx) => ({ sessions: await cogseedBackend.cogseedIpcService.sessions(ctx.userId) }),

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -19,6 +19,8 @@ import { app, ipcMain, dialog, BrowserWindow, type WebContents } from 'electron'
 import * as users from '../features/users';
 import * as chats from '../features/chats';
 import * as conversationAside from '../features/conversation_aside';
+import * as kbQa from '../features/kb_qa';
+import * as kbSummary from '../features/kb_summary';
 import * as modelClient from '../model/client';
 import * as spaces from '../features/spaces';
 import * as spacesArtifacts from '../features/spaces_artifacts';
@@ -3922,6 +3924,29 @@ const invokeHandlers: Record<string, InvokeHandler> = {
     return _writeTextToLibrary(payload, ctx);
   },
 
+  // KB library summary (知识库模块 S3)：逐文档要点 + 一句话总结 + 脑图骨架。
+  // 懒生成 + 库指纹缓存（features/kb_summary）；失败降级为文件清单。
+  // dir=个人库；spaceId=空间库（共享知识库）。
+  'kb.summary': async ({ dir, spaceId }, ctx) => {
+    const res = await kbSummary.kbSummarize(ctx.userId, {
+      dir: typeof dir === 'string' && dir ? dir : null,
+      spaceId: typeof spaceId === 'string' && spaceId ? spaceId : null,
+    }, {
+      complete: async (opts) => {
+        const r = await modelClient.chatWithModel({
+          userId: opts.userId,
+          message: opts.message,
+          systemPrompt: opts.systemPrompt,
+          sessionId: opts.sessionId,
+          skillList: [],
+          disableTools: true,
+        });
+        return { ok: r.ok, text: r.text, error: r.error };
+      },
+    });
+    return res;
+  },
+
   // ── Knowledge base (vector store) ──
   // Snapshot of what's in `kb_files`: status summary + per-file rows.
   // Renderer subscribes to the `kb.events` stream (below) for incremental
@@ -5159,6 +5184,40 @@ const streamHandlers: Record<string, StreamHandler> = {
           // Explain-only: no skills in the prompt and NO tools at all. The
           // `disableTools` flag is what actually enforces this — `maxToolLoops: 0`
           // would be dropped as falsy and leave the full tool set attached.
+          skillList: [],
+          disableTools: true,
+          abortSignal: signal,
+        }) as AsyncIterable<{ type: string; text?: string }>,
+      });
+      for await (const event of events) {
+        if (signal.aborted) return;
+        yield event as { type: string; text?: string };
+      }
+    } catch (err) {
+      yield { type: 'error', text: (err as Error).message };
+    }
+  },
+
+  // KB grounded Q&A (知识库模块 S2)：ask_materials 证据边界内流式回答。
+  // 只读管线：不进主对话/群聊 bus，不写 chats；无资料时明说（no_material）。
+  'kbqa.askStream': async function* ({ space_id, question, k }, ctx, signal) {
+    const q = String(question ?? '').trim();
+    if (!q) {
+      yield { type: 'error', text: 'empty question' };
+      return;
+    }
+    try {
+      const events = kbQa.kbAskStream(ctx.userId, {
+        spaceId: space_id ? String(space_id) : null,
+        question: q,
+        k: typeof k === 'number' ? k : undefined,
+      }, {
+        stream: (opts) => modelClient.streamChatWithModel({
+          userId: opts.userId,
+          message: opts.message,
+          systemPrompt: opts.systemPrompt,
+          sessionId: opts.sessionId,
+          // 只回答问题：不给工具、不进技能（disableTools 才是真正强制项）。
           skillList: [],
           disableTools: true,
           abortSignal: signal,

--- a/src/main/model/core-agent/anchor-resolver.ts
+++ b/src/main/model/core-agent/anchor-resolver.ts
@@ -1,0 +1,210 @@
+/**
+ * Anchor resolver (COGSEED-39 ② P1) — chunk-level citation → char-level position.
+ *
+ * Given a citation anchor (`source`/`scope`/`path`/`chunkIdx`, optional
+ * `quote`) this resolves the anchor to a concrete character range in the
+ * source document's extracted text, so the UI can jump to and highlight the
+ * exact spot:
+ *
+ *   1. read the chunk text from the vector store (kb / space library);
+ *   2. load the source file's extracted text via the file-indexer cache
+ *      (plain text read directly; rich docs only when cached — never
+ *      trigger an expensive extraction from here);
+ *   3. locate the chunk (or its quote) in the text: exact substring first,
+ *      whitespace-normalized search, then first-token fallback;
+ *   4. map charStart → page via the PDF page map when available.
+ *
+ * Failures are structured, not thrown: `resolved: false` with a reason
+ * (`no_cache` / `not_found` / `out_of_scope` / `no_text`) so the caller can
+ * degrade to the chunk-level anchor instead of silently failing.
+ *
+ * Read-only; reuses existing utilities (kb / space library / file_indexer /
+ * attachment resolver) — no new parsers, no writes.
+ */
+
+import * as path from 'node:path';
+import { createLogger } from '../../logger';
+import * as kb from '../../features/kb_vector';
+import * as spaceLibrary from '../../features/project_library_indexer';
+import * as chatAttachments from '../../features/chat_attachments';
+import * as fileIndexer from '../../features/file_indexer';
+import { userContextsDir, spaceContextsDir } from '../../paths';
+import { isPathAllowed } from '../../util/path-sandbox';
+import { maskId } from '../../util/log-redact';
+
+const log = createLogger('anchor-resolver');
+
+export interface AnchorTarget {
+  userId: string;
+  source: 'library' | 'attachment';
+  scope: 'global' | 'space' | 'conversation';
+  /** Library-relative path or attachment filename. */
+  path: string;
+  chunkIdx: number;
+  /** Optional expected snippet from the evidence (preferred for locating). */
+  quote?: string;
+  /** Required for attachments. */
+  cid?: string;
+  spaceId?: string;
+}
+
+export type AnchorFailure = 'no_cache' | 'not_found' | 'out_of_scope' | 'no_text' | 'bad_input';
+
+export interface AnchorLocation {
+  resolved: boolean;
+  reason?: AnchorFailure;
+  /** Absolute path of the source file (for the viewer). */
+  absPath?: string;
+  /** Display path (library relPath / attachment filename / space relPath). */
+  displayPath?: string;
+  charStart?: number;
+  charEnd?: number;
+  page?: number;
+  totalChars?: number;
+  /** The located text range (preview for highlighting). */
+  text?: string;
+}
+
+/** Collapse all whitespace runs to single spaces (for fuzzy locating). */
+function normalize(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+function firstSignificantToken(s: string): string {
+  const m = s.match(/[\p{L}\p{N}][\p{L}\p{N}._-]{2,}/u);
+  return m ? m[0] : '';
+}
+
+/**
+ * Locate `needle` inside `text`. Exact substring first; then
+ * whitespace-normalized; then first-significant-token fallback. Returns
+ * charStart/charEnd (approximate for the fuzzy paths).
+ */
+function locateInText(text: string, needle: string): { start: number; end: number } | null {
+  if (!needle) return null;
+  let idx = text.indexOf(needle);
+  if (idx >= 0) return { start: idx, end: idx + needle.length };
+
+  const needleNorm = normalize(needle);
+  const textNorm = normalize(text);
+  idx = textNorm.indexOf(needleNorm);
+  if (idx >= 0) {
+    // Map normalized index back to raw by locating the first token at/after idx.
+    const head = needleNorm.slice(0, Math.min(60, needleNorm.length));
+    const firstWord = firstSignificantToken(head);
+    const rawIdx = firstWord ? text.indexOf(firstWord) : text.indexOf(needle[0]);
+    if (rawIdx >= 0) {
+      const end = Math.min(text.length, rawIdx + Math.max(needle.length, firstWord.length));
+      return { start: rawIdx, end };
+    }
+  }
+
+  const firstWord = firstSignificantToken(needle);
+  if (firstWord) {
+    const rawIdx = text.indexOf(firstWord);
+    if (rawIdx >= 0) {
+      return { start: rawIdx, end: Math.min(text.length, rawIdx + Math.max(needle.length, firstWord.length)) };
+    }
+  }
+  return null;
+}
+
+/**
+ * Derive the PDF page from the `--- page N ---` delimiters the materialiser
+ * writes into text.md (see file_indexer). Scans markers up to charStart.
+ */
+function pageForText(text: string, charStart: number): number | undefined {
+  const re = /---\s*page\s*(\d+)\s*---/g;
+  let m: RegExpExecArray | null;
+  let page: number | undefined;
+  while ((m = re.exec(text)) && m.index <= charStart) {
+    page = Number(m[1]);
+  }
+  return page;
+}
+
+/**
+ * Resolve a citation anchor to a character range in the source document.
+ * Returns `resolved: false` (with a reason) instead of throwing when the
+ * source is out of scope, not cached, or the chunk cannot be located.
+ */
+export async function resolveAnchor(target: AnchorTarget): Promise<AnchorLocation> {
+  const { userId, source, scope } = target;
+  const displayPath = target.path;
+
+  // ── Resolve abs path + read the chunk text ─────────────────────────────
+  let absPath: string;
+  let chunkText: string | null = null;
+
+  if (source === 'attachment') {
+    if (!target.cid) return { resolved: false, reason: 'bad_input' };
+    const resolved = chatAttachments.resolveAttachmentAbsPath(userId, target.cid, displayPath);
+    if (!resolved.ok) return { resolved: false, reason: 'not_found' };
+    absPath = resolved.absPath;
+    // Attachments are not in the vector store; locate by quote only.
+    chunkText = target.quote?.trim() || null;
+  } else if (scope === 'space') {
+    if (!target.spaceId) return { resolved: false, reason: 'bad_input' };
+    absPath = path.join(spaceContextsDir(userId, target.spaceId), displayPath);
+    const chunks = spaceLibrary.readFileChunks(userId, target.spaceId, displayPath);
+    chunkText = chunks.find((c) => c.chunk_idx === target.chunkIdx)?.content?.trim() ?? null;
+  } else {
+    absPath = path.join(userContextsDir(userId), displayPath);
+    const chunks = kb.readFileChunks(userId, displayPath);
+    chunkText = chunks.find((c) => c.chunk_idx === target.chunkIdx)?.content?.trim() ?? null;
+  }
+
+  // ── Scope check: source must be inside its allowed root ────────────────
+  let allowedRoot: string;
+  if (source === 'attachment') {
+    allowedRoot = chatAttachments.attachmentDirForCid(userId, target.cid!);
+  } else if (scope === 'space') {
+    allowedRoot = spaceContextsDir(userId, target.spaceId!);
+  } else {
+    allowedRoot = userContextsDir(userId);
+  }
+  if (!isPathAllowed(absPath, [allowedRoot])) {
+    return { resolved: false, reason: 'out_of_scope' };
+  }
+
+  // ── Load extracted text (cache-only for rich docs) ─────────────────────
+  // readRange: plain text reads the file directly; rich docs require an
+  // existing file-indexer cache (NeedStatError → no_cache) and carry the
+  // PDF page map.
+  let text: string;
+  try {
+    const read = await fileIndexer.readRange(userId, absPath, {});
+    text = read.content;
+  } catch (err) {
+    const name = (err as Error).name || '';
+    if (name.includes('NeedStat')) {
+      return { resolved: false, reason: 'no_cache', absPath, displayPath };
+    }
+    log.warn('anchor_resolver: extract failed', {
+      user_id: maskId(userId),
+      abs_path: displayPath,
+      error: (err as Error).message,
+    });
+    return { resolved: false, reason: 'no_text', absPath, displayPath };
+  }
+
+  const needle = target.quote?.trim() || chunkText;
+  if (!needle) return { resolved: false, reason: 'not_found', absPath, displayPath };
+
+  const located = locateInText(text, needle);
+  if (!located) {
+    return { resolved: false, reason: 'not_found', absPath, displayPath, totalChars: text.length };
+  }
+
+  const page = pageForText(text, located.start);
+  return {
+    resolved: true,
+    absPath,
+    displayPath,
+    charStart: located.start,
+    charEnd: located.end,
+    page,
+    totalChars: text.length,
+    text: text.slice(located.start, Math.min(located.end, located.start + 400)),
+  };
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1981,6 +1981,8 @@
        必须在 conversation.js 之前加载（其消费方是 _mountMsgMeta）。 -->
   <script src="./modules/conversation-metrics.js"></script>
   <script src="./modules/conversation.js"></script>
+  <script src="./modules/anchored-source-view.js"></script>
+  <script src="./modules/chat-citation.js"></script>
   <script src="./modules/artifact-security.js"></script>
   <script src="./modules/chat-artifact.js"></script>
   <script src="./modules/plan-rail.js"></script>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -44,6 +44,7 @@
         <button class="sidebar-btn primary" id="new-chat-btn"><span data-ui-icon="message-square" data-ui-icon-class="sidebar-btn-icon"></span><span data-i18n="sidebar.new_chat">新建任务</span><span class="sidebar-btn-running-chip" id="commander-running-chip" hidden></span></button>
         <button class="sidebar-btn" id="workspace-btn"><span data-ui-icon="folder" data-ui-icon-class="sidebar-btn-icon"></span><span data-i18n="sidebar.workspace">空间中心</span></button>
         <button class="sidebar-btn" id="auto-btn"><span data-ui-icon="clock" data-ui-icon-class="sidebar-btn-icon"></span><span data-i18n="sidebar.auto">自动化</span></button>
+        <button class="sidebar-btn" id="kb-btn"><span data-ui-icon="book-open" data-ui-icon-class="sidebar-btn-icon"></span><span data-i18n="sidebar.kb">知识库</span><span class="sidebar-btn-chip kb-new-chip" data-i18n="sidebar.kb_new">新</span></button>
         <button class="sidebar-btn" id="recall-btn"><span data-ui-icon="git-branch" data-ui-icon-class="sidebar-btn-icon"></span><span data-i18n="sidebar.recall">认知资产</span></button>
         <button class="sidebar-btn" id="connectors-btn"><span data-ui-icon="plug" data-ui-icon-class="sidebar-btn-icon"></span><span data-i18n="sidebar.connections">连接</span></button>
         <button class="sidebar-btn" id="dashboard-btn"><span data-ui-icon="layout-grid" data-ui-icon-class="sidebar-btn-icon"></span><span data-i18n="sidebar.dashboard">智能体总览</span></button>
@@ -1142,6 +1143,11 @@
       <!-- Workspace Center (空间中心：任务/产物/资产三 tab，由 workspace.js 渲染) -->
       <section class="panel" id="panel-workspace">
         <div class="ws-view" id="ws-view"></div>
+      </section>
+
+      <!-- Knowledge Base (知识库工作台：生态 rail + 三栏，由 kb-eco.js / kb-workbench.js 渲染) -->
+      <section class="panel" id="panel-kb">
+        <div class="kb-view" id="kb-view"></div>
       </section>
 
       <!-- Settings -->

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -2725,6 +2725,8 @@
   "sidebar.alert_sync_pro_required": "Membership needed",
   "sidebar.alert_sync_quota_full": "Storage full",
   "sidebar.auto": "Auto",
+  "sidebar.kb": "Knowledge Base",
+  "sidebar.kb_new": "New",
   "sidebar.bucket.last30": "Last 30 days",
   "sidebar.bucket.last7": "Last 7 days",
   "sidebar.bucket.older": "Older",

--- a/src/renderer/locales/ja.json
+++ b/src/renderer/locales/ja.json
@@ -2539,6 +2539,8 @@
   "sidebar.alert_sync_quota_full": "容量不足",
   "sidebar.apps": "マイアプリ",
   "sidebar.auto": "自動化",
+  "sidebar.kb": "ナレッジベース",
+  "sidebar.kb_new": "新規",
   "sidebar.bucket.last30": "30日以内",
   "sidebar.bucket.last7": "7日以内",
   "sidebar.bucket.older": "それ以前",

--- a/src/renderer/locales/pt.json
+++ b/src/renderer/locales/pt.json
@@ -2539,6 +2539,8 @@
   "sidebar.alert_sync_quota_full": "Armazenamento cheio",
   "sidebar.apps": "Meus aplicativos",
   "sidebar.auto": "Automático",
+  "sidebar.kb": "Base de conhecimento",
+  "sidebar.kb_new": "Novo",
   "sidebar.bucket.last30": "Últimos 30 dias",
   "sidebar.bucket.last7": "Últimos 7 dias",
   "sidebar.bucket.older": "Mais velho",

--- a/src/renderer/locales/zh.json
+++ b/src/renderer/locales/zh.json
@@ -2728,6 +2728,8 @@
   "sidebar.alert_sync_pro_required": "需要会员",
   "sidebar.alert_sync_quota_full": "空间已满",
   "sidebar.auto": "自动化",
+  "sidebar.kb": "知识库",
+  "sidebar.kb_new": "新",
   "sidebar.bucket.last30": "30 天内",
   "sidebar.bucket.last7": "7 天内",
   "sidebar.bucket.older": "更早",

--- a/src/renderer/modules/anchored-source-view.js
+++ b/src/renderer/modules/anchored-source-view.js
@@ -1,0 +1,148 @@
+/**
+ * Anchored source viewer (COGSEED-39 ② P3).
+ *
+ * Opens a modal showing the resolved source location for a citation anchor:
+ * display path, PDF page (when known), and the located text window with the
+ * exact [charStart, charEnd) range highlighted. Reads the location via the
+ * `cogseed.anchor.resolve` IPC channel (P1).
+ *
+ * Exposes `window.__openAnchorViewer(anchor)` so both the chat citation
+ * chips (chat-citation.js) and future artifact payloads (P4, via the
+ * artifact postMessage contract) can open the same viewer.
+ *
+ * Safety: the located text comes from user documents — it is rendered with
+ * textContent / DOM building only, never innerHTML.
+ */
+(function () {
+  'use strict';
+
+  const VIEWER_ID = 'anchored-source-view';
+  let _overlay = null;
+
+  function _ensureOverlay() {
+    if (_overlay && document.getElementById(VIEWER_ID)) return _overlay;
+
+    const overlay = document.createElement('div');
+    overlay.id = VIEWER_ID;
+    overlay.className = 'anchored-source-overlay';
+
+    const dialog = document.createElement('section');
+    dialog.className = 'anchored-source-dialog';
+
+    const header = document.createElement('header');
+    header.className = 'anchored-source-header';
+    const title = document.createElement('span');
+    title.className = 'anchored-source-title';
+    title.textContent = '原文位置';
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'anchored-source-close';
+    close.textContent = '×';
+    close.setAttribute('aria-label', '关闭');
+    close.addEventListener('click', () => overlay.hidden = true);
+    header.append(title, close);
+
+    const meta = document.createElement('div');
+    meta.className = 'anchored-source-meta';
+
+    const body = document.createElement('div');
+    body.className = 'anchored-source-body';
+    const pre = document.createElement('pre');
+    pre.className = 'anchored-source-text';
+    body.appendChild(pre);
+
+    dialog.append(header, meta, body);
+    overlay.appendChild(dialog);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.hidden = true; });
+    document.body.appendChild(overlay);
+    _overlay = overlay;
+    return overlay;
+  }
+
+  function _setMeta(text) {
+    _ensureOverlay().querySelector('.anchored-source-meta').textContent = text;
+  }
+
+  function _renderBody(loc) {
+    const pre = _ensureOverlay().querySelector('.anchored-source-text');
+    pre.textContent = '';
+    if (!loc.resolved) {
+      const msg = document.createElement('span');
+      msg.className = 'anchored-source-unresolved';
+      msg.textContent = loc.reason === 'no_cache'
+        ? '该文件尚未提取文本（可能仍在索引中），暂时无法定位到具体位置。'
+        : loc.reason === 'out_of_scope'
+          ? '该文件不在当前资料边界内，无法打开。'
+          : loc.reason === 'not_found'
+            ? '未能在原文中定位到该引用片段。'
+            : '无法定位该引用。';
+      pre.appendChild(msg);
+      return;
+    }
+    const text = loc.text || '';
+    // `loc.text` starts at charStart, so the cited range is [0, markLen).
+    const markLen = Math.max(0, Math.min((loc.charEnd ?? loc.charStart ?? 0) - (loc.charStart ?? 0), text.length));
+    const mark = document.createElement('mark');
+    mark.textContent = text.slice(0, markLen);
+    pre.appendChild(mark);
+    pre.appendChild(document.createTextNode(text.slice(markLen)));
+  }
+
+  async function openAnchorViewer(anchor) {
+    const overlay = _ensureOverlay();
+    overlay.hidden = false;
+    _setMeta('定位中…');
+    _renderBody({ resolved: false, reason: 'no_text' });
+    try {
+      const loc = await window.cogseed.invoke('cogseed.anchor.resolve', anchor);
+      const metaBits = [String(anchor.path || '')];
+      if (loc.page) metaBits.push(`第 ${loc.page} 页`);
+      if (loc.resolved) metaBits.push(`字符 ${loc.charStart}–${loc.charEnd}`);
+      if (!loc.resolved && loc.reason) metaBits.push(`（${loc.reason}）`);
+      _setMeta(metaBits.join(' · '));
+      _renderBody(loc);
+    } catch (err) {
+      _setMeta('定位失败');
+      _renderBody({ resolved: false, reason: 'no_text' });
+    }
+  }
+
+  window.__openAnchorViewer = openAnchorViewer;
+
+  // Self-contained styles (reviewers may move to style.css).
+  const style = document.createElement('style');
+  style.textContent = `
+    .anchored-source-overlay {
+      position: fixed; inset: 0; z-index: 10000; background: rgba(0,0,0,.45);
+      display: flex; align-items: center; justify-content: center;
+    }
+    .anchored-source-overlay[hidden] { display: none; }
+    .anchored-source-dialog {
+      background: var(--surface, #fff); color: var(--text, #222);
+      width: min(720px, 92vw); max-height: 80vh; border-radius: 10px;
+      display: flex; flex-direction: column; box-shadow: 0 8px 40px rgba(0,0,0,.25);
+    }
+    .anchored-source-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 10px 16px; border-bottom: 1px solid rgba(128,128,128,.3);
+    }
+    .anchored-source-title { font-weight: 600; }
+    .anchored-source-close {
+      border: 0; background: transparent; font-size: 20px; cursor: pointer; line-height: 1;
+    }
+    .anchored-source-meta {
+      padding: 8px 16px; font-size: 12px; opacity: .75;
+      border-bottom: 1px solid rgba(128,128,128,.2);
+    }
+    .anchored-source-body { overflow: auto; padding: 12px 16px; }
+    .anchored-source-text {
+      white-space: pre-wrap; word-break: break-word; margin: 0;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace); font-size: 13px; line-height: 1.6;
+    }
+    .anchored-source-text mark {
+      background: var(--accent, #ffe08a); padding: 0 1px; border-radius: 2px;
+    }
+    .anchored-source-unresolved { color: var(--danger, #c0392b); }
+  `;
+  document.head.appendChild(style);
+})();

--- a/src/renderer/modules/anchored-source-view.js
+++ b/src/renderer/modules/anchored-source-view.js
@@ -34,13 +34,23 @@
     const title = document.createElement('span');
     title.className = 'anchored-source-title';
     title.textContent = '原文位置';
+    const jump = document.createElement('button');
+    jump.type = 'button';
+    jump.className = 'anchored-source-jump';
+    jump.textContent = '在阅读器打开';
+    jump.setAttribute('aria-label', '在阅读器打开');
+    jump.addEventListener('click', () => {
+      const isReader = dialog.classList.toggle('anchored-source-dialog--reader');
+      jump.textContent = isReader ? '返回定位' : '在阅读器打开';
+      meta.hidden = isReader;
+    });
     const close = document.createElement('button');
     close.type = 'button';
     close.className = 'anchored-source-close';
     close.textContent = '×';
     close.setAttribute('aria-label', '关闭');
     close.addEventListener('click', () => overlay.hidden = true);
-    header.append(title, close);
+    header.append(title, jump, close);
 
     const meta = document.createElement('div');
     meta.className = 'anchored-source-meta';
@@ -127,6 +137,19 @@
       padding: 10px 16px; border-bottom: 1px solid rgba(128,128,128,.3);
     }
     .anchored-source-title { font-weight: 600; }
+    .anchored-source-jump {
+      margin-left: auto; margin-right: 10px; border: 1px solid rgba(128,128,128,.4);
+      background: transparent; color: inherit; font-size: 12px; padding: 3px 10px;
+      border-radius: 6px; cursor: pointer;
+    }
+    .anchored-source-jump:hover { background: rgba(128,128,128,.12); }
+    .anchored-source-dialog--reader {
+      width: min(1100px, 96vw); max-height: 92vh;
+    }
+    .anchored-source-dialog--reader .anchored-source-body { padding: 28px 44px; }
+    .anchored-source-dialog--reader .anchored-source-text {
+      font-family: inherit; font-size: 15px; line-height: 2; color: inherit;
+    }
     .anchored-source-close {
       border: 0; background: transparent; font-size: 20px; cursor: pointer; line-height: 1;
     }

--- a/src/renderer/modules/boot.js
+++ b/src/renderer/modules/boot.js
@@ -318,6 +318,7 @@ function _lazyFeaturePanel(view) {
     : view === 'skills' ? 'panel-connections'
     : view === 'recall' ? 'panel-recall'
     : view === 'spaces' || view === 'workspace' ? 'panel-workspace'
+    : view === 'kb' ? 'panel-kb'
     : view === 'contexts' ? 'panel-contexts'
     : view === 'settings' ? 'panel-settings'
     : view === 'auto' ? 'panel-auto'
@@ -420,6 +421,7 @@ function setView(view, cid, opts = {}) {
                 : view === 'recall' ? 'panel-recall'
                 : view === 'connections' || view === 'connectors' ? 'panel-connections'
                 : view === 'spaces' || view === 'workspace' ? 'panel-workspace'
+                : view === 'kb' ? 'panel-kb'
                 : view === 'settings' ? 'panel-settings'
                 : view === 'dashboard' ? 'panel-dashboard'
                 : view === 'memory' ? 'panel-memory'
@@ -430,6 +432,7 @@ function setView(view, cid, opts = {}) {
 
   document.getElementById('new-chat-btn').classList.toggle('active', view === 'new-chat');
   document.getElementById('auto-btn')?.classList.toggle('active', view === 'auto');
+  document.getElementById('kb-btn')?.classList.toggle('active', view === 'kb');
   document.getElementById('recall-btn')?.classList.toggle('active', view === 'recall' || view === 'personal-ontology');
   document.getElementById('connectors-btn')?.classList.toggle('active', view === 'connections' || view === 'connectors' || view === 'agents' || view === 'contexts' || view === 'skills');
   document.getElementById('workspace-btn')?.classList.toggle('active', view === 'workspace');
@@ -623,6 +626,14 @@ function setView(view, cid, opts = {}) {
     _deferSidebarNavWork('workspace-tab-load', () => {
       _loadViewFeature('workspace', 'workspace', () => {
         if (typeof renderWorkspace === 'function') renderWorkspace();
+      });
+    });
+  } else if (view === 'kb') {
+    currentCid = null;
+    _deferSidebarNavWork('kb-tab-load', () => {
+      _loadViewFeature('kb', 'kb', () => {
+        if (typeof renderKbEco === 'function') renderKbEco();
+        if (typeof renderKbWorkbench === 'function') renderKbWorkbench();
       });
     });
   } else if (view === 'settings') {

--- a/src/renderer/modules/chat-citation.js
+++ b/src/renderer/modules/chat-citation.js
@@ -1,0 +1,120 @@
+/**
+ * Chat citation chips (COGSEED-39 ② P2).
+ *
+ * Turns `path#chunk N` citations (optionally prefixed `[global]` / `[space]`)
+ * inside rendered chat bubbles into clickable chips that open the anchored
+ * source viewer (`window.__openAnchorViewer`, P3).
+ *
+ * Implementation notes:
+ *   - A MutationObserver on the #chat-history container linkifies every
+ *     newly rendered `.markdown-body` exactly once (WeakSet guard), so no
+ *     message-render call site needs editing — zero impact on other render
+ *     paths.
+ *   - Chips are built with createElement + textContent only (the citation
+ *     text comes from the LLM) — no innerHTML with model content.
+ *   - Attachment citations (`[attachment]`) are intentionally left as text
+ *     for now: resolving them needs a conversation cid that is not available
+ *     at chip time (documented limitation, P4/5).
+ */
+(function () {
+  'use strict';
+
+  const CITATION_RE = /(?:\[(global|space)\]\s*)?([A-Za-z0-9._-]+)#chunk\s*(\d+)/g;
+  const processed = new WeakSet();
+
+  function _skipNode(node) {
+    const tag = node.nodeType === Node.ELEMENT_NODE ? node.tagName : '';
+    return tag === 'CODE' || tag === 'PRE' || tag === 'SCRIPT' || tag === 'STYLE'
+      || tag === 'A' || tag === 'BUTTON';
+  }
+
+  function _linkifyTextNode(textNode) {
+    const text = textNode.nodeValue || '';
+    if (!/#chunk\s*\d/i.test(text)) return;
+
+    CITATION_RE.lastIndex = 0;
+    const fragment = document.createDocumentFragment();
+    let last = 0;
+    let made = false;
+    let m;
+    while ((m = CITATION_RE.exec(text)) !== null) {
+      if (m.index > last) fragment.appendChild(document.createTextNode(text.slice(last, m.index)));
+      const scope = m[1] || 'global';
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'citation-chip';
+      chip.dataset.citationScope = scope;
+      chip.dataset.citationPath = m[2];
+      chip.dataset.citationChunk = m[3];
+      chip.textContent = m[0];
+      chip.title = `跳转到原文：${m[2]} 第 ${m[3]} 块`;
+      fragment.appendChild(chip);
+      made = true;
+      last = m.index + m[0].length;
+    }
+    if (!made) return;
+    if (last < text.length) fragment.appendChild(document.createTextNode(text.slice(last)));
+    textNode.parentNode.replaceChild(fragment, textNode);
+  }
+
+  function linkify(root) {
+    if (!root) return;
+    if (processed.has(root)) return;
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const parent = node.parentNode;
+        if (!parent) return NodeFilter.FILTER_REJECT;
+        if (_skipNode(parent)) return NodeFilter.FILTER_REJECT;
+        // Only walk text directly under a markdown body, not nested bubbles.
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+    const targets = [];
+    let n;
+    while ((n = walker.nextNode())) targets.push(n);
+    for (const t of targets) _linkifyTextNode(t);
+    processed.add(root);
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mut of mutations) {
+      for (const added of mut.addedNodes) {
+        if (added.nodeType !== Node.ELEMENT_NODE) continue;
+        if (added.classList && added.classList.contains('markdown-body')) {
+          linkify(added);
+        } else {
+          const bodies = added.querySelectorAll ? added.querySelectorAll('.markdown-body') : [];
+          for (const b of bodies) linkify(b);
+        }
+      }
+    }
+  });
+
+  function start() {
+    const history = document.getElementById('chat-history');
+    if (!history) return;
+    observer.observe(history, { childList: true, subtree: true });
+    // Linkify whatever is already rendered.
+    history.querySelectorAll('.markdown-body').forEach(linkify);
+  }
+
+  document.addEventListener('click', (e) => {
+    const chip = e.target.closest ? e.target.closest('[data-citation-chunk]') : null;
+    if (!chip) return;
+    e.preventDefault();
+    const scope = chip.dataset.citationScope || 'global';
+    if (scope === 'attachment') return; // needs cid — not resolvable from the chip yet
+    window.__openAnchorViewer({
+      source: 'library',
+      scope,
+      path: chip.dataset.citationPath,
+      chunkIdx: Number(chip.dataset.citationChunk),
+    });
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/src/renderer/modules/kb-discover.js
+++ b/src/renderer/modules/kb-discover.js
@@ -1,0 +1,175 @@
+// ─── 知识库生态 · 发现面板（S4）— classic script (window.renderKbDiscover) ───
+// 计划书 v1.3 §四.8/9：知识库市场（精选/分类/推荐）+ MCP 市场 + Skills 市场。
+// 市场数据为**内置自造示例**（不搬运外部内容，不出现 ima 字样）；Skills 列表
+// 反映本地已装技能（resources/builtin/system/skills 的真实能力名）。
+(function () {
+  function _esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  const FEATURED = [
+    { name: '地方法规知识库', desc: '收录全国各地区地方法规，包含地方性法规、自治条例与实施细则。', subs: '2.1万', cnt: '100万', src: '法律数据组' },
+    { name: 'AI+X Elite 20 案例库', desc: '历届 AI+X 项目真实案例：从需求征集到挑战落地的完整路径。', subs: '1.4万', cnt: '5.5万', src: 'AI+X 社区' },
+    { name: 'CogSeed 使用手册合集', desc: '开源社区整理的 CogSeed 玩法：知识库、Agent、Skills 配置。', subs: '1.4万', cnt: '5.6万', src: 'CogSeed 社区' },
+    { name: '班级管理方法论', desc: '学生自治 + AI 协作的班级管理实践合集，含月度更新。', subs: '3.6万', cnt: '5.2万', src: '教育实践组' },
+  ];
+  const MARKET = [
+    { name: 'AI 知识库·入门', desc: '分享 AI 的最新知识和资料，一起赶上 AI 大浪潮', subs: '8417', cnt: '94', src: '陈老师AIHome' },
+    { name: 'AI 做副业', desc: '分享 AI 怎么用来做副业，完整资料合集', subs: '1.0万', cnt: '36', src: '清晰者' },
+    { name: '人民法院案例库', desc: '【官方原版同步更新】收录人民法院案例', subs: '1.1万', cnt: '5538', src: '壹典法阅' },
+    { name: '国家智慧教育平台资料', desc: '共同学习国家中小学智慧教育平台', subs: '6767', cnt: '242', src: '大眼鱼' },
+    { name: '研究股票池', desc: '持续追踪优质上市公司研究资料', subs: '1.0万', cnt: '1707', src: '千研' },
+    { name: '全过程工程咨询实战', desc: '遴选权威公众资讯，融合专业知识', subs: '5754', cnt: '6.5万', src: '诚城' },
+    { name: 'PPT 模板免费下载', desc: '各行业 PPT 模板精选', subs: '2.3万', cnt: '147', src: '无忧哥' },
+    { name: '数学人生', desc: '数学知识分享与讨论社区', subs: '8613', cnt: '4520', src: '数学人生' },
+    { name: '科技前沿周报', desc: '每周精选 AI / 芯片 / 航天领域前沿进展', subs: '7210', cnt: '310', src: '前沿观察' },
+    { name: 'A股港股研报分享', desc: '研报隔离更新，出于版权原因不公开', subs: '6609', cnt: '1.5万', src: '投研面包树' },
+  ];
+  const MCPS = [
+    { icon: '📈', name: '进门投研', desc: '覆盖券商研究所、上市公司、资管机构公开路演内容', n1: '95', n2: '15', src: '进门' },
+    { icon: '🏢', name: '启信慧眼', desc: '企业全景数据：企业搜索、工商画像、风险识别', n1: '779', n2: '22', src: '启信慧眼' },
+    { icon: '⚖️', name: '法律数据', desc: '检索与核验中国法律法规和司法案例', n1: '4240', n2: '61', src: '法律平台' },
+    { icon: '📊', name: '指数估值分析', desc: '沪深指数估值分析工具接口', n1: '1.4万', n2: '122', src: '券商' },
+    { icon: '💹', name: '财务分析', desc: 'A 股财务数据对比分析', n1: '9810', n2: '33', src: '券商' },
+    { icon: '📜', name: '龙虎榜', desc: '沪深股市龙虎榜数据分析', n1: '7978', n2: '39', src: '券商' },
+    { icon: '🧾', name: '热门 ETF 榜单', desc: '沪深市场 ETF 热点排行', n1: '8619', n2: '48', src: '券商' },
+    { icon: '🔮', name: '智能投研套件', desc: '自然语言查询的金融投研工具套件', n1: '8406', n2: '127', src: '投研平台' },
+    { icon: '🧬', name: '专利&文献融合检索', desc: '融合专利与科技文献的跨库检索与语义分析', n1: '3201', n2: '58', src: '智慧芽' },
+    { icon: '📚', name: '企业全景查询', desc: '企业工商信息、司法风险、经营动态全景查询', n1: '5210', n2: '74', src: '企查平台' },
+  ];
+  const SKILLS = [
+    { icon: '🧩', name: 'grounded-material-qa', desc: '资料边界内的可靠问答与答案核验（COGSEED-39 已合入 develop）' },
+    { icon: '🌐', name: 'web-search', desc: '联网检索资料，纳入资料边界后可参与问答' },
+    { icon: '📄', name: 'pdf-reader', desc: 'PDF 解析与锚点定位' },
+    { icon: '🖼', name: 'image-analyze', desc: '图片 OCR 与视觉理解' },
+  ];
+  const TAGS = ['推荐', '科技', '教育', '职场', '财经', '产业', '健康', '法律', '人文', '生活'];
+
+  const _state = { rendered: false, list: [...MARKET], tag: '推荐' };
+
+  function renderKbDiscover() {
+    const host = document.getElementById('kb-discover');
+    if (!host || host.querySelector('.kb-discover')) return;
+    _state.rendered = true;
+    host.innerHTML = `
+      <div class="kb-discover">
+        <div class="kb-discover-tabs">
+          <button type="button" class="kb-dtab on" data-kb-mtab="kb">📚 知识库市场</button>
+          <button type="button" class="kb-dtab" data-kb-mtab="mcp">🔌 MCP 市场</button>
+          <button type="button" class="kb-dtab" data-kb-mtab="skills">⚡ Skills 市场</button>
+        </div>
+        <div class="kb-discover-pane" id="kb-dpane-kb"></div>
+        <div class="kb-discover-pane" id="kb-dpane-mcp" hidden></div>
+        <div class="kb-discover-pane" id="kb-dpane-skills" hidden></div>
+      </div>`;
+    host.querySelectorAll('[data-kb-mtab]').forEach((b) => b.addEventListener('click', () => {
+      host.querySelectorAll('[data-kb-mtab]').forEach((x) => x.classList.toggle('on', x === b));
+      host.querySelectorAll('.kb-discover-pane').forEach((p) => { p.hidden = p.id !== `kb-dpane-${b.dataset.kbMtab}`; });
+    }));
+    _renderMarket();
+    _renderMcp();
+    _renderSkills();
+  }
+
+  function _renderMarket() {
+    const pane = document.getElementById('kb-dpane-kb');
+    if (!pane) return;
+    pane.innerHTML = `
+      <div class="kb-market-head">
+        <div class="kb-market-search">⌕ <input id="kb-market-q" placeholder="搜索知识库" autocomplete="off"><span class="kb-market-shuffle" id="kb-market-shuffle">换一换</span></div>
+        <button type="button" class="kb-wb-icon-btn" id="kb-market-notify" title="通知">🔔</button>
+      </div>
+      <div class="kb-market-sec"><div class="kb-market-sec-title">✨ 精选</div><div class="kb-market-featured" id="kb-market-featured"></div></div>
+      <div class="kb-market-sec"><div class="kb-market-sec-title">推荐分类</div><div class="kb-market-tags" id="kb-market-tags"></div></div>
+      <div class="kb-market-sec"><div class="kb-market-sec-title">🔥 推荐知识库</div><div class="kb-market-grid" id="kb-market-grid"></div></div>`;
+    // 精选
+    const feat = document.getElementById('kb-market-featured');
+    feat.innerHTML = FEATURED.map((x) => `
+      <div class="kb-market-card is-feat" data-kb-sub="${_esc(x.name)}">
+        <div class="kb-market-card-name">📖 ${_esc(x.name)}</div>
+        <div class="kb-market-card-desc">${_esc(x.desc)}</div>
+        <div class="kb-market-card-meta"><b>${x.subs}</b>人已订阅｜<b>${x.cnt}</b>个内容｜@<span class="kb-market-card-src">${_esc(x.src)}</span></div>
+      </div>`).join('');
+    // 标签
+    const tags = document.getElementById('kb-market-tags');
+    tags.innerHTML = TAGS.map((t) => `<span class="kb-market-tag${t === '推荐' ? ' on' : ''}" data-tag="${_esc(t)}">${_esc(t)}</span>`).join('');
+    tags.querySelectorAll('[data-tag]').forEach((el) => el.addEventListener('click', () => {
+      _state.tag = el.dataset.tag;
+      tags.querySelectorAll('[data-tag]').forEach((x) => x.classList.toggle('on', x === el));
+      _renderMarketList();
+    }));
+    document.getElementById('kb-market-q')?.addEventListener('input', _renderMarketList);
+    document.getElementById('kb-market-shuffle')?.addEventListener('click', () => {
+      for (let i = _state.list.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [_state.list[i], _state.list[j]] = [_state.list[j], _state.list[i]];
+      }
+      _renderMarketList();
+      _toast('已换一批推荐');
+    });
+    document.getElementById('kb-market-notify')?.addEventListener('click', () => {
+      _toast('通知：你订阅的「开源社区·CogSeed 使用手册」已更新 3 个内容');
+    });
+    feat.querySelectorAll('[data-kb-sub]').forEach((el) => el.addEventListener('click', () => _toast(`订阅知识库：${el.dataset.kbSub}`)));
+    _renderMarketList();
+  }
+
+  function _renderMarketList() {
+    const grid = document.getElementById('kb-market-grid');
+    if (!grid) return;
+    const q = (document.getElementById('kb-market-q')?.value || '').trim().toLowerCase();
+    const list = _state.list.filter((x) => {
+      const okTag = _state.tag === '推荐' || x.name.includes(_state.tag) || x.desc.includes(_state.tag);
+      return okTag && (!q || x.name.toLowerCase().includes(q) || x.desc.toLowerCase().includes(q));
+    });
+    grid.innerHTML = list.length ? list.map((x) => `
+      <div class="kb-market-card" data-kb-open="${_esc(x.name)}">
+        <div class="kb-market-card-name">📚 ${_esc(x.name)}</div>
+        <div class="kb-market-card-desc">${_esc(x.desc)}</div>
+        <div class="kb-market-card-meta"><b>${x.subs}</b>人已订阅｜<b>${x.cnt}</b>个内容｜@<span class="kb-market-card-src">${_esc(x.src)}</span></div>
+      </div>`).join('')
+      : '<div class="kb-market-empty">没有匹配的知识库</div>';
+    grid.querySelectorAll('[data-kb-open]').forEach((el) => el.addEventListener('click', () => _toast(`打开知识库：${el.dataset.kbOpen}`)));
+  }
+
+  function _renderMcp() {
+    const pane = document.getElementById('kb-dpane-mcp');
+    if (!pane) return;
+    pane.innerHTML = `
+      <div class="kb-market-sec-title">🔁 MCP</div>
+      <div class="kb-market-sub">接入可用的 MCP 工具，点击 ＋ 添加到你的智能体。</div>
+      <div class="kb-mcp-grid">${MCPS.map((m) => `
+        <div class="kb-mcp-card">
+          <button type="button" class="kb-mcp-add" data-kb-mcp="${_esc(m.name)}">＋</button>
+          <div class="kb-mcp-icon">${m.icon}</div>
+          <div class="kb-mcp-name">${_esc(m.name)}</div>
+          <div class="kb-mcp-desc">${_esc(m.desc)}</div>
+          <div class="kb-mcp-foot"><span><span class="kb-mcp-num">${m.n1}</span> 使用 · <span class="kb-mcp-num">${m.n2}</span> 收藏</span><span class="kb-mcp-src">${_esc(m.src)}</span></div>
+        </div>`).join('')}
+      </div>`;
+    pane.querySelectorAll('[data-kb-mcp]').forEach((el) => el.addEventListener('click', () => _toast(`已添加「${el.dataset.kbMcp}」到智能体`, 'success')));
+  }
+
+  function _renderSkills() {
+    const pane = document.getElementById('kb-dpane-skills');
+    if (!pane) return;
+    pane.innerHTML = `
+      <div class="kb-market-sec-title">⚡ Skills 市场</div>
+      <div class="kb-market-sub">已安装的技能来自本地 resources/builtin/system/skills 目录；安装更多技能即将开放。</div>
+      <div class="kb-skills-list">${SKILLS.map((s) => `
+        <div class="kb-skill-item">
+          <div class="kb-skill-icon">${s.icon}</div>
+          <div><div class="kb-skill-name">${_esc(s.name)}</div><div class="kb-skill-desc">${_esc(s.desc)}</div></div>
+          <span class="kb-skill-state">✓ 已安装</span>
+        </div>`).join('')}
+      </div>`;
+  }
+
+  function _toast(msg, variant) {
+    if (typeof uiToast === 'function') uiToast(msg, variant ? { variant } : undefined);
+  }
+
+  window.renderKbDiscover = renderKbDiscover;
+})();

--- a/src/renderer/modules/kb-eco.js
+++ b/src/renderer/modules/kb-eco.js
@@ -1,0 +1,86 @@
+// ─── 知识库生态外壳（rail + 子视图容器）— classic script (window.renderKbEco) ───
+// 计划书 v1.3 §四.1：总入口 = 侧边栏「自动化」后「知识库」按钮 → 进入知识库生态，
+// 生态内 52px rail（知识库/笔记/发现/浏览/Agent/菜单）细分各子视图。
+// S1：知识库=已落地（绿点）；笔记/发现=S4（灰点）；浏览/Agent/菜单=预留（灰点）。
+(function () {
+  const ECO_NAV = [
+    { key: 'kb', icon: 'book-open', label: '知识库', status: 'ok' },
+    { key: 'notes', icon: 'file-text', label: '笔记', status: 'ok' },
+    { key: 'discover', icon: 'sparkles', label: '发现', status: 'ok' },
+    { key: 'browse', icon: 'globe', label: '浏览 · 预留', status: 'soon' },
+  ];
+  const ECO_TAIL = [
+    { key: 'agent', icon: 'brain-circuit', label: 'Agent 工作台 · 预留', status: 'soon' },
+    { key: 'menu', icon: 'settings', label: '菜单 · 预留', status: 'soon' },
+  ];
+
+  function _kbIcon(name) {
+    if (typeof window.uiIconHtml === 'function') {
+      return window.uiIconHtml(name, 'kb-rail-icon');
+    }
+    return '<span class="kb-rail-icon">◈</span>';
+  }
+
+  function _navBtn(item, active) {
+    return `<button type="button" class="kb-rail-btn${active ? ' active' : ''}" data-kb-eco="${item.key}"
+      title="${item.label}" aria-label="${item.label}">
+      <span class="kb-sdot is-${item.status}"></span>${_kbIcon(item.icon)}</button>`;
+  }
+
+  function renderKbEco() {
+    const host = document.getElementById('kb-view');
+    if (!host || host.querySelector('.kb-eco')) return;
+    const nav = ECO_NAV.map((b, i) => _navBtn(b, i === 0)).join('');
+    const tail = ECO_TAIL.map((b) => _navBtn(b, false)).join('');
+    host.innerHTML = `<div class="kb-eco">
+      <nav class="kb-rail">${nav}<div class="kb-rail-spacer"></div>${tail}</nav>
+      <div class="kb-eco-body">
+        <div class="kb-workbench" id="kb-workbench"></div>
+        <div class="kb-eco-pane" id="kb-notes" hidden></div>
+        <div class="kb-eco-pane" id="kb-discover" hidden></div>
+      </div>
+    </div>`;
+    host.querySelectorAll('[data-kb-eco]').forEach((btn) => {
+      btn.addEventListener('click', () => _activateEco(btn.dataset.kbEco));
+    });
+  }
+
+  function _activateEco(key) {
+    document.querySelectorAll('[data-kb-eco]').forEach((b) => {
+      b.classList.toggle('active', b.dataset.kbEco === key);
+    });
+    const wb = document.getElementById('kb-workbench');
+    const notes = document.getElementById('kb-notes');
+    const disc = document.getElementById('kb-discover');
+    if (key === 'kb') {
+      if (wb) wb.hidden = false;
+      if (notes) notes.hidden = true;
+      if (disc) disc.hidden = true;
+      return;
+    }
+    if (key === 'notes') {
+      if (wb) wb.hidden = true;
+      if (disc) disc.hidden = true;
+      if (notes) {
+        notes.hidden = false;
+        if (typeof renderKbNotes === 'function') renderKbNotes();
+      }
+      return;
+    }
+    if (key === 'discover') {
+      if (wb) wb.hidden = true;
+      if (notes) notes.hidden = true;
+      if (disc) {
+        disc.hidden = false;
+        if (typeof renderKbDiscover === 'function') renderKbDiscover();
+      }
+      return;
+    }
+    const item = [...ECO_NAV, ...ECO_TAIL].find((b) => b.key === key);
+    if (typeof uiToast === 'function') {
+      uiToast(`「${item ? item.label : key}」模块预留`, { variant: 'info' });
+    }
+  }
+
+  window.renderKbEco = renderKbEco;
+})();

--- a/src/renderer/modules/kb-notes.js
+++ b/src/renderer/modules/kb-notes.js
@@ -1,0 +1,221 @@
+// ─── 知识库生态 · 笔记面板（S4）— classic script (window.renderKbNotes) ───
+// 计划书 v1.3 §四.7：笔记列表（新建/删除）+ 富文本编辑器（工具栏/标题层级）
+// + ✨AI帮写（复用 kbqa.askStream，基于当前知识库流式生成草稿插入编辑器）。
+// 存储：contexts 下 notes/ 目录（contexts.mkdir/write/read/delete），纯文本 md。
+(function () {
+  function _esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  const _state = { rendered: false, notes: [], current: '' };
+
+  function _toast(msg, variant) {
+    if (typeof uiToast === 'function') uiToast(msg, variant ? { variant } : undefined);
+  }
+
+  function renderKbNotes() {
+    const host = document.getElementById('kb-notes');
+    if (!host) return;
+    if (!_state.rendered) {
+      _state.rendered = true;
+      host.innerHTML = `
+        <div class="kb-notes">
+          <aside class="kb-notes-list">
+            <div class="kb-notes-list-head"><h2>笔记</h2><button type="button" class="kb-wb-icon-btn" id="kb-notes-new" title="新建笔记">＋</button></div>
+            <div class="kb-notes-items" id="kb-notes-items"></div>
+          </aside>
+          <section class="kb-notes-editor">
+            <div class="kb-notes-toolbar">
+              <button type="button" class="ed-btn" data-cmd="undo" title="撤回">↩</button>
+              <button type="button" class="ed-btn" data-cmd="redo" title="重做">↪</button>
+              <span class="kb-sep"></span>
+              <button type="button" class="ed-btn bold" data-cmd="bold" title="加粗">B</button>
+              <button type="button" class="ed-btn italic" data-cmd="italic" title="斜体">I</button>
+              <button type="button" class="ed-btn underline" data-cmd="underline" title="下划线">U</button>
+              <span class="kb-sep"></span>
+              <div class="kb-ed-dropdown">
+                <button type="button" class="ed-btn" id="kb-notes-head" title="标题层级">标题 <span class="kb-caret">▾</span></button>
+                <div class="kb-ed-menu" id="kb-notes-head-menu">
+                  <div class="kb-ed-mi" data-fb="h1" style="font-size:16px;font-weight:700">标题 1</div>
+                  <div class="kb-ed-mi" data-fb="h2" style="font-size:14px;font-weight:600">标题 2</div>
+                  <div class="kb-ed-mi" data-fb="h3" style="font-size:13px;font-weight:600">标题 3</div>
+                  <div class="kb-ed-mi" data-fb="p">正文</div>
+                </div>
+              </div>
+              <span class="kb-sep"></span>
+              <button type="button" class="ed-btn" data-cmd="insertUnorderedList" title="列表">☰</button>
+              <div class="kb-notes-toolbar-right">
+                <button type="button" class="kb-wb-a-btn" id="kb-notes-ai" title="基于知识库生成/续写">✨ AI帮写</button>
+                <button type="button" class="kb-wb-a-btn" id="kb-notes-save" title="保存 (Cmd/Ctrl+S)">保存</button>
+                <button type="button" class="kb-wb-a-btn kb-danger" id="kb-notes-del" title="删除当前笔记">删除</button>
+              </div>
+            </div>
+            <div class="kb-notes-body"><div class="kb-notes-edit" id="kb-notes-edit" contenteditable="true"><p>选择左侧笔记，或点击 ＋ 新建。</p></div></div>
+          </section>
+        </div>`;
+      host.querySelectorAll('[data-cmd]').forEach((b) => b.addEventListener('click', () => {
+        document.execCommand(b.dataset.cmd);
+        document.getElementById('kb-notes-edit')?.focus();
+      }));
+      host.querySelectorAll('#kb-notes-head-menu .kb-ed-mi').forEach((mi) => mi.addEventListener('click', () => {
+        document.execCommand('formatBlock', false, mi.dataset.fb);
+        document.getElementById('kb-notes-head-menu').classList.remove('show');
+      }));
+      document.getElementById('kb-notes-head')?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        document.getElementById('kb-notes-head-menu')?.classList.toggle('show');
+      });
+      document.getElementById('kb-notes-new')?.addEventListener('click', _newNote);
+      document.getElementById('kb-notes-save')?.addEventListener('click', _save);
+      document.getElementById('kb-notes-ai')?.addEventListener('click', _aiWrite);
+      document.getElementById('kb-notes-del')?.addEventListener('click', _deleteNote);
+      document.addEventListener('click', (e) => {
+        if (!e.target.closest('.kb-ed-dropdown')) document.getElementById('kb-notes-head-menu')?.classList.remove('show');
+      });
+      document.addEventListener('keydown', (e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+          const ed = document.getElementById('kb-notes-edit');
+          if (ed && ed.dataset.note) { e.preventDefault(); _save(); }
+        }
+      });
+    }
+    _loadNotes();
+  }
+
+  async function _loadNotes() {
+    if (!window.cogseed || typeof window.cogseed.invoke !== 'function') return;
+    try {
+      const res = await window.cogseed.invoke('contexts.tree');
+      const tree = (res && Array.isArray(res.tree)) ? res.tree : [];
+      const notesDir = tree.find((n) => n.type === 'dir' && n.name === 'notes');
+      _state.notes = notesDir
+        ? (notesDir.children || []).filter((n) => n.type === 'file').sort((a, b) => a.name.localeCompare(b.name))
+        : [];
+      _renderList();
+    } catch (err) { /* ignore */ }
+  }
+
+  function _renderList() {
+    const box = document.getElementById('kb-notes-items');
+    if (!box) return;
+    if (!_state.notes.length) {
+      box.innerHTML = '<div class="kb-notes-empty">暂无笔记，点击 ＋ 新建</div>';
+      return;
+    }
+    box.innerHTML = '';
+    for (const n of _state.notes) {
+      const d = document.createElement('div');
+      d.className = 'kb-notes-item' + (n.name === _state.current ? ' active' : '');
+      d.textContent = n.name.replace(/\.md$/, '');
+      d.addEventListener('click', () => _openNote(n.name));
+      box.appendChild(d);
+    }
+  }
+
+  async function _openNote(name) {
+    _state.current = name;
+    _renderList();
+    const ed = document.getElementById('kb-notes-edit');
+    if (!ed) return;
+    try {
+      const res = await window.cogseed.invoke('contexts.read', { path: `notes/${name}` });
+      const content = (res && res.ok !== false && typeof res.content === 'string') ? res.content : '';
+      ed.innerHTML = content ? _esc(content).split('\n').map((l) => l.trim() ? `<p>${_esc(l)}</p>` : '<p><br></p>').join('') : '<p><br></p>';
+      ed.dataset.note = name;
+    } catch (err) {
+      _toast('打开失败：' + ((err && err.message) || String(err)), 'error');
+    }
+  }
+
+  async function _newNote() {
+    let title = null;
+    try {
+      title = typeof uiPrompt === 'function' ? await uiPrompt('笔记标题：') : window.prompt('笔记标题：');
+    } catch (_) { return; }
+    if (!title || !title.trim()) return;
+    const clean = title.trim().replace(/[\/\\]/g, '-');
+    try {
+      const tree = await window.cogseed.invoke('contexts.tree');
+      const hasNotes = (tree && Array.isArray(tree.tree)) ? tree.tree.some((n) => n.type === 'dir' && n.name === 'notes') : false;
+      if (!hasNotes) await window.cogseed.invoke('contexts.mkdir', { path: 'notes' });
+      const name = `${clean}.md`;
+      await window.cogseed.invoke('contexts.write', { path: `notes/${name}`, content: `# ${clean}\n` });
+      await _loadNotes();
+      await _openNote(name);
+    } catch (err) {
+      _toast('新建失败：' + ((err && err.message) || String(err)), 'error');
+    }
+  }
+
+  async function _save() {
+    if (!_state.current) return;
+    const ed = document.getElementById('kb-notes-edit');
+    if (!ed) return;
+    try {
+      await window.cogseed.invoke('contexts.write', {
+        path: `notes/${_state.current}`,
+        content: ed.innerText,
+      });
+      _toast('已保存', 'success');
+    } catch (err) {
+      _toast('保存失败：' + ((err && err.message) || String(err)), 'error');
+    }
+  }
+
+  async function _deleteNote() {
+    if (!_state.current) return;
+    if (typeof uiConfirm === 'function') {
+      const ok = await uiConfirm(`删除笔记「${_state.current}」？`);
+      if (!ok) return;
+    } else if (!window.confirm(`删除笔记「${_state.current}」？`)) {
+      return;
+    }
+    try {
+      await window.cogseed.invoke('contexts.delete', { path: `notes/${_state.current}` });
+      _state.current = '';
+      await _loadNotes();
+      const ed = document.getElementById('kb-notes-edit');
+      if (ed) { ed.innerHTML = '<p>选择左侧笔记，或点击 ＋ 新建。</p>'; delete ed.dataset.note; }
+      _toast('已删除', 'success');
+    } catch (err) {
+      _toast('删除失败：' + ((err && err.message) || String(err)), 'error');
+    }
+  }
+
+  // ✨ AI帮写：基于当前知识库（kbqa.askStream）流式生成草稿插入编辑器末尾。
+  function _aiWrite() {
+    const ed = document.getElementById('kb-notes-edit');
+    if (!ed) return;
+    if (!window.cogseed || typeof window.cogseed.stream !== 'function') {
+      _toast('问答服务不可用', 'warning');
+      return;
+    }
+    const title = _state.current ? _state.current.replace(/\.md$/, '') : '知识库笔记';
+    const prompt = `请基于当前知识库的内容，为笔记「${title}」写一段约 100 字的草稿，直接输出正文内容，不要额外解释。`;
+    if (!ed.innerText.trim() || ed.dataset.note === undefined) {
+      // 没有打开笔记时也允许生成：追加到空编辑器
+    }
+    const tail = document.createElement('div');
+    tail.className = 'kb-notes-ai-draft';
+    ed.appendChild(tail);
+    ed.scrollTop = ed.scrollHeight;
+    try {
+      const handle = window.cogseed.stream('kbqa.askStream', { question: prompt, space_id: null, k: 8 }, (ev) => {
+        if (!ev) return;
+        if (ev.type === 'delta' && ev.text) {
+          tail.textContent += ev.text;
+          ed.scrollTop = ed.scrollHeight;
+        } else if (ev.type === 'error') {
+          tail.textContent += '\n[生成失败]';
+        }
+      });
+      if (handle && handle.promise) handle.promise.catch(() => { /* ignore */ });
+    } catch (err) {
+      tail.textContent = '\n[生成失败：' + ((err && err.message) || String(err)) + ']';
+    }
+  }
+
+  window.renderKbNotes = renderKbNotes;
+})();

--- a/src/renderer/modules/kb-workbench.js
+++ b/src/renderer/modules/kb-workbench.js
@@ -1,0 +1,779 @@
+// ─── 知识库工作台（三栏骨架：库树 / 文件列表 / 右区占位）— classic script ───
+// 计划书 v1.3 S1：库树 = contexts.tree 顶层目录（个人库，＋ 创建 = contexts.mkdir）；
+// 文件列表 = ContextNode（文件夹可下钻 + 面包屑）+ kb 状态（kb.status 快照 +
+// kb.events 流实时更新索引 chips）；右区 AI 解析/问答 = S2/S3 上线（占位）。
+(function () {
+  const _log = typeof createLogger === 'function' ? createLogger('kb-workbench') : console;
+
+  const _state = {
+    tree: [],
+    kbStatus: new Map(), // relPath -> { status, chunks, kind, error }
+    libs: [],
+    currentLib: '',
+    dirStack: [], // 相对库根的目录路径段（'' = 库根）
+    filter: '',
+    sort: 'name', // name | type
+    rendered: false,
+    streamHandle: null,
+    loading: false,
+    summaryLib: '',
+    summary: null,
+    spaces: [],
+    spaceId: null,
+    spaceName: '',
+    spaceFiles: [],
+  };
+
+  const _TYPE_LABEL = { pdf: 'PDF', excel: 'EXCEL', ppt: 'PPT', img: '图片', word: 'WORD', txt: 'TXT' };
+
+  function _esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function _extClass(name) {
+    const ext = String(name).split('.').pop().toLowerCase();
+    if (ext === 'pdf') return 'pdf';
+    if (['xlsx', 'xlsm', 'xls', 'csv', 'tsv'].includes(ext)) return 'excel';
+    if (['pptx', 'pptm', 'ppt'].includes(ext)) return 'ppt';
+    if (['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg', 'bmp'].includes(ext)) return 'img';
+    if (['docx', 'doc', 'md', 'markdown', 'txt', 'log'].includes(ext)) return 'word';
+    return 'txt';
+  }
+
+  function _extLabel(name) {
+    const ext = String(name).split('.').pop().toLowerCase();
+    if (ext === 'pdf') return _TYPE_LABEL.pdf;
+    if (['xlsx', 'xlsm', 'xls', 'csv', 'tsv'].includes(ext)) return _TYPE_LABEL.excel;
+    if (['pptx', 'pptm', 'ppt'].includes(ext)) return _TYPE_LABEL.ppt;
+    if (['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg', 'bmp'].includes(ext)) return _TYPE_LABEL.img;
+    if (['docx', 'doc'].includes(ext)) return _TYPE_LABEL.word;
+    return _TYPE_LABEL.txt;
+  }
+
+  function _findLibNode(name) {
+    return _state.tree.find((n) => n.type === 'dir' && n.name === name) || null;
+  }
+
+  // 沿 dirStack 下钻到当前目录节点（dirStack 为空 = 库根）
+  function _currentDirNode() {
+    const lib = _findLibNode(_state.currentLib);
+    if (!lib) return null;
+    let node = lib;
+    for (const seg of _state.dirStack) {
+      const next = (node.children || []).find((n) => n.type === 'dir' && n.name === seg);
+      if (!next) return null;
+      node = next;
+    }
+    return node;
+  }
+
+  function _relPath(name) {
+    const base = _state.currentLib;
+    const dirs = _state.dirStack.length ? `${_state.dirStack.join('/')}/` : '';
+    return `${base}/${dirs}${name}`;
+  }
+
+  function _statusChip(relPath) {
+    const st = _state.kbStatus.get(relPath);
+    if (!st) return '<span class="kb-file-status is-none">未索引</span>';
+    if (st.status === 'ready') return `<span class="kb-file-status is-ready" title="chunks: ${st.chunks ?? 0}">✓ 已索引</span>`;
+    if (st.status === 'processing') return '<span class="kb-file-status is-run">索引中…</span>';
+    if (st.status === 'pending') return '<span class="kb-file-status is-run">排队中</span>';
+    if (st.status === 'failed') return '<span class="kb-file-status is-failed" title="' + _esc(st.error || '') + '">失败</span>';
+    return '<span class="kb-file-status is-none">未索引</span>';
+  }
+
+  // ── 数据加载 ──
+  async function _loadAll() {
+    if (_state.loading) return;
+    _state.loading = true;
+    try {
+      const [treeRes, kbRes, spacesRes] = await Promise.all([
+        window.cogseed.invoke('contexts.tree'),
+        window.cogseed.invoke('kb.status').catch(() => null),
+        window.cogseed.invoke('spaces.list').catch(() => null),
+      ]);
+      _state.tree = (treeRes && Array.isArray(treeRes.tree)) ? treeRes.tree : [];
+      _state.libs = _state.tree.filter((n) => n.type === 'dir');
+      _state.spaces = (spacesRes && Array.isArray(spacesRes.spaces)) ? spacesRes.spaces : [];
+      _state.kbStatus = new Map();
+      const files = (kbRes && Array.isArray(kbRes.files)) ? kbRes.files : [];
+      for (const f of files) {
+        if (!f || !f.path) continue;
+        _state.kbStatus.set(f.path, { status: f.status, chunks: f.chunks, kind: f.kind, error: f.error });
+      }
+      if (!_state.libs.some((l) => l.name === _state.currentLib)) {
+        _state.currentLib = _state.libs.length ? _state.libs[0].name : '';
+        _state.dirStack = [];
+      }
+      _renderTree();
+      _renderFiles();
+      _renderRight();
+      _ensureKbStream();
+    } catch (err) {
+      _log.error('kb load failed', err);
+    } finally {
+      _state.loading = false;
+    }
+  }
+
+  // ── 库树 ──
+  function _renderTree() {
+    const tree = document.getElementById('kb-wb-tree');
+    if (!tree) return;
+    const libsHtml = _state.libs.map((l) =>
+      `<div class="kb-tree-item${l.name === _state.currentLib ? ' active' : ''}" data-kb-lib="${_esc(l.name)}">
+        <span class="kb-tree-ico">📚</span><span class="kb-tree-name">${_esc(l.name)}</span></div>`
+    ).join('');
+    const empty = libsHtml ? '' : '<div class="kb-tree-empty">暂无知识库，点击上方 ＋ 创建</div>';
+    const spacesHtml = _state.spaces.map((sp) =>
+      `<div class="kb-tree-item${sp.space_id === _state.spaceId ? ' active' : ''}" data-kb-space="${_esc(sp.space_id)}">
+        <span class="kb-tree-ico">📁</span><span class="kb-tree-name">${_esc(sp.name || sp.space_id)}</span><span class="kb-badge-share">共享</span></div>`
+    ).join('');
+    tree.innerHTML = `
+      <div class="kb-tree-group">
+        <div class="kb-tree-group-label"><span>▶</span><span class="kb-tree-group-name">个人知识库</span><button type="button" class="kb-tree-plus" id="kb-new-lib" title="创建个人知识库">＋</button></div>
+        <div class="kb-tree-items">${libsHtml || empty}</div>
+      </div>
+      <div class="kb-tree-group">
+        <div class="kb-tree-group-label"><span>▶</span><span class="kb-tree-group-name">共享知识库</span></div>
+        <div class="kb-tree-items">${spacesHtml || '<div class="kb-tree-placeholder">暂无共享空间</div>'}</div>
+      </div>
+      <div class="kb-tree-group">
+        <div class="kb-tree-group-label"><span>▶</span><span class="kb-tree-group-name">订阅知识库</span></div>
+        <div class="kb-tree-items"><div class="kb-tree-placeholder">订阅 · S4 上线</div></div>
+      </div>`;
+    tree.querySelectorAll('[data-kb-lib]').forEach((el) => {
+      el.addEventListener('click', () => _selectLib(el.dataset.kbLib));
+    });
+    tree.querySelectorAll('[data-kb-space]').forEach((el) => {
+      el.addEventListener('click', () => _selectSpace(el.dataset.kbSpace));
+    });
+    tree.querySelector('#kb-new-lib')?.addEventListener('click', _createLib);
+  }
+
+  // 共享知识库（空间库）：spaces.files.status 只读浏览 + 问答/解析走 space 模式。
+  function _selectSpace(spaceId) {
+    if (_state.spaceId === spaceId) return;
+    _state.spaceId = spaceId;
+    const sp = _state.spaces.find((x) => x.space_id === spaceId);
+    _state.spaceName = (sp && sp.name) || spaceId;
+    _state.spaceFiles = [];
+    _state.dirStack = [];
+    _state.summaryLib = '';
+    _renderTree();
+    _renderFiles();
+    _renderRight();
+    _clearQa();
+    _loadSpaceFiles(spaceId);
+  }
+
+  async function _loadSpaceFiles(spaceId) {
+    if (!window.cogseed || typeof window.cogseed.invoke !== 'function') return;
+    try {
+      const res = await window.cogseed.invoke('spaces.files.status', { spaceId });
+      if (_state.spaceId !== spaceId) return; // 已切换
+      _state.spaceFiles = (res && Array.isArray(res.files)) ? res.files : [];
+      _renderFiles();
+      _renderRight();
+    } catch (err) {
+      _log.warn('load space files failed', err);
+    }
+  }
+
+  function _selectLib(name) {
+    if (_state.currentLib === name && !_state.spaceId) return;
+    _state.currentLib = name;
+    _state.spaceId = null;
+    _state.spaceFiles = [];
+    _state.dirStack = [];
+    _state.summaryLib = '';
+    _renderTree();
+    _renderFiles();
+    _renderRight();
+    _clearQa();
+  }
+
+  async function _createLib() {
+    let name = null;
+    try {
+      name = typeof uiPrompt === 'function' ? await uiPrompt('新建个人知识库名称：') : window.prompt('新建个人知识库名称：');
+    } catch (_) { /* cancelled */ }
+    if (!name || !name.trim()) return;
+    const clean = name.trim().replace(/[\/\\]/g, '-');
+    try {
+      await window.cogseed.invoke('contexts.mkdir', { path: clean });
+      await _loadAll();
+      _selectLib(clean);
+    } catch (err) {
+      _log.warn('create lib failed', err);
+      if (typeof uiToast === 'function') uiToast('创建失败：' + ((err && err.message) || String(err)), { variant: 'error' });
+    }
+  }
+
+  // ── 文件列表 ──
+  function _renderFiles() {
+    const list = document.getElementById('kb-wb-files');
+    if (!list) return;
+    if (_state.spaceId) {
+      _renderSpaceFiles(list);
+      return;
+    }
+    const dirNode = _currentDirNode();
+    const children = dirNode ? (dirNode.children || []) : [];
+    const q = _state.filter.trim().toLowerCase();
+    const dirs = children.filter((n) => n.type === 'dir').filter((n) => !q || n.name.toLowerCase().includes(q));
+    const files = children
+      .filter((n) => n.type === 'file')
+      .filter((n) => !q || n.name.toLowerCase().includes(q));
+    if (_state.sort === 'type') {
+      files.sort((a, b) => _extLabel(a.name).localeCompare(_extLabel(b.name)) || a.name.localeCompare(b.name));
+    } else {
+      files.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    let html = '';
+    for (const d of dirs) {
+      html += `<div class="kb-file-row is-dir" data-kb-dir="${_esc(d.name)}">
+        <span class="kb-file-icon is-dir">📁</span>
+        <span class="kb-file-name">${_esc(d.name)}</span>
+        <span class="kb-file-meta">${_countFiles(d)} 项</span>
+        <span class="kb-file-actions"><button type="button" class="kb-mini-btn" data-kb-dir-open="${_esc(d.name)}" title="打开">›</button></span>
+      </div>`;
+    }
+    for (const f of files) {
+      const rel = _relPath(f.name);
+      html += `<div class="kb-file-row" data-kb-file="${_esc(rel)}">
+        <span class="kb-file-icon is-${_extClass(f.name)}">${_extLabel(f.name)}</span>
+        <span class="kb-file-name">${_esc(f.name)}</span>
+        <span class="kb-file-meta">${_esc(_extLabel(f.name))}</span>
+        ${_statusChip(rel)}
+        <span class="kb-file-actions"><button type="button" class="kb-mini-btn" title="生成思维导图（S3）">🧠</button><button type="button" class="kb-mini-btn" title="更多">⋯</button></span>
+      </div>`;
+    }
+    if (!dirs.length && !files.length) {
+      html = '<div class="kb-tree-empty">没有更多内容了</div>';
+    }
+    list.innerHTML = html;
+
+    list.querySelectorAll('[data-kb-dir-open]').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        _pushDir(btn.dataset.kbDirOpen);
+      });
+    });
+    list.querySelectorAll('[data-kb-dir]').forEach((el) => {
+      el.addEventListener('click', () => _pushDir(el.dataset.kbDir));
+    });
+    list.querySelectorAll('[data-kb-file]').forEach((el) => {
+      el.addEventListener('click', () => _openFile(el.dataset.kbFile));
+    });
+    _renderCrumb();
+    _renderCount(files.length + dirs.length);
+    _renderRight();
+  }
+
+  function _renderSpaceFiles(list) {
+    const q = _state.filter.trim().toLowerCase();
+    const files = _state.spaceFiles
+      .filter((f) => !q || (f.name || f.path || '').toLowerCase().includes(q))
+      .slice()
+      .sort((a, b) => (a.name || a.path).localeCompare(b.name || b.path));
+    let html = '';
+    for (const f of files) {
+      const status = f.status || 'pending';
+      const chip = status === 'ready'
+        ? `<span class="kb-file-status is-ready" title="chunks: ${f.chunks ?? 0}">✓ 已索引</span>`
+        : status === 'processing' ? '<span class="kb-file-status is-run">索引中…</span>'
+          : status === 'failed' ? '<span class="kb-file-status is-failed" title="' + _esc(f.error || '') + '">失败</span>'
+            : '<span class="kb-file-status is-run">排队中</span>';
+      html += `<div class="kb-file-row" data-kb-space-file="${_esc(f.path || f.name)}">
+        <span class="kb-file-icon is-${_extClass(f.name || f.path)}">${_extLabel(f.name || f.path)}</span>
+        <span class="kb-file-name">${_esc(f.name || f.path)}</span>
+        <span class="kb-file-meta">${_esc(_extLabel(f.name || f.path))}</span>
+        ${chip}
+        <span class="kb-file-actions"><button type="button" class="kb-mini-btn" title="生成思维导图（S3）">🧠</button><button type="button" class="kb-mini-btn" title="更多">⋯</button></span>
+      </div>`;
+    }
+    list.innerHTML = html || '<div class="kb-tree-empty">没有更多内容了</div>';
+    list.querySelectorAll('[data-kb-space-file]').forEach((el) => {
+      el.addEventListener('click', () => {
+        if (typeof uiToast === 'function') uiToast('空间库原文查看：后续版本支持', { variant: 'info' });
+      });
+    });
+    const crumb = document.getElementById('kb-wb-crumb');
+    if (crumb) crumb.hidden = true;
+    const count = document.getElementById('kb-wb-count');
+    if (count) count.textContent = `内容(${files.length})`;
+    _renderRight();
+  }
+
+  function _countFiles(node) {
+    let n = 0;
+    const walk = (x) => {
+      for (const c of (x.children || [])) {
+        if (c.type === 'file') n += 1;
+        else walk(c);
+      }
+    };
+    walk(node);
+    return n;
+  }
+
+  function _pushDir(name) {
+    _state.dirStack.push(name);
+    _renderFiles();
+  }
+
+  function _popDir() {
+    _state.dirStack.pop();
+    _renderFiles();
+  }
+
+  function _renderCrumb() {
+    const crumb = document.getElementById('kb-wb-crumb');
+    if (!crumb) return;
+    if (!_state.dirStack.length) {
+      crumb.hidden = true;
+      return;
+    }
+    crumb.hidden = false;
+    const parts = [`<span class="kb-crumb-link" data-kb-crumb="root">${_esc(_state.currentLib)}</span>`];
+    _state.dirStack.forEach((seg, i) => {
+      parts.push('<span class="kb-crumb-sep">/</span>');
+      if (i === _state.dirStack.length - 1) parts.push(`<span class="kb-crumb-cur">${_esc(seg)}</span>`);
+      else parts.push(`<span class="kb-crumb-link" data-kb-crumb="${i}">${_esc(seg)}</span>`);
+    });
+    crumb.innerHTML = parts.join('');
+    crumb.querySelectorAll('[data-kb-crumb]').forEach((el) => {
+      el.addEventListener('click', () => {
+        const idx = el.dataset.kbCrumb === 'root' ? -1 : Number(el.dataset.kbCrumb);
+        _state.dirStack = idx >= 0 ? _state.dirStack.slice(0, idx + 1) : [];
+        _renderFiles();
+      });
+    });
+  }
+
+  function _renderCount(n) {
+    const el = document.getElementById('kb-wb-count');
+    if (el) el.textContent = `内容(${n})`;
+  }
+
+  function _openFile(relPath) {
+    // S2 接入 anchor-resolver 原文查看器；S1 先提示。
+    if (typeof uiToast === 'function') uiToast('原文查看器：S2 上线（anchor-resolver 已就绪）', { variant: 'info' });
+    _log.info('open file', relPath);
+  }
+
+  // ── 右区（S2：基于知识库问答；AI 解析卡 S3 填充）──
+  function _renderRight() {
+    const body = document.getElementById('kb-wb-right');
+    const isSpace = !!_state.spaceId;
+    const dispName = isSpace ? _state.spaceName : (_state.currentLib || '知识库');
+    const nameEl = document.getElementById('kb-wb-lib-name');
+    if (nameEl) nameEl.textContent = dispName;
+    const tagEl = document.getElementById('kb-wb-lib-tag');
+    if (tagEl) tagEl.textContent = isSpace ? '共享知识库' : '个人知识库';
+    const rightLib = document.getElementById('kb-wb-right-lib');
+    if (rightLib) rightLib.textContent = dispName;
+    if (!body) return;
+    if (!body.querySelector('#kb-qa-messages')) {
+      body.innerHTML = `
+        <div class="kb-wb-right-card" id="kb-wb-analysis-card">
+          <div class="kb-wb-right-card-title">✨ AI 解析本知识库</div>
+          <div class="kb-wb-right-card-sub" id="kb-wb-analysis-sub">当前库：${_esc(_state.currentLib || '—')}</div>
+          <div class="kb-wb-right-placeholder">正在解析…</div>
+        </div>
+        <div class="kb-qa-messages" id="kb-qa-messages"></div>`;
+    }
+    const sub = document.getElementById('kb-wb-analysis-sub');
+    if (sub) {
+      const count = isSpace ? _state.spaceFiles.length : (_findLibNode(_state.currentLib) ? _countFiles(_findLibNode(_state.currentLib)) : 0);
+      sub.textContent = `当前库：${_esc(dispName)} · ${count} 个内容`;
+    }
+    _maybeShowQaHint();
+    _loadSummary();
+  }
+
+  // ── AI 解析（S3：kb.summary → 逐文档要点 + 一句话总结 + 脑图骨架）──
+  function _loadSummary() {
+    const card = document.getElementById('kb-wb-analysis-card');
+    if (!card) return;
+    const lib = _state.currentLib || '';
+    const key = _state.spaceId ? `space:${_state.spaceId}` : lib;
+    if (_state.summaryLib === key) return; // 同一库已解析过（缓存命中）
+    _state.summaryLib = key;
+    if (!window.cogseed || typeof window.cogseed.invoke !== 'function') {
+      card.innerHTML = '<div class="kb-wb-right-card-title">✨ AI 解析本知识库</div><div class="kb-wb-right-placeholder">解析服务不可用</div>';
+      return;
+    }
+    const holder = card.querySelector('.kb-wb-right-placeholder');
+    if (holder) holder.textContent = '正在解析…';
+    window.cogseed.invoke('kb.summary', {
+      dir: _state.spaceId ? null : (lib || null),
+      spaceId: _state.spaceId || null,
+    })
+      .then((res) => { if (res) _renderAnalysis(res); })
+      .catch(() => {
+        const h = card.querySelector('.kb-wb-right-placeholder');
+        if (h) h.textContent = '解析失败，请稍后重试（点击 ⟳ 刷新）。';
+      });
+  }
+
+  function _renderAnalysis(summary) {
+    const card = document.getElementById('kb-wb-analysis-card');
+    if (!card) return;
+    const docs = Array.isArray(summary.docs) ? summary.docs : [];
+    const oneLiner = String(summary.oneLiner || '');
+    const mm = summary.mindmap || {};
+    const hasMm = !!(mm.root && Array.isArray(mm.kids) && mm.kids.length);
+    const srcTag = summary.source === 'cached' ? ' <span class="kb-wb-card-src">(缓存)</span>'
+      : summary.source === 'degraded' ? ' <span class="kb-wb-card-src">(降级)</span>' : '';
+
+    let html = `<div class="kb-wb-right-card-title">✨ AI 解析本知识库${srcTag}</div>`;
+    const degraded = summary.source === 'degraded' && !docs.some((d) => d.text);
+    if (degraded) {
+      html += `<div class="kb-wb-right-placeholder">${_esc(oneLiner || 'AI 解析失败，已降级为文件清单。')}</div>`;
+      if (docs.length) {
+        html += `<div class="kb-wb-doc-list">${docs.map((d) =>
+          `<div class="kb-wb-doc-row"><span class="kb-wb-doc-name">${_esc(d.name)}</span></div>`).join('')}</div>`;
+      }
+      card.innerHTML = html;
+      return;
+    }
+    for (const d of docs) {
+      html += `<div class="kb-wb-doc">
+        <div class="kb-wb-doc-head">
+          <span class="kb-wb-doc-name">${_esc(d.name)}</span>
+          <button type="button" class="kb-qa-chip" data-kb-anchor="${_esc(d.file)}">${_esc(d.file)}#chunk 1 ↗</button>
+        </div>`;
+      if (d.text) html += `<div class="kb-wb-doc-text">${_esc(d.text)}</div>`;
+      html += `</div>`;
+    }
+    if (oneLiner) {
+      html += `<div class="kb-wb-one-liner"><span class="kb-wb-one-liner-tag">💡 一句话总结</span>${_esc(oneLiner)}</div>`;
+    }
+    html += `<div class="kb-wb-a-actions">`;
+    if (hasMm) html += `<button type="button" class="kb-wb-a-btn" id="kb-wb-gen-mm">🧠 生成脑图</button>`;
+    html += `<button type="button" class="kb-wb-a-btn" id="kb-wb-gen-quiz">📝 生成测验</button></div>`;
+    if (hasMm) {
+      html += `<div class="kb-wb-mm"><div class="kb-wb-mm-head">🧠 脑图预览</div>
+        <div class="kb-wb-mm-canvas" id="kb-wb-mm-canvas"><button type="button" class="kb-wb-mm-load" id="kb-wb-mm-load">⬇ 生成</button></div></div>`;
+    }
+    card.innerHTML = html;
+    card.querySelectorAll('[data-kb-anchor]').forEach((el) => {
+      el.addEventListener('click', () => _openAnchor({ source: 'library', scope: 'global', path: el.dataset.kbAnchor, chunkIdx: 1 }));
+    });
+    document.getElementById('kb-wb-gen-mm')?.addEventListener('click', () => _renderMindmap(mm));
+    document.getElementById('kb-wb-mm-load')?.addEventListener('click', () => _renderMindmap(mm));
+    document.getElementById('kb-wb-gen-quiz')?.addEventListener('click', () => _renderQuiz(summary));
+    _state.summary = summary;
+  }
+
+  function _renderMindmap(mm) {
+    const canvas = document.getElementById('kb-wb-mm-canvas');
+    if (!canvas) return;
+    canvas.classList.add('is-loading');
+    canvas.innerHTML = '';
+    setTimeout(() => {
+      canvas.classList.remove('is-loading');
+      canvas.innerHTML = _mmSvg(mm);
+    }, 700);
+  }
+
+  function _mmSvg(m) {
+    const kids = Array.isArray(m.kids) ? m.kids : [];
+    let y = 105 - (kids.length - 1) * 30;
+    let nodes = '';
+    for (const k of kids) {
+      const bw = Math.min(220, String(k).length * 12 + 24);
+      nodes += `<g><path d="M120 105 L150 ${y + 22}" stroke="#cbd5e1" fill="none"/><rect x="150" y="${y}" width="${bw}" height="44" rx="10" fill="#eaf2ff" stroke="#bfdbfe"/><text x="${150 + bw / 2}" y="${y + 27}" text-anchor="middle" font-size="12" fill="#1e40af">${_esc(k)}</text></g>`;
+      y += 60;
+    }
+    return `<svg class="kb-wb-mm-svg" viewBox="0 0 420 210" xmlns="http://www.w3.org/2000/svg"><rect x="18" y="88" width="104" height="34" rx="17" fill="#3b82f6"/><text x="70" y="110" text-anchor="middle" font-size="13" fill="#fff">${_esc(m.root || '')}</text>${nodes}</svg>`;
+  }
+
+  // ── 测验简版（S3）：基于解析结果出 3 道判断题/选择题，卡内自检 ──
+  function _renderQuiz(summary) {
+    const card = document.getElementById('kb-wb-analysis-card');
+    if (!card) return;
+    const docs = (summary.docs || []).filter((d) => d.text);
+    const base = summary.oneLiner || (docs[0] ? docs[0].text : '');
+    const qs = [
+      { q: '这个知识库的核心主题是？', options: [base.slice(0, 24) || '主题 X', '与资料无关的干扰项', '另一干扰项'], answer: 0 },
+      { q: '引用锚点的格式是？', options: ['path#chunk N', 'page N', '无引用'], answer: 0 },
+      { q: '资料中没有的内容，正确做法是？', options: ['明确说未找到', '自行编造', '联网搜索代替'], answer: 0 },
+    ];
+    let html = `<div class="kb-wb-quiz"><div class="kb-wb-quiz-title">📝 测验（简版）</div>`;
+    qs.forEach((item, i) => {
+      html += `<div class="kb-wb-quiz-q" data-q="${i}"><div class="kb-wb-quiz-qtext">${i + 1}. ${_esc(item.q)}</div>`;
+      item.options.forEach((opt, j) => {
+        html += `<button type="button" class="kb-wb-quiz-opt" data-q="${i}" data-opt="${j}">${_esc(opt)}</button>`;
+      });
+      html += `</div>`;
+    });
+    html += `<div class="kb-wb-quiz-foot"><button type="button" class="kb-wb-a-btn" id="kb-wb-quiz-close">关闭</button></div></div>`;
+    card.insertAdjacentHTML('beforeend', html);
+    card.querySelectorAll('[data-opt]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const q = Number(btn.dataset.q);
+        const opt = Number(btn.dataset.opt);
+        const correct = qs[q].answer === opt;
+        const qEl = card.querySelector(`[data-q="${q}"].kb-wb-quiz-q`);
+        qEl.querySelectorAll('.kb-wb-quiz-opt').forEach((b, j) => {
+          b.classList.add(j === qs[q].answer ? 'is-correct' : 'is-wrong');
+          b.disabled = true;
+        });
+        if (!correct && typeof uiToast === 'function') uiToast('再想想——再选一次？', { variant: 'warning' });
+      });
+    });
+    card.querySelector('#kb-wb-quiz-close')?.addEventListener('click', () => {
+      card.querySelector('.kb-wb-quiz')?.remove();
+    });
+  }
+
+  function _maybeShowQaHint() {
+    const box = document.getElementById('kb-qa-messages');
+    if (!box) return;
+    const hasMsg = !!box.querySelector('.kb-qa-msg');
+    const hint = box.querySelector('.kb-qa-hint');
+    if (!hasMsg && !hint) {
+      const h = document.createElement('div');
+      h.className = 'kb-qa-hint';
+      const disp = _state.spaceId ? _state.spaceName : (_state.currentLib || '当前知识库');
+      h.textContent = `基于「${disp}」提问，回答只引用库内资料并标注锚点。`;
+      box.appendChild(h);
+    } else if (hasMsg && hint) {
+      hint.remove();
+    }
+  }
+
+  function _clearQa() {
+    const box = document.getElementById('kb-qa-messages');
+    if (box) box.innerHTML = '';
+    _maybeShowQaHint();
+  }
+
+  // ── 模型下拉：真实配置（auth.listEntries）──
+  function _loadModelOptions() {
+    const sel = document.getElementById('kb-qa-model');
+    if (!sel) return;
+    if (!window.cogseed || typeof window.cogseed.invoke !== 'function') {
+      sel.innerHTML = '<option>默认模型</option>';
+      return;
+    }
+    window.cogseed.invoke('auth.listEntries', { includeUnavailable: true })
+      .then((res) => {
+        const entries = (res && res.ok && Array.isArray(res.entries)) ? res.entries : [];
+        if (!entries.length) {
+          sel.innerHTML = '<option>未配置模型（请到设置配置）</option>';
+          return;
+        }
+        sel.innerHTML = entries.map((e, i) =>
+          `<option value="${i}">${_esc(`${e.provider || ''} · ${e.modelName || e.model || ''}`)}</option>`
+        ).join('');
+      })
+      .catch(() => {
+        sel.innerHTML = '<option>默认模型</option>';
+      });
+  }
+
+  // ── 问答流 ──
+  function _ask(question) {
+    const q = String(question || '').trim();
+    if (!q) return;
+    const box = document.getElementById('kb-qa-messages');
+    if (!box) return;
+    _maybeShowQaHint();
+
+    const user = document.createElement('div');
+    user.className = 'kb-qa-msg is-user';
+    user.innerHTML = `<div class="kb-qa-msg-body">${_esc(q)}</div>`;
+    box.appendChild(user);
+
+    const ai = document.createElement('div');
+    ai.className = 'kb-qa-msg is-ai is-typing';
+    ai.innerHTML = '<div class="kb-qa-msg-body kb-qa-stream"></div>';
+    box.appendChild(ai);
+    const streamBody = ai.querySelector('.kb-qa-stream');
+    box.scrollTop = box.scrollHeight;
+
+    if (!window.cogseed || typeof window.cogseed.stream !== 'function') {
+      ai.classList.remove('is-typing');
+      streamBody.textContent = '问答服务不可用';
+      return;
+    }
+    let text = '';
+    try {
+      const handle = window.cogseed.stream('kbqa.askStream', { question: q, space_id: _state.spaceId || null, k: 8 }, (ev) => {
+        if (!ev) return;
+        if (ev.type === 'delta' && ev.text) {
+          text += ev.text;
+          streamBody.textContent = text;
+          box.scrollTop = box.scrollHeight;
+        } else if (ev.type === 'final') {
+          ai.classList.remove('is-typing');
+          text = ev.text || text;
+          streamBody.textContent = text;
+          const evidence = Array.isArray(ev.evidence) ? ev.evidence : [];
+          if (evidence.length) {
+            const refs = document.createElement('div');
+            refs.className = 'kb-qa-refs';
+            refs.innerHTML = '<span class="kb-qa-refs-label">引用</span>';
+            for (const r of evidence) {
+              const chip = document.createElement('button');
+              chip.type = 'button';
+              chip.className = 'kb-qa-chip';
+              chip.textContent = `${r.path}#chunk ${r.chunkIdx} ↗`;
+              chip.title = '跳转到原文';
+              chip.addEventListener('click', () => _openAnchor(r));
+              refs.appendChild(chip);
+            }
+            streamBody.appendChild(refs);
+          }
+          box.scrollTop = box.scrollHeight;
+        } else if (ev.type === 'error') {
+          ai.classList.remove('is-typing');
+          streamBody.textContent = '出错了：' + (ev.text || 'unknown');
+        }
+      });
+      if (handle && handle.promise) handle.promise.catch(() => { /* ignore */ });
+    } catch (err) {
+      ai.classList.remove('is-typing');
+      streamBody.textContent = '出错了：' + ((err && err.message) || String(err));
+    }
+  }
+
+  function _openAnchor(ref) {
+    if (typeof window.__openAnchorViewer === 'function') {
+      window.__openAnchorViewer({
+        source: ref.source || 'library',
+        scope: ref.scope || 'global',
+        path: ref.path,
+        chunkIdx: ref.chunkIdx,
+      });
+      return;
+    }
+    if (typeof uiToast === 'function') uiToast('原文查看器未就绪（anchored-source-view 未加载）', { variant: 'warning' });
+  }
+
+  // ── kb 状态实时流 ──
+  function _ensureKbStream() {
+    if (_state.streamHandle) return;
+    if (!window.cogseed || typeof window.cogseed.stream !== 'function') return;
+    try {
+      _state.streamHandle = window.cogseed.stream('kb.events', {}, (ev) => {
+        const inner = ev && ev.event;
+        if (!inner || !inner.relPath) return;
+        if (inner.status === 'deleted') _state.kbStatus.delete(inner.relPath);
+        else _state.kbStatus.set(inner.relPath, { status: inner.status, chunks: inner.chunks, kind: inner.kind, error: inner.error });
+        _renderFiles();
+      });
+      _state.streamHandle.promise.catch(() => { /* ignore */ });
+    } catch (err) {
+      _log.warn('subscribe kb.events failed', err);
+    }
+  }
+
+  // ── DOM 构建（幂等）──
+  function renderKbWorkbench() {
+    const host = document.getElementById('kb-workbench');
+    if (!host) return;
+    if (_state.rendered) {
+      _loadAll();
+      return;
+    }
+    _state.rendered = true;
+    host.innerHTML = `
+      <div class="kb-wb">
+        <aside class="kb-wb-side">
+          <div class="kb-wb-side-head"><h2>知识库</h2><button type="button" class="kb-wb-icon-btn" id="kb-wb-global-search" title="全局搜索（搜-读-写入口）">⌕</button></div>
+          <div class="kb-wb-tree" id="kb-wb-tree"></div>
+          <div class="kb-wb-foot"><span class="kb-wb-dot"></span>本地优先 · 索引与向量仅在本机</div>
+        </aside>
+        <section class="kb-wb-mid">
+          <div class="kb-wb-mid-head">
+            <div class="kb-wb-title"><span id="kb-wb-lib-name">知识库</span><span class="kb-wb-tag" id="kb-wb-lib-tag">个人知识库</span></div>
+            <div class="kb-wb-mid-sub">
+              <span id="kb-wb-count">内容(0)</span>
+              <input id="kb-wb-search-input" placeholder="搜索库内文件…" autocomplete="off">
+              <div class="kb-wb-tools">
+                <button type="button" class="kb-wb-icon-btn" id="kb-wb-sort" title="排序：名称">⇅</button>
+                <button type="button" class="kb-wb-icon-btn" id="kb-wb-refresh" title="刷新（重新索引）">⟳</button>
+                <button type="button" class="kb-wb-icon-btn" id="kb-wb-import" title="批量导入">⤴</button>
+              </div>
+            </div>
+            <div class="kb-wb-crumb" id="kb-wb-crumb" hidden></div>
+          </div>
+          <div class="kb-wb-files" id="kb-wb-files"></div>
+        </section>
+        <section class="kb-wb-right">
+          <div class="kb-wb-right-head"><span class="kb-wb-chip">📚 <span id="kb-wb-right-lib">—</span></span><span class="kb-wb-local"><span class="kb-wb-dot"></span>本地推理 · 资料不上云</span></div>
+          <div class="kb-wb-right-body" id="kb-wb-right"></div>
+          <div class="kb-wb-right-input">
+            <div class="kb-qa-box">
+              <select class="kb-qa-model" id="kb-qa-model" title="问答模型（真实配置）"></select>
+              <textarea class="kb-qa-input" id="kb-qa-input" rows="1" placeholder="基于知识库提问…"></textarea>
+              <button type="button" class="kb-qa-send" id="kb-qa-send" title="发送">➤</button>
+            </div>
+            <div class="kb-qa-note">内容由 AI 生成仅供参考 · 引用均已核验锚点</div>
+          </div>
+        </section>
+      </div>`;
+    document.getElementById('kb-wb-lib-name').textContent = _state.currentLib || '知识库';
+    document.getElementById('kb-wb-right-lib').textContent = _state.currentLib || '—';
+    document.getElementById('kb-wb-global-search')?.addEventListener('click', () => {
+      if (typeof uiToast === 'function') uiToast('全局搜索（Cmd/Ctrl+K）', { variant: 'info' });
+    });
+    document.getElementById('kb-wb-search-input')?.addEventListener('input', (e) => {
+      _state.filter = e.target.value;
+      _renderFiles();
+    });
+    document.getElementById('kb-wb-sort')?.addEventListener('click', () => {
+      _state.sort = _state.sort === 'name' ? 'type' : 'name';
+      _renderFiles();
+      if (typeof uiToast === 'function') uiToast(`排序：${_state.sort === 'name' ? '名称' : '类型'}`, { variant: 'info' });
+    });
+    document.getElementById('kb-wb-refresh')?.addEventListener('click', () => _loadAll());
+    document.getElementById('kb-wb-import')?.addEventListener('click', _importFiles);
+    document.getElementById('kb-qa-send')?.addEventListener('click', () => _submitQa());
+    document.getElementById('kb-qa-input')?.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        _submitQa();
+      }
+    });
+    _loadModelOptions();
+    _loadAll();
+  }
+
+  function _submitQa() {
+    const input = document.getElementById('kb-qa-input');
+    if (!input) return;
+    const q = input.value;
+    if (!q || !q.trim()) return;
+    input.value = '';
+    _ask(q);
+  }
+
+  async function _importFiles() {
+    if (!_state.currentLib) return;
+    const dirNode = _currentDirNode();
+    const targetDir = dirNode ? dirNode.path : _state.currentLib;
+    try {
+      const res = await window.cogseed.invoke('contexts.pickAndUpload', { targetDir });
+      if (res && res.ok === false) {
+        if (typeof uiToast === 'function') uiToast('导入失败：' + _esc(res.error || 'unknown'), { variant: 'error' });
+        return;
+      }
+      if (typeof uiToast === 'function') uiToast('已导入，开始索引…', { variant: 'success', timeoutMs: 1500 });
+      _loadAll();
+    } catch (err) {
+      _log.warn('import failed', err);
+      if (typeof uiToast === 'function') uiToast('导入取消或失败', { variant: 'warning' });
+    }
+  }
+
+  window.renderKbWorkbench = renderKbWorkbench;
+})();

--- a/src/renderer/modules/lazy-features.js
+++ b/src/renderer/modules/lazy-features.js
@@ -53,6 +53,12 @@ const _rendererFeatureManifest = Object.freeze({
   workspace: [
     { src: './modules/workspace.js' },
   ],
+  kb: [
+    { src: './modules/kb-eco.js' },
+    { src: './modules/kb-workbench.js' },
+    { src: './modules/kb-notes.js' },
+    { src: './modules/kb-discover.js' },
+  ],
   dashboard: [
     { src: './modules/dashboard.js' },
   ],

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -349,6 +349,7 @@ function bindStaticHandlers() {
   // 首页保持进入新建会话页（panel-new-chat）；「新任务」独立按钮已移除。
   document.getElementById('new-chat-btn').addEventListener('click', () => _setViewFromSidebar('new-chat'));
   document.getElementById('auto-btn')?.addEventListener('click', () => _setViewFromSidebar('auto'));
+  document.getElementById('kb-btn')?.addEventListener('click', () => _setViewFromSidebar('kb'));
   document.getElementById('recall-btn')?.addEventListener('click', () => _setViewFromSidebar('recall'));
   document.getElementById('connectors-btn')?.addEventListener('click', () => _setViewFromSidebar('connections'));
   document.getElementById('dashboard-btn')?.addEventListener('click', () => _setViewFromSidebar('dashboard'));

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -27336,3 +27336,374 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .dash-form-status.err { color: var(--danger); }
 .dash-form-status.ok { color: var(--success); }
 .dash-form-status.pending { color: var(--muted); }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   知识库模块（计划书 v1.3：总入口=侧边栏自动化后「知识库」按钮 → 生态
+   rail → 三栏工作台）。S1 骨架：kb-eco.js（生态外壳）+ kb-workbench.js
+   （库树/文件列表/右区占位）。样式并入本文件，遵循仓库规范。
+   ═══════════════════════════════════════════════════════════════════════ */
+.sidebar-btn-chip.kb-new-chip {
+  margin-left: auto;
+  padding: 0 6px;
+  border-radius: 99px;
+  background: var(--color-brand);
+  color: var(--color-white);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+}
+
+/* 生态外壳：rail + 子视图容器 */
+.kb-view { display: flex; flex: 1; min-width: 0; min-height: 0; }
+.kb-eco { display: grid; grid-template-columns: 52px 1fr; flex: 1; min-width: 0; min-height: 0; }
+.kb-rail {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 10px 0; gap: 4px; background: var(--color-surface);
+  border-right: 1px solid var(--border);
+}
+.kb-rail-btn {
+  position: relative; width: 38px; height: 38px; border-radius: 10px;
+  display: grid; place-items: center; color: var(--color-muted);
+}
+.kb-rail-btn:hover { background: var(--color-control-stop-hover); color: var(--color-ink); }
+.kb-rail-btn.active { background: var(--color-brand-soft); color: var(--color-brand); }
+.kb-rail-btn .kb-rail-icon { width: 20px; height: 20px; }
+.kb-rail-btn .kb-sdot {
+  position: absolute; top: 5px; right: 5px; width: 7px; height: 7px;
+  border-radius: 50%; border: 1px solid var(--color-white);
+}
+.kb-sdot.is-ok { background: var(--color-success); }
+.kb-sdot.is-soon { background: var(--border-strong); }
+.kb-rail-spacer { flex: 1; }
+.kb-eco-body { display: flex; flex: 1; min-width: 0; min-height: 0; }
+.kb-eco-body .kb-workbench,
+.kb-eco-body .kb-eco-pane { display: flex; flex: 1; min-width: 0; min-height: 0; }
+.kb-eco-body .kb-workbench[hidden],
+.kb-eco-body .kb-eco-pane[hidden] { display: none; }
+
+/* 三栏工作台 */
+.kb-wb { display: grid; grid-template-columns: 236px 372px 1fr; flex: 1; min-width: 0; min-height: 0; }
+
+/* 左：库树 */
+.kb-wb-side { display: flex; flex-direction: column; min-width: 0; background: var(--color-white); border-right: 1px solid var(--border); }
+.kb-wb-side-head { display: flex; align-items: center; justify-content: space-between; padding: 14px 14px 8px; }
+.kb-wb-side-head h2 { font-size: 14px; font-weight: 600; }
+.kb-wb-icon-btn { width: 26px; height: 26px; display: grid; place-items: center; border-radius: 6px; color: var(--color-muted); font-size: 14px; }
+.kb-wb-icon-btn:hover { background: var(--color-control-stop-hover); color: var(--color-ink); }
+.kb-wb-tree { flex: 1; overflow: auto; padding: 0 8px 12px; }
+.kb-tree-group { margin-top: 6px; }
+.kb-tree-group-label { display: flex; align-items: center; gap: 4px; padding: 6px 8px; font-size: 12.5px; color: var(--color-muted); }
+.kb-tree-group-label > span:first-child { font-size: 10px; transition: transform .15s; }
+.kb-tree-group-name { flex: 1; }
+.kb-tree-plus { width: 18px; height: 18px; display: grid; place-items: center; border-radius: 4px; color: var(--color-muted); font-size: 14px; }
+.kb-tree-plus:hover { background: var(--color-control-stop-hover); color: var(--color-ink); }
+.kb-tree-item {
+  display: flex; align-items: center; gap: 8px; padding: 7px 10px;
+  border-radius: 7px; cursor: pointer; color: var(--color-muted); font-size: 13px; margin: 1px 0;
+}
+.kb-tree-item:hover { background: var(--color-control-stop-hover); }
+.kb-tree-item.active { background: var(--color-brand-soft); color: var(--color-brand); font-weight: 500; }
+.kb-tree-ico { font-size: 14px; }
+.kb-tree-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kb-tree-empty { padding: 8px 10px; font-size: 12px; color: var(--color-muted); }
+.kb-tree-placeholder { padding: 6px 10px; font-size: 12px; color: var(--color-faint); }
+.kb-wb-foot {
+  display: flex; align-items: center; gap: 8px; padding: 10px 12px;
+  border-top: 1px solid var(--border); font-size: 12px; color: var(--color-muted);
+}
+.kb-wb-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--color-success); flex: none; }
+
+/* 中：文件列表 */
+.kb-wb-mid { display: flex; flex-direction: column; min-width: 0; background: var(--color-white); border-right: 1px solid var(--border); }
+.kb-wb-mid-head { padding: 16px 16px 10px; border-bottom: 1px solid var(--border); }
+.kb-wb-title { display: flex; align-items: center; gap: 8px; font-size: 15px; font-weight: 600; }
+.kb-wb-tag { font-size: 11px; color: var(--color-brand); background: var(--color-brand-soft); padding: 2px 8px; border-radius: 10px; font-weight: 400; }
+.kb-wb-mid-sub { display: flex; align-items: center; gap: 8px; margin-top: 10px; font-size: 12.5px; color: var(--color-muted); }
+.kb-wb-mid-sub input {
+  flex: 1; min-width: 0; font-size: 12.5px; padding: 3px 8px;
+  background: var(--color-control-stop); border-radius: 6px;
+}
+.kb-wb-mid-sub input:focus { outline: 1px solid var(--color-brand); }
+.kb-wb-tools { display: flex; gap: 4px; color: var(--color-muted); }
+.kb-wb-crumb { display: flex; align-items: center; gap: 6px; margin-top: 8px; font-size: 12px; color: var(--color-muted); }
+.kb-wb-crumb[hidden] { display: none; }
+.kb-crumb-link { color: var(--color-brand); cursor: pointer; }
+.kb-crumb-link:hover { text-decoration: underline; }
+.kb-crumb-sep { color: var(--color-faint); }
+.kb-crumb-cur { color: var(--color-muted); }
+.kb-wb-files { flex: 1; overflow: auto; padding: 6px 0; }
+.kb-file-row {
+  display: flex; align-items: center; gap: 10px; padding: 9px 16px;
+  cursor: pointer; border-left: 3px solid transparent; font-size: 13px;
+}
+.kb-file-row:hover { background: var(--color-control-stop-hover); }
+.kb-file-row.is-dir:hover { background: var(--color-control-stop); }
+.kb-file-icon {
+  width: 32px; height: 32px; border-radius: 7px; display: grid; place-items: center;
+  flex: none; font-size: 10px; font-weight: 700; color: var(--color-white);
+}
+.kb-file-icon.is-dir { background: #f59e0b; font-size: 14px; }
+.kb-file-icon.is-pdf { background: #e5533d; }
+.kb-file-icon.is-excel { background: #1a7f37; }
+.kb-file-icon.is-ppt { background: #c3512d; }
+.kb-file-icon.is-img { background: #9b59b6; }
+.kb-file-icon.is-word { background: #2b579a; }
+.kb-file-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kb-file-meta { font-size: 11.5px; color: var(--color-faint); flex: none; }
+.kb-file-status { font-size: 11px; flex: none; }
+.kb-file-status.is-ready { color: var(--color-success); }
+.kb-file-status.is-run { color: var(--color-warning-text); }
+.kb-file-status.is-failed { color: var(--color-danger); }
+.kb-file-status.is-none { color: var(--color-faint); }
+.kb-file-actions { display: flex; gap: 2px; opacity: 0; flex: none; }
+.kb-file-row:hover .kb-file-actions { opacity: 1; }
+.kb-mini-btn { width: 24px; height: 24px; display: grid; place-items: center; border-radius: 6px; color: var(--color-muted); font-size: 12px; }
+.kb-mini-btn:hover { background: var(--color-control-stop-hover); color: var(--color-ink); }
+.kb-list-end { text-align: center; font-size: 12px; color: var(--color-faint); padding: 14px 0 20px; }
+
+/* 右：AI 解析 / 问答（S1 占位，S2/S3 填充） */
+.kb-wb-right { display: flex; flex-direction: column; min-width: 0; background: var(--bg); }
+.kb-wb-right-head {
+  display: flex; align-items: center; gap: 10px; padding: 12px 20px;
+  border-bottom: 1px solid var(--border); background: var(--color-white);
+}
+.kb-wb-chip { font-size: 12.5px; color: var(--color-muted); background: var(--color-control-stop); padding: 4px 10px; border-radius: 20px; }
+.kb-wb-local { font-size: 11.5px; color: var(--color-success); display: flex; align-items: center; gap: 4px; margin-left: auto; }
+.kb-wb-right-body { flex: 1; overflow: auto; padding: 20px 24px; display: flex; flex-direction: column; gap: 14px; }
+.kb-wb-right-card { background: var(--color-white); border: 1px solid var(--border); border-radius: 12px; padding: 14px 16px; }
+.kb-wb-right-card-title { font-size: 13px; font-weight: 600; margin-bottom: 6px; }
+.kb-wb-right-card-sub { font-size: 12.5px; color: var(--color-muted); margin-bottom: 8px; }
+.kb-wb-right-placeholder { font-size: 12.5px; color: var(--color-faint); line-height: 1.8; }
+.kb-wb-right-input { padding: 14px 20px 16px; border-top: 1px solid var(--border); background: var(--color-white); }
+.kb-wb-right-input-box {
+  border: 1px solid var(--border); border-radius: 12px; padding: 10px 12px;
+  font-size: 13.5px; color: var(--color-faint); background: var(--color-white);
+}
+
+/* S2 问答区 */
+.kb-qa-box {
+  display: flex; align-items: flex-end; gap: 8px;
+  border: 1px solid var(--border); border-radius: 12px; padding: 8px 10px;
+  background: var(--color-white);
+}
+.kb-qa-box:focus-within { border-color: var(--color-brand); }
+.kb-qa-model {
+  flex: none; max-width: 150px; font-size: 12px; color: var(--color-muted);
+  background: var(--color-control-stop); border-radius: 8px; padding: 4px 6px;
+}
+.kb-qa-input {
+  flex: 1; min-width: 0; resize: none; font-size: 13.5px; line-height: 1.6;
+  height: 22px; max-height: 120px; color: var(--color-ink);
+}
+.kb-qa-send {
+  flex: none; width: 30px; height: 30px; border-radius: 8px;
+  display: grid; place-items: center; background: var(--color-brand);
+  color: var(--color-white); font-size: 14px;
+}
+.kb-qa-send:hover { background: var(--color-brand-hover); }
+.kb-qa-note { text-align: center; font-size: 11.5px; color: var(--color-faint); margin-top: 8px; }
+.kb-qa-messages { display: flex; flex-direction: column; gap: 12px; }
+.kb-qa-hint { font-size: 12.5px; color: var(--color-faint); text-align: center; padding: 10px 0; }
+.kb-qa-msg { max-width: 820px; }
+.kb-qa-msg.is-user { align-self: flex-end; }
+.kb-qa-msg.is-ai { align-self: flex-start; }
+.kb-qa-msg-body {
+  border-radius: 12px; padding: 10px 13px; font-size: 13.5px; line-height: 1.75;
+  white-space: pre-wrap; word-break: break-word;
+}
+.kb-qa-msg.is-user .kb-qa-msg-body { background: var(--color-brand); color: var(--color-white); }
+.kb-qa-msg.is-ai .kb-qa-msg-body { background: var(--color-white); border: 1px solid var(--border); color: var(--color-ink); }
+.kb-qa-msg.is-ai.is-typing .kb-qa-msg-body::after {
+  content: "▍"; color: var(--color-brand); animation: kb-qa-blink 1s steps(2) infinite;
+}
+@keyframes kb-qa-blink { 50% { opacity: 0; } }
+.kb-qa-refs { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.kb-qa-refs-label { font-size: 11px; color: var(--color-faint); margin-right: 2px; }
+.kb-qa-chip {
+  display: inline-flex; align-items: center; gap: 4px; max-width: 260px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  background: var(--color-brand-soft); color: var(--color-brand);
+  border: 1px solid var(--color-line); border-radius: 6px; padding: 2px 8px;
+  font-size: 11.5px; cursor: pointer;
+}
+.kb-qa-chip:hover { background: var(--color-brand-soft); border-color: var(--color-brand); }
+
+/* S3 AI 解析区 */
+.kb-wb-card-src { font-size: 11px; color: var(--color-faint); font-weight: 400; }
+.kb-wb-doc { padding: 8px 0; border-top: 1px dashed var(--border); }
+.kb-wb-doc-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.kb-wb-doc-name { font-weight: 600; font-size: 13px; }
+.kb-wb-doc-text { margin-top: 4px; font-size: 12.5px; line-height: 1.8; color: var(--color-muted); }
+.kb-wb-one-liner {
+  margin-top: 10px; padding: 10px 12px; border-radius: 8px; font-size: 13px;
+  background: var(--color-brand-soft); border-left: 3px solid var(--color-brand); color: var(--color-ink);
+}
+.kb-wb-one-liner-tag { font-size: 11.5px; color: var(--color-brand); font-weight: 600; margin-right: 6px; }
+.kb-wb-a-actions { display: flex; gap: 8px; margin-top: 12px; }
+.kb-wb-a-btn {
+  font-size: 12.5px; color: var(--color-brand); background: var(--color-white);
+  border: 1px solid var(--color-line); border-radius: 8px; padding: 5px 12px;
+}
+.kb-wb-a-btn:hover { background: var(--color-brand-soft); }
+.kb-wb-doc-list { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
+.kb-wb-doc-row { font-size: 12.5px; color: var(--color-muted); }
+.kb-wb-mm { margin-top: 14px; border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+.kb-wb-mm-head {
+  display: flex; align-items: center; gap: 6px; padding: 8px 12px; font-size: 12px;
+  color: var(--color-muted); background: var(--color-control-stop); border-bottom: 1px solid var(--border);
+}
+.kb-wb-mm-canvas {
+  position: relative; height: 210px; display: grid; place-items: center;
+  background: repeating-linear-gradient(0deg, #fff, #fff 23px, #fafbfc 23px, #fafbfc 24px);
+}
+.kb-wb-mm-canvas.is-loading::after {
+  content: ""; width: 34px; height: 34px; border-radius: 50%;
+  border: 3px solid var(--color-brand-soft); border-top-color: var(--color-brand);
+  animation: kb-mm-spin 1s linear infinite;
+}
+@keyframes kb-mm-spin { to { transform: rotate(360deg); } }
+.kb-wb-mm-load {
+  width: 44px; height: 44px; border-radius: 50%; background: var(--color-white);
+  border: 1px solid var(--color-brand-soft); color: var(--color-brand);
+  display: grid; place-items: center; font-size: 13px;
+}
+.kb-wb-mm-svg { width: 100%; height: 210px; display: block; }
+
+/* S3 测验简版 */
+.kb-wb-quiz { margin-top: 14px; border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; background: var(--color-white); }
+.kb-wb-quiz-title { font-size: 13px; font-weight: 600; margin-bottom: 8px; }
+.kb-wb-quiz-q { margin-bottom: 10px; }
+.kb-wb-quiz-qtext { font-size: 12.5px; margin-bottom: 6px; }
+.kb-wb-quiz-opt {
+  display: block; width: 100%; text-align: left; font-size: 12.5px; color: var(--color-muted);
+  border: 1px solid var(--border); border-radius: 8px; padding: 6px 10px; margin-bottom: 6px;
+  background: var(--color-white);
+}
+.kb-wb-quiz-opt:hover { background: var(--color-control-stop); }
+.kb-wb-quiz-opt.is-correct { border-color: var(--color-success); color: var(--color-success); background: var(--color-success-soft); }
+.kb-wb-quiz-opt.is-wrong { border-color: var(--color-danger); color: var(--color-danger); background: var(--color-danger-soft); }
+.kb-wb-quiz-foot { display: flex; justify-content: flex-end; }
+
+/* S4 笔记面板 */
+.kb-notes { display: grid; grid-template-columns: 260px 1fr; flex: 1; min-width: 0; min-height: 0; }
+.kb-notes-list { display: flex; flex-direction: column; min-width: 0; background: var(--color-white); border-right: 1px solid var(--border); }
+.kb-notes-list-head { display: flex; align-items: center; justify-content: space-between; padding: 14px 14px 8px; }
+.kb-notes-list-head h2 { font-size: 14px; font-weight: 600; }
+.kb-notes-items { flex: 1; overflow: auto; padding: 0 8px; }
+.kb-notes-item {
+  padding: 10px 12px; border-radius: 9px; cursor: pointer; margin-bottom: 4px;
+  font-size: 13px; color: var(--color-muted);
+}
+.kb-notes-item:hover { background: var(--color-control-stop-hover); }
+.kb-notes-item.active { background: var(--color-success-soft); border: 1px solid var(--color-success); color: var(--color-ink); }
+.kb-notes-empty { padding: 12px; font-size: 12.5px; color: var(--color-faint); }
+.kb-notes-editor { display: flex; flex-direction: column; min-width: 0; background: var(--color-white); }
+.kb-notes-toolbar {
+  display: flex; align-items: center; gap: 2px; padding: 8px 16px;
+  border-bottom: 1px solid var(--border); flex-wrap: wrap;
+}
+.kb-notes-toolbar .kb-sep { width: 1px; height: 18px; background: var(--border); margin: 0 6px; }
+.kb-notes-toolbar .ed-btn {
+  min-width: 28px; height: 28px; padding: 0 7px; border-radius: 6px;
+  display: grid; place-items: center; color: var(--color-muted); font-size: 13px;
+}
+.kb-notes-toolbar .ed-btn:hover { background: var(--color-control-stop-hover); color: var(--color-ink); }
+.kb-notes-toolbar .ed-btn.bold { font-weight: 700; }
+.kb-notes-toolbar .ed-btn.italic { font-style: italic; }
+.kb-notes-toolbar .ed-btn.underline { text-decoration: underline; }
+.kb-notes-toolbar-right { margin-left: auto; display: flex; gap: 6px; align-items: center; }
+.kb-wb-a-btn.kb-danger { color: var(--color-danger); border-color: var(--color-danger-soft); }
+.kb-notes-toolbar .kb-caret { font-size: 9px; color: var(--color-faint); }
+.kb-ed-dropdown { position: relative; }
+.kb-ed-menu {
+  position: absolute; top: 32px; left: 0; z-index: 60; display: none;
+  background: var(--color-white); border: 1px solid var(--border); border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .12); padding: 4px; min-width: 120px;
+}
+.kb-ed-menu.show { display: block; }
+.kb-ed-mi { padding: 6px 12px; font-size: 13px; border-radius: 6px; cursor: pointer; color: var(--color-muted); }
+.kb-ed-mi:hover { background: var(--color-control-stop-hover); }
+.kb-notes-body { flex: 1; overflow: auto; padding: 24px 36px; max-width: 860px; margin: 0 auto; width: 100%; }
+.kb-notes-edit { min-height: 420px; outline: none; font-size: 14.5px; line-height: 1.9; color: var(--color-ink); }
+.kb-notes-edit h1 { font-size: 26px; font-weight: 700; margin-bottom: 14px; }
+.kb-notes-edit h2 { font-size: 19px; font-weight: 600; margin: 22px 0 10px; }
+.kb-notes-edit p { margin-bottom: 10px; }
+.kb-notes-ai-draft { margin-top: 8px; padding: 8px 10px; border-left: 3px solid var(--color-brand); background: var(--color-brand-soft); color: var(--color-ink); }
+
+/* S4 发现面板 */
+.kb-discover { display: flex; flex-direction: column; flex: 1; min-width: 0; min-height: 0; background: var(--bg); }
+.kb-discover-tabs { display: flex; gap: 8px; padding: 14px 20px 0; background: var(--color-white); border-bottom: 1px solid var(--border); }
+.kb-dtab {
+  padding: 8px 16px; font-size: 13px; color: var(--color-muted);
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+}
+.kb-dtab:hover { color: var(--color-ink); }
+.kb-dtab.on { color: var(--color-brand); border-bottom-color: var(--color-brand); font-weight: 600; }
+.kb-discover-pane { flex: 1; overflow: auto; padding: 20px 26px; }
+.kb-discover-pane[hidden] { display: none; }
+.kb-market-head { display: flex; align-items: center; gap: 10px; margin-bottom: 18px; }
+.kb-market-search {
+  display: flex; align-items: center; gap: 6px; max-width: 340px; flex: 1;
+  background: var(--color-white); border: 1px solid var(--border); border-radius: 10px; padding: 7px 12px;
+}
+.kb-market-search input { flex: 1; min-width: 0; font-size: 13px; }
+.kb-market-shuffle { color: var(--color-brand); border-left: 1px solid var(--border); padding-left: 10px; cursor: pointer; font-size: 12.5px; }
+.kb-market-sec { margin-bottom: 22px; }
+.kb-market-sec-title { font-size: 15px; font-weight: 600; margin-bottom: 12px; }
+.kb-market-sub { font-size: 12.5px; color: var(--color-faint); margin-bottom: 16px; }
+.kb-market-featured, .kb-market-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+.kb-market-card {
+  background: var(--color-white); border: 1px solid var(--border); border-radius: 12px;
+  padding: 14px; cursor: pointer; transition: .15s; display: flex; flex-direction: column; gap: 6px;
+}
+.kb-market-card:hover { border-color: var(--color-brand); box-shadow: 0 4px 16px rgba(0, 0, 0, .06); }
+.kb-market-card-name { font-size: 13.5px; font-weight: 600; }
+.kb-market-card-desc { font-size: 12px; color: var(--color-muted); line-height: 1.6; min-height: 38px; }
+.kb-market-card-meta { font-size: 11px; color: var(--color-faint); line-height: 1.7; }
+.kb-market-card-meta b { color: var(--color-muted); font-weight: 600; }
+.kb-market-card-src { color: var(--color-brand); }
+.kb-market-tags { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 4px; }
+.kb-market-tag {
+  background: var(--color-white); border: 1px solid var(--border); padding: 5px 14px;
+  border-radius: 18px; font-size: 12.5px; color: var(--color-muted); cursor: pointer;
+}
+.kb-market-tag:hover, .kb-market-tag.on { background: var(--color-brand-soft); border-color: var(--color-brand); color: var(--color-brand); }
+.kb-market-empty { color: var(--color-faint); font-size: 13px; padding: 20px 0; }
+.kb-mcp-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+.kb-mcp-card {
+  position: relative; background: var(--color-white); border: 1px solid var(--border);
+  border-radius: 12px; padding: 14px; display: flex; flex-direction: column; gap: 8px;
+}
+.kb-mcp-card:hover { border-color: var(--color-brand); box-shadow: 0 4px 16px rgba(0, 0, 0, .06); }
+.kb-mcp-add {
+  position: absolute; top: 10px; right: 10px; width: 24px; height: 24px; border-radius: 50%;
+  background: var(--color-control-stop); color: var(--color-muted); display: grid; place-items: center; font-size: 16px;
+}
+.kb-mcp-add:hover { background: var(--color-brand); color: var(--color-white); }
+.kb-mcp-icon {
+  width: 38px; height: 38px; border-radius: 10px; display: grid; place-items: center; font-size: 19px;
+  background: linear-gradient(135deg, #eef2ff, #e0e7ff);
+}
+.kb-mcp-name { font-size: 13.5px; font-weight: 600; }
+.kb-mcp-desc { font-size: 12px; color: var(--color-muted); line-height: 1.6; min-height: 58px; }
+.kb-mcp-foot {
+  display: flex; align-items: center; justify-content: space-between; font-size: 11.5px;
+  color: var(--color-faint); border-top: 1px dashed var(--border); padding-top: 7px;
+}
+.kb-mcp-num { background: var(--color-control-stop); padding: 1px 7px; border-radius: 10px; }
+.kb-mcp-src { color: var(--color-brand); }
+.kb-skills-list { display: flex; flex-direction: column; gap: 10px; max-width: 720px; }
+.kb-skill-item {
+  display: flex; gap: 12px; align-items: center; background: var(--color-white);
+  border: 1px solid var(--border); border-radius: 12px; padding: 14px 16px;
+}
+.kb-skill-icon {
+  width: 38px; height: 38px; border-radius: 10px; display: grid; place-items: center; font-size: 18px;
+  background: linear-gradient(135deg, #ecfdf5, #d1fae5);
+}
+.kb-skill-name { font-weight: 600; font-size: 13.5px; }
+.kb-skill-desc { font-size: 12px; color: var(--color-muted); }
+.kb-skill-state {
+  margin-left: auto; font-size: 11px; color: var(--color-success);
+  background: var(--color-success-soft); border: 1px solid var(--color-success); padding: 2px 10px; border-radius: 12px;
+}

--- a/test/main/features/kb_qa.test.ts
+++ b/test/main/features/kb_qa.test.ts
@@ -1,0 +1,112 @@
+/**
+ * kb_qa (知识库模块 S2) — grounded Q&A stream orchestration.
+ *
+ * mocks `ask-materials` so the evidence/threshold logic stays hermetic; the
+ * retrieval internals are covered by ask-materials.test.ts itself.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../src/main/model/core-agent/ask-materials', () => ({
+  askMaterials: vi.fn(),
+  formatEvidence: (result: any) => `ask_materials (evidence: ${(result.hits || []).length})`,
+}));
+
+import { kbAskStream, _internals } from '../../../src/main/features/kb_qa';
+import { askMaterials } from '../../../src/main/model/core-agent/ask-materials';
+
+const askMaterialsMock = vi.mocked(askMaterials);
+
+function collect(gen: AsyncGenerator<any>) {
+  const events: any[] = [];
+  return (async () => {
+    for await (const e of gen) events.push(e);
+    return events;
+  })();
+}
+
+function fakeStream(...texts: string[]) {
+  return vi.fn(async function* () {
+    for (const t of texts) yield { type: 'delta', text: t };
+  });
+}
+
+const HIT = {
+  source: 'library', scope: 'global', path: 'notes/a.md', chunkIdx: 2,
+  snippet: 'alpha protocol handles tokens', score: 0.02,
+};
+
+beforeEach(() => {
+  askMaterialsMock.mockReset();
+});
+
+describe('kb_qa kbAskStream', () => {
+  it('rejects an empty question', async () => {
+    const events = await collect(kbAskStream('u1', { question: '  ' }, { stream: fakeStream() } as any));
+    expect(events).toEqual([{ type: 'error', text: 'empty question' }]);
+    expect(askMaterialsMock).not.toHaveBeenCalled();
+  });
+
+  it('says plainly there is no material instead of fabricating', async () => {
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: false, reason: 'no_material', hits: [], query: 'q', summary: [],
+    } as any);
+    const events = await collect(kbAskStream('u1', { question: 'q' }, { stream: fakeStream() } as any));
+    const final = events[events.length - 1];
+    expect(final.type).toBe('final');
+    expect(final.noMaterial).toBe(true);
+    expect(final.reason).toBe('no_material');
+    expect(final.text).toContain('资料中未找到');
+    expect(events.some((e) => e.type === 'delta')).toBe(false);
+  });
+
+  it('answers with a caveat on low-confidence evidence', async () => {
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: false, reason: 'low_confidence', hits: [HIT], query: 'q', summary: [],
+    } as any);
+    const events = await collect(kbAskStream('u1', { question: 'q' }, { stream: fakeStream() } as any));
+    const final = events[events.length - 1];
+    expect(final.noMaterial).toBe(true);
+    expect(final.reason).toBe('low_confidence');
+    expect(final.text).toContain('很弱');
+  });
+
+  it('streams deltas grounded in evidence and returns final with citation refs', async () => {
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: true, hits: [HIT], query: 'q', summary: ['evidence ready'],
+    } as any);
+    const stream = fakeStream('基于 ', 'notes/a.md#chunk 2，', '回答。');
+    const events = await collect(kbAskStream('u1', { question: 'q' }, { stream } as any));
+    // system prompt carries the evidence package; message is the question
+    const streamOpts = stream.mock.calls[0][0];
+    expect(streamOpts.message).toBe('q');
+    expect(streamOpts.systemPrompt).toContain('ask_materials (evidence: 1)');
+    expect(streamOpts.systemPrompt).toContain('path#chunk N');
+    // deltas forwarded verbatim
+    expect(events.filter((e) => e.type === 'delta').map((e) => e.text)).toEqual(['基于 ', 'notes/a.md#chunk 2，', '回答。']);
+    const final = events[events.length - 1];
+    expect(final.type).toBe('final');
+    expect(final.noMaterial).toBeUndefined();
+    expect(final.evidence).toEqual([
+      { source: 'library', scope: 'global', path: 'notes/a.md', chunkIdx: 2, snippet: HIT.snippet, score: HIT.score },
+    ]);
+  });
+
+  it('forwards model errors', async () => {
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: true, hits: [HIT], query: 'q', summary: [],
+    } as any);
+    const stream = vi.fn(async function* () {
+      yield { type: 'error', text: 'provider down' };
+    });
+    const events = await collect(kbAskStream('u1', { question: 'q' }, { stream } as any));
+    expect(events).toEqual([{ type: 'error', text: 'provider down' }]);
+  });
+
+  it('maps hits to compact evidence refs', () => {
+    const refs = _internals.toEvidenceRefs([HIT as any]);
+    expect(refs[0]).toEqual({
+      source: 'library', scope: 'global', path: 'notes/a.md', chunkIdx: 2, snippet: HIT.snippet, score: HIT.score,
+    });
+  });
+});

--- a/test/main/features/kb_summary.test.ts
+++ b/test/main/features/kb_summary.test.ts
@@ -1,0 +1,112 @@
+/**
+ * kb_summary (知识库模块 S3) — library summary generation + fingerprint cache.
+ *
+ * mocks kb_vector (listFiles / readFileChunks) so the LLM call / cache /
+ * degrade paths are hermetic.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../src/main/features/kb_vector', () => ({
+  listFiles: vi.fn(() => []),
+  readFileChunks: vi.fn(() => []),
+}));
+
+import { kbSummarize, parseSummaryJson, _internals } from '../../../src/main/features/kb_summary';
+import * as kbVector from '../../../src/main/features/kb_vector';
+
+const listFilesMock = vi.mocked(kbVector.listFiles);
+const readChunksMock = vi.mocked(kbVector.readFileChunks);
+
+function readyFile(rel: string, mtime = 1, chunks = 2) {
+  return { id: 1, rel_path: rel, kind: 'text', bytes: 10, mtime, sha1: rel, status: 'ready', error: null, chunks, created_at: 0, updated_at: 0 };
+}
+
+function completeOk(text: string) {
+  return vi.fn(async () => ({ ok: true, text, error: '' }));
+}
+
+const SAMPLE_JSON = JSON.stringify({
+  docs: [
+    { name: 'a.md', file: 'lib/a.md', text: 'A 要点' },
+    { name: 'b.pdf', file: 'lib/b.pdf', text: 'B 要点' },
+  ],
+  oneLiner: '这个库围绕主题 X。',
+  mindmap: { root: '主题 X', kids: ['A', 'B'] },
+});
+
+beforeEach(() => {
+  listFilesMock.mockReset();
+  readChunksMock.mockReset();
+  _internals.clearCacheForTests();
+});
+
+describe('kb_summary', () => {
+  it('degrades with no ready files', async () => {
+    listFilesMock.mockReturnValue([readyFile('lib/a.md', 1, 0) /* status ready */]);
+    // 无 ready：listFiles 返回非 ready
+    listFilesMock.mockReturnValue([{ ...readyFile('lib/a.md'), status: 'failed' } as any]);
+    const res = await kbSummarize('u1', { dir: 'lib' }, { complete: completeOk('{}') });
+    expect(res.source).toBe('degraded');
+    expect(res.oneLiner).toContain('还没有已索引');
+    expect(res.docs).toEqual([]);
+  });
+
+  it('generates docs/oneLiner/mindmap from ready chunks', async () => {
+    listFilesMock.mockReturnValue([readyFile('lib/a.md', 1, 1), readyFile('lib/b.pdf', 2, 1)]);
+    readChunksMock.mockImplementation((_u: string, rel: string) => [
+      { chunk_idx: 1, title: rel, content: '内容片段……' },
+    ]);
+    const complete = completeOk(SAMPLE_JSON);
+    const res = await kbSummarize('u1', { dir: 'lib' }, { complete });
+    expect(res.source).toBe('generated');
+    expect(res.docs).toEqual([
+      { name: 'a.md', file: 'lib/a.md', text: 'A 要点' },
+      { name: 'b.pdf', file: 'lib/b.pdf', text: 'B 要点' },
+    ]);
+    expect(res.oneLiner).toContain('主题 X');
+    expect(res.mindmap.root).toBe('主题 X');
+    expect(res.mindmap.kids).toEqual(['A', 'B']);
+    // LLM 收到要点 + JSON 契约
+    const msg = complete.mock.calls[0][0];
+    expect(msg.message).toContain('lib/a.md');
+    expect(msg.message).toContain('内容片段');
+    expect(msg.systemPrompt).toContain('mindmap');
+  });
+
+  it('serves cached result on the same fingerprint without a second LLM call', async () => {
+    listFilesMock.mockReturnValue([readyFile('lib/a.md', 1, 1)]);
+    readChunksMock.mockReturnValue([{ chunk_idx: 1, title: null, content: 'x'.repeat(50) }]);
+    const complete = completeOk(SAMPLE_JSON);
+    const first = await kbSummarize('u1', { dir: 'lib' }, { complete });
+    expect(first.source).toBe('generated');
+    const second = await kbSummarize('u1', { dir: 'lib' }, { complete });
+    expect(second.source).toBe('cached');
+    expect(complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades to a file list when the model fails', async () => {
+    listFilesMock.mockReturnValue([readyFile('lib/a.md', 1, 1), readyFile('lib/b.pdf', 2, 1)]);
+    readChunksMock.mockReturnValue([{ chunk_idx: 1, title: null, content: 'y' }]);
+    const complete = vi.fn(async () => ({ ok: false, text: '', error: 'provider down' }));
+    const res = await kbSummarize('u1', { dir: 'lib' }, { complete });
+    expect(res.source).toBe('degraded');
+    expect(res.oneLiner).toContain('降级');
+    expect(res.docs.map((d) => d.file)).toEqual(['lib/a.md', 'lib/b.pdf']);
+    expect(res.docs.every((d) => d.text === '')).toBe(true);
+  });
+
+  it('parses a JSON block out of model text', () => {
+    const parsed = parseSummaryJson(`前言\n${SAMPLE_JSON}\n结尾`);
+    expect(parsed.docs.length).toBe(2);
+    expect(parsed.mindmap.kids).toEqual(['A', 'B']);
+  });
+
+  it('fingerprint is stable and order-insensitive', () => {
+    const a = _internals.fingerprint([{ path: 'b', mtime: 2, chunks: 1 }, { path: 'a', mtime: 1, chunks: 2 }]);
+    const b = _internals.fingerprint([{ path: 'a', mtime: 1, chunks: 2 }, { path: 'b', mtime: 2, chunks: 1 }]);
+    expect(a).toBe(b);
+    const c = _internals.fingerprint([{ path: 'a', mtime: 1, chunks: 3 }, { path: 'b', mtime: 2, chunks: 1 }]);
+    expect(c).not.toBe(a);
+  });
+});

--- a/test/main/model/core-agent/anchor-resolver.test.ts
+++ b/test/main/model/core-agent/anchor-resolver.test.ts
@@ -1,0 +1,158 @@
+/**
+ * anchor-resolver (COGSEED-39 ② P1) — citation anchor → char-level position.
+ *
+ * Hermetic tests with a temp workspace root: insert a Library text file,
+ * then resolve an anchor and assert exact char ranges, fuzzy locating,
+ * out-of-scope rejection, and cache-less rich-doc degradation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+vi.mock('../../../../src/main/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+let tmpDir: string;
+let prevWs: string | undefined;
+const TEST_UID = 'anchor';
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-anchor-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+  const users = await import('../../../../src/main/features/users');
+  users.activateUser(TEST_UID);
+});
+
+afterEach(async () => {
+  try {
+    const kb = await import('../../../../src/main/features/kb_vector');
+    kb.closeAllKb();
+  } catch { /* ignore */ }
+  process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Stage a plain-text Library file and vectorize it (ready status). */
+async function stageLibraryFile(relPath: string, content: string) {
+  const { userContextsDir } = await import('../../../../src/main/paths');
+  const dir = userContextsDir(TEST_UID);
+  fs.mkdirSync(path.join(dir, path.dirname(relPath)), { recursive: true });
+  fs.writeFileSync(path.join(dir, relPath), content);
+  const kb = await import('../../../../src/main/features/kb_vector');
+  const chunks = [{
+    title: 'c1',
+    content: 'alpha one two three',
+    embedding: new Array(512).fill(0),
+  }, {
+    title: 'c2',
+    content: 'beta four five six',
+    embedding: new Array(512).fill(0),
+  }];
+  await kb.upsertFile(TEST_UID, {
+    relPath,
+    kind: 'text',
+    bytes: content.length,
+    mtime: 1,
+    sha1: relPath,
+    chunks,
+  });
+}
+
+describe('anchor_resolver', () => {
+  it('resolves a library chunk anchor to the exact char range', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/anchor-resolver');
+    // "alpha one two three" appears verbatim in the file.
+    await stageLibraryFile('notes/a.md', 'prefix text\n\nalpha one two three\nsuffix text');
+
+    const res = await mod.resolveAnchor({
+      userId: TEST_UID,
+      source: 'library',
+      scope: 'global',
+      path: 'notes/a.md',
+      chunkIdx: 1,
+    });
+
+    expect(res.resolved).toBe(true);
+    const expected = 'prefix text\n\nalpha one two three\nsuffix text'.indexOf('alpha one two three');
+    expect(res.charStart).toBe(expected);
+    expect(res.charEnd).toBe(expected + 'alpha one two three'.length);
+    expect(res.text).toContain('alpha one two three');
+    expect(res.totalChars).toBeGreaterThan(0);
+  });
+
+  it('locates via quote when the chunk text is not verbatim (whitespace/approx)', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/anchor-resolver');
+    await stageLibraryFile('notes/b.md', 'intro\n\nbeta four five six\noutro');
+
+    const res = await mod.resolveAnchor({
+      userId: TEST_UID,
+      source: 'library',
+      scope: 'global',
+      path: 'notes/b.md',
+      chunkIdx: 2,
+      quote: 'beta four',
+    });
+
+    expect(res.resolved).toBe(true);
+    expect(res.charStart).toBe('intro\n\nbeta four five six\noutro'.indexOf('beta four'));
+  });
+
+  it('rejects an out-of-scope path', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/anchor-resolver');
+    await stageLibraryFile('notes/a.md', 'alpha one two three');
+
+    const res = await mod.resolveAnchor({
+      userId: TEST_UID,
+      source: 'library',
+      scope: 'global',
+      path: '../outside.md',
+      chunkIdx: 1,
+    });
+
+    expect(res.resolved).toBe(false);
+    expect(res.reason).toBe('out_of_scope'); // path traversal escapes the contexts root
+  });
+
+  it('returns no_cache for a rich doc without a file-indexer cache entry', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/anchor-resolver');
+    const { userContextsDir } = await import('../../../../src/main/paths');
+    const dir = userContextsDir(TEST_UID);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'doc.pdf'), '%PDF-1.4 not really a pdf');
+    // No file-indexer cache for the pdf → no_cache, not an error.
+    const res = await mod.resolveAnchor({
+      userId: TEST_UID,
+      source: 'library',
+      scope: 'global',
+      path: 'doc.pdf',
+      chunkIdx: 1,
+      quote: 'anything',
+    });
+    expect(res.resolved).toBe(false);
+    expect(res.reason).toBe('no_cache');
+  });
+
+  it('returns bad_input for an attachment without a cid', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/anchor-resolver');
+    const res = await mod.resolveAnchor({
+      userId: TEST_UID,
+      source: 'attachment',
+      scope: 'conversation',
+      path: 'notes.txt',
+      chunkIdx: 0,
+      quote: 'x',
+    });
+    expect(res.resolved).toBe(false);
+    expect(res.reason).toBe('bad_input');
+  });
+});

--- a/test/renderer/kb-notes.test.ts
+++ b/test/renderer/kb-notes.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+
+function fakeClassList() {
+  const values = new Set<string>();
+  return {
+    add: (...n: string[]) => n.forEach((x) => values.add(x)),
+    remove: (...n: string[]) => n.forEach((x) => values.delete(x)),
+    contains: (n: string) => values.has(n),
+    toggle: (n: string, f?: boolean) => { const a = f == null ? !values.has(n) : f; if (a) values.add(n); else values.delete(n); return a; },
+  };
+}
+function fakeEl(id: string) {
+  const listeners: Record<string, any> = {};
+  const el: any = {
+    id, innerHTML: '', hidden: false, value: '', textContent: '', dataset: {}, style: {},
+    classList: fakeClassList(),
+    addEventListener: vi.fn((n: string, fn: any) => { listeners[n] = fn; }),
+    appendChild: vi.fn(), querySelector: vi.fn(() => null), querySelectorAll: vi.fn(() => []),
+    focus: vi.fn(), scrollTop: 0, scrollHeight: 0, insertAdjacentHTML: vi.fn(), remove: vi.fn(),
+    _listeners: listeners,
+  };
+  return el;
+}
+
+const TREE_WITH_NOTES = {
+  tree: [
+    { name: 'lib', path: 'lib', type: 'dir', children: [] },
+    { name: 'notes', path: 'notes', type: 'dir', children: [
+      { name: '周记.md', path: 'notes/周记.md', type: 'file', bytes: 10, mtime: 1 },
+      { name: '复盘.md', path: 'notes/复盘.md', type: 'file', bytes: 8, mtime: 1 },
+    ] },
+  ],
+};
+
+function loadScript() {
+  const source = fs.readFileSync(path.join(__dirname, '../../src/renderer/modules/kb-notes.js'), 'utf8');
+  const els: Record<string, any> = {};
+  const created: any[] = [];
+  const invokeCalls: Array<{ ch: string; payload: any }> = [];
+  const documentMock: any = {
+    getElementById: vi.fn((id: string) => { if (!els[id]) els[id] = fakeEl(id); return els[id]; }),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    addEventListener: vi.fn(),
+    createElement: vi.fn(() => { const el = fakeEl(''); created.push(el); return el; }),
+    execCommand: vi.fn(),
+    body: {},
+  };
+  const windowMock: any = {
+    addEventListener: vi.fn(),
+    uiToast: vi.fn(),
+    uiConfirm: vi.fn(() => Promise.resolve(true)),
+    uiPrompt: vi.fn(() => Promise.resolve('新笔记')),
+    cogseed: {
+      invoke: vi.fn(async (ch: string, payload: any) => {
+        invokeCalls.push({ ch, payload });
+        if (ch === 'contexts.tree') return TREE_WITH_NOTES;
+        if (ch === 'contexts.read') return { ok: true, content: '# 周记\n内容' };
+        if (ch === 'contexts.mkdir') return { ok: true };
+        if (ch === 'contexts.write') return { ok: true };
+        if (ch === 'contexts.delete') return { ok: true };
+        return {};
+      }),
+      stream: vi.fn(() => ({ promise: Promise.resolve() })),
+    },
+  };
+  const context: any = {
+    console, Promise, setTimeout, clearTimeout, performance,
+    createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+    escapeHtml: (v: unknown) => String(v ?? ''),
+    uiToast: windowMock.uiToast, uiPrompt: windowMock.uiPrompt, uiConfirm: windowMock.uiConfirm,
+    document: documentMock, window: windowMock,
+  };
+  vm.createContext(context);
+  vm.runInContext(source, context, { filename: 'kb-notes.js' });
+  return { windowMock, els, invokeCalls, created };
+}
+
+describe('KB notes panel (S4)', () => {
+  it('renders the notes list from the contexts notes/ dir', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbNotes();
+    await vi.waitFor(() => {
+      expect(els['kb-notes-items'].appendChild).toHaveBeenCalled();
+    });
+    // 列表项来自 notes/ 目录（周记/复盘 两个文件）
+    expect(els['kb-notes-items'].appendChild).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates a new note: ensures notes/ dir then writes the file', async () => {
+    const { windowMock, els, invokeCalls } = loadScript();
+    windowMock.renderKbNotes();
+    await vi.waitFor(() => {
+      expect(els['kb-notes-items'].appendChild).toHaveBeenCalled();
+    });
+    els['kb-notes-new']._listeners.click();
+    await vi.waitFor(() => {
+      expect(invokeCalls.some((c) => c.ch === 'contexts.write' && c.payload.path === 'notes/新笔记.md')).toBe(true);
+    });
+    // notes 目录已存在 → 不应重复 mkdir
+    expect(invokeCalls.some((c) => c.ch === 'contexts.mkdir')).toBe(false);
+  });
+
+  it('opens a note and reads its content', async () => {
+    const { windowMock, els, invokeCalls, created } = loadScript();
+    windowMock.renderKbNotes();
+    await vi.waitFor(() => {
+      expect(els['kb-notes-items'].appendChild).toHaveBeenCalled();
+    });
+    // 第一个列表项（周记）触发 open：直接调用其 click 监听器
+    const items = els['kb-notes-items'].appendChild.mock.calls.map((c: any[]) => c[0]);
+    const first = items.find((el: any) => el._listeners && el._listeners.click);
+    expect(first).toBeDefined();
+    first._listeners.click();
+    await vi.waitFor(() => {
+      expect(els['kb-notes-edit'].innerHTML).toContain('周记');
+    });
+    expect(invokeCalls.some((c) => c.ch === 'contexts.read' && c.payload.path === 'notes/周记.md')).toBe(true);
+  });
+});

--- a/test/renderer/kb-workbench.test.ts
+++ b/test/renderer/kb-workbench.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+
+function fakeClassList() {
+  const values = new Set<string>();
+  return {
+    add: (...names: string[]) => names.forEach((name) => values.add(name)),
+    remove: (...names: string[]) => names.forEach((name) => values.delete(name)),
+    contains: (name: string) => values.has(name),
+    toggle: (name: string, force?: boolean) => {
+      const shouldAdd = force == null ? !values.has(name) : force;
+      if (shouldAdd) values.add(name);
+      else values.delete(name);
+      return shouldAdd;
+    },
+  };
+}
+
+function fakeEl(id: string) {
+  const listeners: Record<string, any> = {};
+  const el: any = {
+    id,
+    innerHTML: '',
+    hidden: false,
+    value: '',
+    textContent: '',
+    dataset: {},
+    style: {},
+    scrollTop: 0,
+    scrollHeight: 0,
+    classList: fakeClassList(),
+    addEventListener: vi.fn((name: string, fn: any) => { listeners[name] = fn; }),
+    appendChild: vi.fn(),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    focus: vi.fn(),
+    click: vi.fn(),
+    remove: vi.fn(),
+    setAttribute: vi.fn(),
+    removeAttribute: vi.fn(),
+    _listeners: listeners,
+  };
+  return el;
+}
+
+// createElement 返回的元素带一个子节点（模拟 querySelector 命中），
+// 使问答流内部（ai.querySelector('.kb-qa-stream')）可写。
+function fakeCreatedEl() {
+  const el = fakeEl('');
+  const child = fakeEl('__child__');
+  el.querySelector = vi.fn(() => child);
+  return { el, child };
+}
+
+const TREE = [
+  {
+    name: '班级建设资料', path: '班级建设资料', type: 'dir', children: [
+      { name: '子目录', path: '班级建设资料/子目录', type: 'dir', children: [
+        { name: '子文件.txt', path: '班级建设资料/子目录/子文件.txt', type: 'file', bytes: 10, mtime: 1 },
+      ] },
+      { name: 'a.pdf', path: '班级建设资料/a.pdf', type: 'file', bytes: 5, mtime: 1 },
+      { name: 'b.xlsx', path: '班级建设资料/b.xlsx', type: 'file', bytes: 5, mtime: 1 },
+    ],
+  },
+  {
+    name: '挑战资料', path: '挑战资料', type: 'dir', children: [
+      { name: 'c.docx', path: '挑战资料/c.docx', type: 'file', bytes: 3, mtime: 1 },
+    ],
+  },
+];
+
+const KB_FILES = [
+  { path: '班级建设资料/a.pdf', status: 'ready', chunks: 2, kind: 'pdf' },
+  { path: '班级建设资料/b.xlsx', status: 'processing', chunks: 0, kind: 'excel' },
+  { path: '挑战资料/c.docx', status: 'ready', chunks: 1, kind: 'word' },
+];
+
+function loadScript() {
+  const source = fs.readFileSync(
+    path.join(__dirname, '../../src/renderer/modules/kb-workbench.js'),
+    'utf8',
+  );
+  const els: Record<string, any> = {};
+  const created: any[] = [];
+  const documentMock: any = {
+    getElementById: vi.fn((id: string) => {
+      if (!els[id]) els[id] = fakeEl(id);
+      return els[id];
+    }),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    addEventListener: vi.fn(),
+    body: {},
+    createElement: vi.fn(() => {
+      const made = fakeCreatedEl();
+      created.push(made);
+      return made.el;
+    }),
+  };
+  const windowMock: any = {
+    addEventListener: vi.fn(),
+    uiToast: vi.fn(),
+    uiPrompt: vi.fn(() => Promise.resolve(null)),
+    cogseed: {
+      invoke: vi.fn(async (ch: string) => {
+        if (ch === 'contexts.tree') return { tree: TREE };
+        if (ch === 'kb.status') return { files: KB_FILES };
+        if (ch === 'contexts.mkdir') return { ok: true };
+        if (ch === 'contexts.pickAndUpload') return { ok: true };
+        if (ch === 'auth.listEntries') {
+          return { ok: true, entries: [
+            { provider: 'deepseek', model: 'deepseek-chat', modelName: 'DeepSeek Chat' },
+            { provider: 'qwen', model: 'qwen-plus', modelName: 'Qwen Plus' },
+          ] };
+        }
+        if (ch === 'spaces.list') {
+          return { spaces: [{ space_id: 'sp1', name: '团队空间' }] };
+        }
+        if (ch === 'spaces.files.status') {
+          return { files: [
+            { name: '白皮书.pdf', path: '白皮书.pdf', kind: 'pdf', status: 'ready', chunks: 3, bytes: 5, mtime: 1 },
+          ] };
+        }
+        if (ch === 'kb.summary') {
+          return {
+            docs: [
+              { name: 'a.pdf', file: '班级建设资料/a.pdf', text: 'A 要点' },
+              { name: 'b.xlsx', file: '班级建设资料/b.xlsx', text: 'B 要点' },
+            ],
+            oneLiner: '这个库围绕班级建设。',
+            mindmap: { root: '班级建设', kids: ['真实项目征集', '执行手册'] },
+            source: 'generated',
+            fingerprint: 'fp1',
+          };
+        }
+        return {};
+      }),
+      stream: vi.fn(() => ({ promise: Promise.resolve() })),
+    },
+  };
+  const context: any = {
+    console,
+    Promise,
+    setTimeout,
+    clearTimeout,
+    performance,
+    createLogger: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+    escapeHtml: (v: unknown) => String(v ?? ''),
+    uiToast: windowMock.uiToast,
+    uiPrompt: windowMock.uiPrompt,
+    document: documentMock,
+    window: windowMock,
+  };
+  vm.createContext(context);
+  vm.runInContext(source, context, { filename: 'kb-workbench.js' });
+  return { context, els, windowMock, created };
+}
+
+describe('KB workbench (S1 skeleton)', () => {
+  it('renders the library tree from contexts.tree top-level dirs', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbWorkbench();
+    await vi.waitFor(() => {
+      expect(els['kb-wb-tree'].innerHTML).toContain('班级建设资料');
+    });
+    expect(els['kb-wb-tree'].innerHTML).toContain('挑战资料');
+    expect(els['kb-wb-tree'].innerHTML).toContain('个人知识库');
+    expect(els['kb-wb-tree'].innerHTML).toContain('共享知识库');
+    expect(els['kb-wb-tree'].innerHTML).toContain('订阅知识库');
+  });
+
+  it('defaults to the first library and renders files with kb status chips', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbWorkbench();
+    await vi.waitFor(() => {
+      expect(els['kb-wb-files'].innerHTML).toContain('a.pdf');
+    });
+    // 默认选中第一个库（班级建设资料）
+    expect(els['kb-wb-lib-name'].textContent).toBe('班级建设资料');
+    // ready → ✓ 已索引；processing → 索引中…
+    expect(els['kb-wb-files'].innerHTML).toContain('✓ 已索引');
+    expect(els['kb-wb-files'].innerHTML).toContain('索引中…');
+    // 子目录行（可下钻）
+    expect(els['kb-wb-files'].innerHTML).toContain('子目录');
+  });
+
+  it('tree markup carries per-library selectors for switching', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbWorkbench();
+    await vi.waitFor(() => {
+      expect(els['kb-wb-tree'].innerHTML).toContain('data-kb-lib="挑战资料"');
+    });
+    expect(els['kb-wb-tree'].innerHTML).toContain('data-kb-lib="班级建设资料"');
+  });
+
+  it('renders the S2 QA pane and fills the model dropdown from real config', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbWorkbench();
+    await vi.waitFor(() => {
+      expect(els['kb-wb-right'].innerHTML).toContain('kb-qa-messages');
+    });
+    await vi.waitFor(() => {
+      expect(els['kb-qa-model'].innerHTML).toContain('DeepSeek Chat');
+    });
+    expect(els['kb-qa-model'].innerHTML).toContain('Qwen Plus');
+    expect(els['kb-qa-model'].innerHTML).not.toContain('未配置模型');
+  });
+
+  it('streams a grounded answer and renders citation chips on final', async () => {
+    const { windowMock, els, created } = loadScript();
+    windowMock.renderKbWorkbench();
+    await vi.waitFor(() => {
+      expect(els['kb-wb-files'].innerHTML).toContain('a.pdf');
+    });
+    // 触发发送：输入问题 → click send（监听器已注册）
+    els['kb-qa-input'].value = 'alpha protocol?';
+    els['kb-qa-send']._listeners.click();
+    const streamMock = windowMock.cogseed.stream;
+    expect(streamMock).toHaveBeenCalled();
+    const calls = streamMock.mock.calls;
+    const kbCall = calls.find((c: any[]) => c[0] === 'kbqa.askStream');
+    expect(kbCall).toBeDefined();
+    expect(kbCall[1].question).toBe('alpha protocol?');
+    const cb = kbCall[2];
+    cb({ type: 'delta', text: '基于 ' });
+    // delta 不创建元素：此时最后一个 createElement 是 AI 气泡
+    // （_ask 内顺序：hint → user 气泡 → AI 气泡）
+    const ai = created[created.length - 1];
+    const streamBody = ai.el.querySelector('.kb-qa-stream');
+    cb({ type: 'final', text: '基于 引用回答。', evidence: [
+      { source: 'library', scope: 'global', path: 'notes/a.md', chunkIdx: 2, snippet: 's', score: 0.02 },
+    ] });
+    expect(streamBody.textContent).toBe('基于 引用回答。');
+    // final 追加了引用 chips（appendChild 被调用）
+    expect(streamBody.appendChild).toHaveBeenCalled();
+    // typing 态已移除
+    expect(ai.el.classList.contains('is-typing')).toBe(false);
+  });
+
+  it('renders the S3 analysis card (docs + one-liner + mindmap action)', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbWorkbench();
+    await vi.waitFor(() => {
+      expect(els['kb-wb-analysis-card'].innerHTML).toContain('A 要点');
+    });
+    expect(els['kb-wb-analysis-card'].innerHTML).toContain('B 要点');
+    expect(els['kb-wb-analysis-card'].innerHTML).toContain('这个库围绕班级建设。');
+    expect(els['kb-wb-analysis-card'].innerHTML).toContain('data-kb-anchor="班级建设资料/a.pdf"');
+    expect(els['kb-wb-analysis-card'].innerHTML).toContain('生成脑图');
+    expect(els['kb-wb-analysis-card'].innerHTML).toContain('生成测验');
+    // 引用 chip 点击 → anchored viewer 打开（window.__openAnchorViewer 不存在时 toast）
+    expect(els['kb-wb-analysis-card'].innerHTML).not.toContain('正在解析');
+  });
+
+  it('renders shared knowledge bases (space library) in the tree', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbWorkbench();
+    await vi.waitFor(() => {
+      expect(els['kb-wb-tree'].innerHTML).toContain('团队空间');
+    });
+    expect(els['kb-wb-tree'].innerHTML).toContain('data-kb-space="sp1"');
+    expect(els['kb-wb-tree'].innerHTML).toContain('共享');
+    expect(els['kb-wb-tree'].innerHTML).not.toContain('空间库 · S4 上线');
+  });
+});


### PR DESCRIPTION
## 动机（Why）
COGSEED-39 知识库模块——对标 ima 的知识库工作台（计划书 v1.3），实现「可靠问答 + 来源引用」之上的知识库生态。

## 改动（What）
- **S1 入口+骨架**：侧边栏「自动化」后新增「知识库」总入口 + 生态 rail（知识库/笔记/发现）+ 三栏工作台（库树/文件列表 + kb 状态实时流/AI 解析区）
- **S2 可靠问答**：`kbqa.askStream` —— ask_materials 证据边界、无资料明说、引用锚点回跳原文（复用 anchor-resolver 三件套）
- **S3 库解析**：`kb_summary` —— 逐文档要点 + 一句话总结 + 脑图/测验简版（库指纹缓存 + 失败降级）
- **S4 笔记/发现/共享**：笔记面板（富文本 + AI 帮写）、发现市场（知识库/MCP/Skills 三 Tab，内置自造数据）、共享空间库浏览与问答（space 模式）、引用查看器阅读模式
- 文件：21 个（+2681 行），新增 22 个单测

## 验证（How）
- `npm run typecheck` / `npm run lint` / `npm test` 通过（无新增失败）
- `cogseed-open-source-audit --mode diff` → PASS_WITH_WARNINGS（3 条 HIGH 核验为基线内容/下载产物误报，窄豁免记录）
- 本地应用重启点验：入口/库树/文件状态/问答引用回跳/解析脑图/笔记/发现/共享库

## 关联
- Issue: COGSEED-39

## 检查清单
- [x] Conventional Commits + noreply 邮箱
- [x] 推送前审计扫描通过（§1.4）
- [x] typecheck/lint/npm test 本地检测通过