### PR TITLE
fix(stt): stop voice recording when leaving chat views

### DIFF
--- a/src/renderer/modules/boot.js
+++ b/src/renderer/modules/boot.js
@@ -410,6 +410,10 @@ function setView(view, cid, opts = {}) {
   if (view !== 'agents' && typeof closeExpenseWorkbench === 'function') {
     closeExpenseWorkbench();
   }
+  // 切离会话 / 新建会话面板时停止正在进行的语音输入，避免麦克风在别的模块继续收音。
+  if (view !== 'conversation' && view !== 'new-chat' && typeof window.__stopSttInputRecording === 'function') {
+    window.__stopSttInputRecording();
+  }
   _saveLastView(view, cid);
   document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
   const panelId = view === 'new-chat' ? 'panel-new-chat'

--- a/src/renderer/modules/stt-input.js
+++ b/src/renderer/modules/stt-input.js
@@ -247,4 +247,10 @@
     const cancel = _el(panel.cancel);
     if (cancel) cancel.addEventListener('click', _cancel);
   });
+
+  // 供 boot.js::setView 在视图切换（离开会话/新建会话面板）时调用：切走即停，
+  // 避免麦克风在别的模块里继续收音。只停当前这路，不影响其它状态。
+  window.__stopSttInputRecording = () => {
+    if (_recording) void _stop();
+  };
 })();


### PR DESCRIPTION
Clicking the mic starts recording, but switching to another view left the mic running. Stop the active recording from boot.js::setView when leaving the conversation / new-chat panels.

## What does this PR do?

Describe the change and why it is needed.

## Related issue

Fixes #(issue)

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Tests added/updated for the change
- [ ] Signed off with `git commit -s` (DCO)
