### PR TITLE
test(renderer): 对齐近期 UI 变更，修复两处过期断言

### DIFF
--- a/test/renderer/new-chat-home.test.ts
+++ b/test/renderer/new-chat-home.test.ts
@@ -21,8 +21,9 @@ describe('new chat home surface', () => {
     expect(html).toContain('id="new-chat-external-agent-btn"');
     expect(html).toContain('data-i18n="new_chat.external_agent_entry"');
     expect(html).toContain('id="model-guard-slot"');
+    // 首页不再有语音入口（外部 Agent 入口保留）。
     expect(html).not.toContain('id="new-chat-mic-btn"');
-    expect(html).not.toContain('data-ui-icon="mic"');
+    // 注意：聊天输入框的语音转写（STT）mic 图标属于另一个表面，不在此断言范围。
   });
 
   it('uses the synced homepage shortcut set and order', () => {

--- a/test/renderer/recall-cognition-flow.test.ts
+++ b/test/renderer/recall-cognition-flow.test.ts
@@ -3250,7 +3250,8 @@ describe('Recall cognition renderer flow', () => {
 
     context.renderSkillsCognitionTree();
 
-    expect(host.innerHTML).toContain('树上还没有叶片');
+    // 空态已升级为「认知种子」首播引导，不再显示旧文案。
+    expect(host.innerHTML).toContain('你的认知种子已经准备好');
     expect(host.innerHTML).not.toContain('cognition-tree-leaf');
   });
 


### PR DESCRIPTION
- new-chat-home：语音入口已从首页移除（new-chat-mic-btn 断言保留）， 聊天输入框的语音转写 mic 图标属于另一表面，不再全局断言其不存在
- recall-cognition-flow：认知树空态已升级为「认知种子」引导页， 断言改为新文案你的认知种子已经准备好

修复后 test/renderer 全套 153 文件 / 1651 用例全绿。

## What does this PR do?

Describe the change and why it is needed.

## Related issue

Fixes #(issue)

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Tests added/updated for the change
- [ ] Signed off with `git commit -s` (DCO)
