### PR TITLE
chore: remove personal names from comments and test fixtures

### DIFF
--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -4803,7 +4803,7 @@ async function runActorTurnBody(
       const actorMaxToolLoops = maxToolLoopsForActorKind(actor.kind);
       const { createLifecycleSink } = await import("../execution-records");
       const { getLocalExecMode } = await import("../permissions");
-      // Vision fallback seam (2026-08-27, 子安口径): if this turn carries
+      // Vision fallback seam (2026-08-27, product call): if this turn carries
       // images and the receiving model is KNOWN vision-incapable, the
       // registered pluggable handler returns MODEL-FACING instructions
       // (image facts + on-disk paths + which vision tools to call — vision

--- a/src/main/features/vision_fallback.ts
+++ b/src/main/features/vision_fallback.ts
@@ -1,5 +1,5 @@
 /**
- * Pluggable vision-fallback seam (2026-08-27, 子安定调).
+ * Pluggable vision-fallback seam (2026-08-27, product call).
  *
  * When a turn carries image attachments but the receiving model is KNOWN to
  * be vision-incapable (vision === false from the model-abilities chain), the
@@ -13,7 +13,7 @@
  *
  * No handler registered (the default today): images pass through unchanged —
  * exactly the pre-seam behavior. The concrete processor shape stays open on
- * purpose (子安: 视觉工具不固化形式).
+ * purpose (product call: 视觉工具不固化形式).
  */
 
 import { createLogger } from '../logger';

--- a/src/main/model/public_model_catalog.ts
+++ b/src/main/model/public_model_catalog.ts
@@ -13,7 +13,7 @@ export interface ProviderModelEntry {
   contextWindow?: number;
   maxTokens?: number;
   /** Accepts image inputs. Only set when confirmed (official docs, endpoint
-   *  modality field, or 子安's explicit word) — unknown stays undefined and
+   *  modality field, or the product owner's explicit word) — unknown stays undefined and
    *  consumers treat it as "assume yes" to avoid breaking working paths. */
   vision?: boolean;
 }
@@ -67,7 +67,7 @@ export const PUBLIC_PROVIDER_MODELS: Readonly<Record<string, readonly ProviderMo
   deepseek: [
     { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
     { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
-    // 窗口与视觉口径来源：子安确认（2026-08-27），deepseek-v4-pro/flash 文本版
+    // 窗口与视觉口径来源：产品确认（2026-08-27），deepseek-v4-pro/flash 文本版
     // 无权威数字故不标 —— 目录只收确凿数据，不猜。
     { id: 'deepseek-v4-flash-vision-exp', name: 'DeepSeek V4 Flash Vision (exp)', contextWindow: 1_048_576, vision: true },
   ],

--- a/test/main/features/messaging-binding-title.test.ts
+++ b/test/main/features/messaging-binding-title.test.ts
@@ -32,8 +32,8 @@ function envelope(partial: Partial<InboundEnvelope>): InboundEnvelope {
 
 describe('messaging/bindings — conversationTitleForEnvelope', () => {
   it('私聊：enrich 到发送者名时标题用名字', () => {
-    const title = conversationTitleForEnvelope(instance, envelope({ externalUserName: '牛保康' }));
-    expect(title).toBe('飞书 · 牛保康');
+    const title = conversationTitleForEnvelope(instance, envelope({ externalUserName: '张三' }));
+    expect(title).toBe('飞书 · 张三');
     expect(title).not.toContain('oc_');
     expect(title).not.toContain('ou_');
   });
@@ -48,7 +48,7 @@ describe('messaging/bindings — conversationTitleForEnvelope', () => {
   it('私聊：externalChatTitle 优先于发送者名', () => {
     const title = conversationTitleForEnvelope(instance, envelope({
       externalChatTitle: '置顶会话',
-      externalUserName: '牛保康',
+      externalUserName: '张三',
     }));
     expect(title).toBe('飞书 · 置顶会话');
   });


### PR DESCRIPTION
## 背景

第二版发版前自查（C-第二版发版清单）：扫描本人名下已合并 PR 时发现 develop 上残留 8 处员工姓名（注释 5 处 + 测试样例 3 处），按清单第 13 项「代码注释中员工姓名 全库必须 0」修复。

## 改动（4 文件 8 行，全部为措辞替换，无逻辑变更）

- `src/main/features/group_chat/bus.ts`：注释中「子安口径」→「product call」
- `src/main/features/vision_fallback.ts`：注释中「子安定调」「子安: …」→「product call / product call: …」
- `src/main/model/public_model_catalog.ts`：注释中「子安's explicit word」「子安确认」→「the product owner's explicit word」「产品确认」
- `test/main/features/messaging-binding-title.test.ts`：测试样例真名 →「张三」（与同文件既有虚构名「李四」风格一致）

## 验证

- 4 个受影响模块测试全绿：messaging-binding-title 6/6、vision_fallback、public_model_catalog、group_chat/bus 共 75/75 通过
- 全库 grep 该姓名归零（develop 现状仅此 8 处，均为本人 PR 引入）

## 关联

来自 #84（bus.ts / vision_fallback.ts / public_model_catalog.ts）与 #64（messaging-binding-title.test.ts）。