### PR TITLE
fix(renderer): refine homepage model guard and top drag regions

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -735,6 +735,7 @@
            MCP 与工具 tab 真嵌入原 connectors 网格（connectors.js 仍按这些 ID 渲染）；
            Agent / 数据源 / 触点 / 模型与额度 为入口卡，跳转到各自面板。 -->
       <section class="panel" id="panel-connections">
+        <div class="app-top-drag-strip" aria-hidden="true"></div>
         <div class="connections-container">
           <div class="connections-tabs" role="tablist" data-i18n-aria-label="sidebar.connections" aria-label="连接">
             <button type="button" class="connections-tab is-active" data-connections-tab="agents" data-i18n="connections.tab.agents">Agent</button>
@@ -1142,6 +1143,7 @@
 
       <!-- Workspace Center (空间中心：任务/产物/资产三 tab，由 workspace.js 渲染) -->
       <section class="panel" id="panel-workspace">
+        <div class="app-top-drag-strip" aria-hidden="true"></div>
         <div class="ws-view" id="ws-view"></div>
       </section>
 

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -326,6 +326,13 @@ html.is-macos body.sidebar-collapsed .sidebar-logo {
   z-index: 6;
   -webkit-app-region: no-drag;
 }
+/* Panel-scoped top strips sit above page content; raise each page header so
+   its tabs and actions keep their own drag/no-drag behavior. */
+.is-macos .connections-tabs,
+.is-macos .ws-page-top {
+  position: relative;
+  z-index: 6;
+}
 
 /* 收起侧边栏（窄图标条）：body.sidebar-collapsed 由 sidebar-resize.js 切换。
    只保留主按钮图标，隐藏文字 / 会话列表 / 搜索；logo 行只留 logo + 展开按钮。 */
@@ -3248,7 +3255,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .model-guard-slot:empty { display: none; }
 
-/* Compact model reminder, shown on every view except Settings when no
+/* Compact model reminder, shown only on the new-chat home when no
    (provider, model, credential) entry has been configured. */
 .model-guard-banner {
   display: flex;
@@ -3271,13 +3278,13 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .model-guard-dismiss {
   position: absolute;
-  top: 7px;
-  left: 8px;
+  top: 4px;
+  left: 4px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   border: 0;
   border-radius: 4px;
@@ -3337,9 +3344,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .model-guard-banner .model-guard-cta:hover { background: #d97e09; }
 
-/* Hide the banner when the user is already on the settings page (they're
-   at the fix spot anyway). Uses :has() — Electron's Chromium supports it. */
-.main-content:has(#panel-settings.active) .model-guard-banner { display: none !important; }
+/* This reminder belongs to the landing page. Other tabs keep their own
+   model-action guards without carrying a floating banner over page actions. */
+.main-content:not(:has(#panel-new-chat.active)) .model-guard-slot { display: none; }
 
 .panel {
   display: none;

--- a/test/renderer/new-chat-home.test.ts
+++ b/test/renderer/new-chat-home.test.ts
@@ -59,6 +59,8 @@ describe('new chat home surface', () => {
     expect(css).toContain('.new-chat-external-agent-btn');
     expect(css).toContain('.main-top-actions');
     expect(css).toMatch(/\.model-guard-banner\s*{[\s\S]*?height:\s*56px;/);
+    expect(css).toMatch(/\.model-guard-dismiss\s*{[\s\S]*?width:\s*28px;[\s\S]*?height:\s*28px;/);
+    expect(css).toMatch(/\.main-content:not\(:has\(#panel-new-chat\.active\)\) \.model-guard-slot\s*{\s*display:\s*none;/);
     expect(css).toMatch(/\.new-chat-input-area \.chat-rich-editor\s*{[\s\S]*?min-height:\s*80px;[\s\S]*?font-size:\s*16px;/);
     expect(css).toMatch(/\.new-chat-input-area \.chat-input-rich-wrap textarea\.chat-rich-source\s*{[\s\S]*?position:\s*absolute;[\s\S]*?width:\s*1px;[\s\S]*?opacity:\s*0;[\s\S]*?pointer-events:\s*none;/);
     expect(css).toMatch(/\.chat-rich-editor\s*{[\s\S]*?outline:\s*none;/);

--- a/test/renderer/top-drag-regions.test.ts
+++ b/test/renderer/top-drag-regions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const root = path.join(__dirname, '../..');
+const html = fs.readFileSync(path.join(root, 'src/renderer/index.html'), 'utf8');
+const css = fs.readFileSync(path.join(root, 'src/renderer/style.css'), 'utf8');
+
+describe('macOS top drag regions', () => {
+  it.each(['connections', 'workspace'])('covers the %s panel top edge', (panel) => {
+    expect(html).toMatch(new RegExp(`id="panel-${panel}"[\\s\\S]*?class="app-top-drag-strip"`));
+  });
+
+  it('keeps Connections tabs and Workspace header controls above the drag strip', () => {
+    expect(css).toMatch(/\.is-macos \.connections-tabs,[\s\S]*?\.is-macos \.ws-page-top\s*{[\s\S]*?z-index:\s*6;/);
+    expect(css).toMatch(/\.is-macos \.ws-page-top button,[\s\S]*?\.is-macos \.connections-tabs button,[\s\S]*?-webkit-app-region:\s*no-drag;/);
+    expect(css).toMatch(/\.is-macos \.ws-page-top button,[\s\S]*?\.is-macos \.ws-page-top input,[\s\S]*?-webkit-app-region:\s*no-drag;/);
+  });
+});


### PR DESCRIPTION
## Summary

- show the model configuration reminder only on the new-chat home
- enlarge the reminder dismiss target
- add macOS top drag coverage to Connections and Workspace
- add focused renderer regression tests

## Validation

- npm run typecheck
- npm run lint
- focused renderer tests: 11 passed
- full npm test: 9682 passed, 21 failed in existing develop resource/environment-sensitive suites; none touch these four files