### PR TITLE
feat(kb): 共享库导入个人库优化 — 导入内容多选弹窗、文件级导入、索引可见性修复

### DIFF
--- a/src/main/features/project_files.ts
+++ b/src/main/features/project_files.ts
@@ -473,6 +473,7 @@ export async function importSpaceFileFromPath(
   spaceId: string,
   name: string,
   sourceAbs: string,
+  opts?: { skipHash?: boolean },
 ): Promise<Result<{ info: SpaceFileInfo }>> {
   const startedAt = Date.now();
   let safeName: string;
@@ -485,7 +486,7 @@ export async function importSpaceFileFromPath(
   } catch (err) { return { ok: false, error: (err as Error).message }; }
 
   try {
-    const source = await inspectLocalImportSource(sourceAbs, maxBytesFor(safeName));
+    const source = await inspectLocalImportSource(sourceAbs, maxBytesFor(safeName), { skipHash: opts?.skipHash });
     if (TEXT_EXTS.has(path.extname(safeName).toLowerCase())) {
       // Text caps are small; validate UTF-8 without bringing large Office/PDF
       // payloads back into the main-process heap.

--- a/src/main/features/space_import.ts
+++ b/src/main/features/space_import.ts
@@ -9,10 +9,13 @@
 import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
-import { spaceContentDir } from '../paths';
+import * as crypto from 'node:crypto';
+import { spaceContentDir, spaceLibraryVectorDbPath, userContextsDir } from '../paths';
 import { safeId } from '../storage';
 import { createLogger } from '../logger';
-
+import * as contexts from './contexts';
+import { importSpaceFileFromPath } from './project_files';
+import * as vs from './vec_store';
 const log = createLogger('space_import');
 
 export const IMPORT_LIMITS = {
@@ -37,6 +40,101 @@ export interface ImportSkippedEntry {
 export type ImportFolderResult =
   | { ok: true; total: number; copied: number; skipped: ImportSkippedEntry[]; targetDir: string }
   | { ok: false; error: string };
+
+export type ImportLibResult =
+  | { ok: true; scanned: number; imported: number; files: Array<{ name: string; ok: boolean; error?: string }> }
+  | { ok: false; error: string };
+
+/**
+ * 把个人知识库（contexts/ 下的一个库目录）的内容镜像导入到共享知识库（空间）。
+ * 对齐 ima「从个人知识库导入」：源目录结构保留，文件走空间索引队列（upsert），
+ * 导入后可直接在共享库内做 AI 问答。单个文件失败不阻断整体。
+ */
+export async function importLibIntoSpace(
+  userId: string,
+  spaceId: string,
+  libName: string,
+): Promise<ImportLibResult> {
+  if (!safeId(spaceId)) return { ok: false, error: 'invalid_space' };
+  const name = String(libName || '').trim();
+  if (!name) return { ok: false, error: 'missing_lib_name' };
+  const srcDir = path.join(userContextsDir(userId), name);
+  let st: fs.Stats;
+  try {
+    st = await fsp.stat(srcDir);
+  } catch {
+    return { ok: false, error: 'source_lib_not_found' };
+  }
+  if (!st.isDirectory()) return { ok: false, error: 'source_lib_not_directory' };
+
+  const files = await contexts.collectImportableFilesFromDir(srcDir);
+  const absByRel = new Map(files.map((f) => [f.rel, f.abs]));
+  return importFilesIntoSpace(userId, spaceId, absByRel);
+}
+
+/**
+ * 把一组个人库文件（relPath → 绝对路径）导入共享库（空间）。
+ * 供「整库导入」与「弹窗勾选文件导入」复用：并发复制 + pending 占位，
+ * 返回逐文件结果，单个失败不阻断。
+ */
+export async function importFilesIntoSpace(
+  userId: string,
+  spaceId: string,
+  absByRel: Map<string, string>,
+): Promise<ImportLibResult> {
+  const entries = Array.from(absByRel.entries());
+  const out: Array<{ name: string; ok: boolean; error?: string }> = [];
+  let imported = 0;
+
+  // 有限并发导入（默认 6 路），避免逐文件串行拖慢大批量导入。
+  const CONCURRENCY = 6;
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (cursor < entries.length) {
+      const [rel, abs] = entries[cursor++];
+      try {
+        const r = await importSpaceFileFromPath(userId, spaceId, rel, abs, { skipHash: true });
+        if (r.ok) imported += 1;
+        out.push({ name: rel, ok: r.ok, error: r.ok ? undefined : String((r as { error?: string }).error || 'import_failed') });
+      } catch (err) {
+        out.push({ name: rel, ok: false, error: (err as Error)?.message || String(err) });
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, entries.length || 1) }, worker));
+
+  // 导入的文件已落盘并 enqueue 进索引队列，但向量化（提取/嵌入）是异步的，
+  // 直接读向量库快照会看不到新文件（"已导入 N 个但列表空"）。
+  // 这里为每个成功导入的文件写一条 pending 占位行（索引完成后会更新为 ready），
+  // 让列表立即可见、状态自然过渡。
+  if (imported > 0) {
+    try {
+      const store = vs.openVecStore(path.dirname(spaceLibraryVectorDbPath(userId, spaceId)));
+      for (const o of out) {
+        if (!o.ok) continue;
+        try {
+          const abs = absByRel.get(o.name);
+          if (!abs) continue;
+          const st = await fsp.stat(abs).catch(() => null);
+          if (!st) continue;
+          const existing = store.getFile(o.name);
+          if (existing && (existing.status === 'ready' || existing.status === 'processing' || existing.status === 'pending')) continue;
+          await store.setFileStatus(o.name, 'pending', {
+            kind: kindForName(o.name),
+            bytes: st.size,
+            mtime: st.mtimeMs / 1000,
+            sha1: await sha1Of(abs),
+          });
+        } catch { /* 占位失败不阻断（索引队列仍会兜底） */ }
+      }
+    } catch { /* store 打开失败不阻断 */ }
+  }
+
+  log.info('space import files done', {
+    userId, spaceId, scanned: entries.length, imported,
+  });
+  return { ok: true, scanned: entries.length, imported, files: out };
+}
 
 function reasonForError(err: unknown): string {
   if (!err) return 'copy_failed';
@@ -160,4 +258,23 @@ export async function importFolderIntoSpace(
 
 function logSafePath(p: string): string {
   return p.replace(/[A-Za-z]:\\/g, '').split(/[\\/]/).slice(-3).join('/');
+}
+
+/** 文件扩展名 → 向量库 kind（与 project_library_indexer.kindFor 一致）。 */
+function kindForName(name: string): vs.VecKind {
+  const ext = path.extname(name).toLowerCase();
+  if (ext === '.pdf') return 'pdf';
+  if (ext === '.docx' || ext === '.docm') return 'docx';
+  if (ext === '.xlsx' || ext === '.xlsm') return 'spreadsheet';
+  if (ext === '.pptx' || ext === '.pptm') return 'presentation';
+  if (['.png', '.jpg', '.jpeg', '.webp', '.gif', '.bmp', '.svg'].includes(ext)) return 'image';
+  return 'text';
+}
+
+/** 轻量 SHA-1（占位行需要；大文件也只需读一次）。 */
+async function sha1Of(absPath: string): Promise<string> {
+  const hash = crypto.createHash('sha1');
+  const stream = fs.createReadStream(absPath);
+  for await (const chunk of stream) hash.update(chunk as Buffer);
+  return hash.digest('hex');
 }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -1709,8 +1709,38 @@ const invokeHandlers: Record<string, InvokeHandler> = {
     };
   },
 
-  'spaces.files.createText': async ({ spaceId, name }, ctx) => {
+  // 共享知识库（空间）导入个人知识库：把个人库（contexts/）内容镜像导入到空间（spaces/），
+  // 对齐 ima「从个人知识库导入」：源目录结构保留，走空间索引队列（upsert）统一入库。
+  'spaces.files.importFromLib': async ({ spaceId, libName } = {}, ctx) => {
     if (!safeId(spaceId)) throw new Error('invalid spaceId');
+    if (!await spaces.spaceExists(ctx.userId, spaceId)) throw new Error('not_found');
+    const r = await spaceImport.importLibIntoSpace(ctx.userId, spaceId, String(libName || ''));
+    if (r.ok === false) return { ok: false, error: r.error };
+    return { ok: true, scanned: r.scanned, imported: r.imported, files: r.files };
+  },
+
+  // 共享知识库（空间）按选中的个人库文件导入：paths 为相对 contexts 根的文件路径数组
+  // （如 ["班级建设资料/a.pdf", "挑战资料/b.docx"]），供「导入内容」弹窗勾选后调用。
+  'spaces.files.importFromLibFiles': async ({ spaceId, paths } = {}, ctx) => {
+    if (!safeId(spaceId)) throw new Error('invalid spaceId');
+    if (!await spaces.spaceExists(ctx.userId, spaceId)) throw new Error('not_found');
+    const list = Array.isArray(paths) ? paths.map((p) => String(p || '')).filter(Boolean) : [];
+    if (!list.length) return { ok: false, error: 'no files selected' };
+    const contextsRoot = userContextsDir(ctx.userId);
+    const absByRel = new Map<string, string>();
+    for (const rel of list) {
+      const abs = path.join(contextsRoot, rel);
+      try {
+        if (fs.existsSync(abs) && fs.statSync(abs).isFile()) absByRel.set(rel, abs);
+      } catch { /* 跳过不可读项 */ }
+    }
+    if (!absByRel.size) return { ok: false, error: 'selected files not found' };
+    const r = await spaceImport.importFilesIntoSpace(ctx.userId, spaceId, absByRel);
+    if (r.ok === false) return { ok: false, error: r.error };
+    return { ok: true, scanned: r.scanned, imported: r.imported, files: r.files };
+  },
+
+  'spaces.files.createText': async ({ spaceId, name }, ctx) => {    if (!safeId(spaceId)) throw new Error('invalid spaceId');
     if (typeof name !== 'string' || !name) throw new Error('invalid name');
     return spaceFiles.createSpaceTextFile(ctx.userId, spaceId, name);
   },

--- a/src/main/util/file-import.ts
+++ b/src/main/util/file-import.ts
@@ -32,7 +32,11 @@ export async function withLocalImportLock<T>(key: string, worker: () => Promise<
   }
 }
 
-export async function inspectLocalImportSource(absPath: string, maxBytes: number): Promise<LocalImportSource> {
+export async function inspectLocalImportSource(
+  absPath: string,
+  maxBytes: number,
+  opts?: { skipHash?: boolean },
+): Promise<LocalImportSource> {
   if (!path.isAbsolute(absPath)) throw Object.assign(new Error('source path must be absolute'), { code: 'E_IMPORT_SOURCE' });
   const lst = await fsp.lstat(absPath);
   if (lst.isSymbolicLink() || !lst.isFile()) {
@@ -43,6 +47,10 @@ export async function inspectLocalImportSource(absPath: string, maxBytes: number
       code: 'E_FILE_TOO_LARGE',
       bytes: lst.size,
     });
+  }
+  // 批量导入场景（如个人库→空间）不需要内容哈希做去重，跳过可省一次全文件读取。
+  if (opts?.skipHash) {
+    return { absPath, bytes: lst.size, mtimeMs: lst.mtimeMs, sha1: '' };
   }
   const hash = crypto.createHash('sha1');
   const stream = fs.createReadStream(absPath);

--- a/src/renderer/modules/kb-eco.js
+++ b/src/renderer/modules/kb-eco.js
@@ -5,9 +5,9 @@
 (function () {
   // 只保留已落地入口（知识库/笔记/发现）；浏览/Agent/菜单为预留项，不展示避免误导。
   const ECO_NAV = [
-    { key: 'kb', icon: 'book-open', label: '知识库', status: 'ok' },
+    { key: 'kb', icon: 'folder', label: '知识库', status: 'ok' },
     { key: 'notes', icon: 'file-text', label: '笔记', status: 'ok' },
-    { key: 'discover', icon: 'sparkles', label: '发现', status: 'ok' },
+    { key: 'discover', icon: 'globe', label: '发现', status: 'ok' },
   ];
   const COMPACT_KEY = 'cogseed.kb.eco.compact';
   let _compact = false;

--- a/src/renderer/modules/kb-notes.js
+++ b/src/renderer/modules/kb-notes.js
@@ -88,6 +88,7 @@
             </div>
             <div class="kb-notes-items" id="kb-notes-items"></div>
           </aside>
+          <div class="kb-wb-divider" data-wb-divider="notes" title="拖动调整宽度"></div>
           <section class="kb-notes-editor">
             <div class="kb-notes-toolbar">
               <button type="button" class="ed-btn" data-cmd="undo" title="撤回">↩</button>
@@ -328,6 +329,48 @@
           const ed = document.getElementById('kb-notes-edit');
           if (ed && ed.dataset.note) { e.preventDefault(); _save(); }
         }
+      });
+      // 笔记列表 / 编辑器 分隔条拖拽（宽度持久化，无 localStorage 环境静默降级）
+      let notesDrag = null;
+      const _notesDividerLoad = () => {
+        try {
+          const w = Number(localStorage.getItem('kb-notes-c1'));
+          const box = document.querySelector('.kb-notes');
+          if (box && w >= 180 && w <= 480) box.style.setProperty('--kb-nc1', `${w}px`);
+        } catch { /* no-op */ }
+      };
+      const _notesDividerSave = () => {
+        try {
+          const box = document.querySelector('.kb-notes');
+          if (!box) return;
+          localStorage.setItem('kb-notes-c1', box.style.getPropertyValue('--kb-nc1') || '280');
+        } catch { /* no-op */ }
+      };
+      _notesDividerLoad();
+      host.querySelector('.kb-wb-divider[data-wb-divider="notes"]')?.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        const box = document.querySelector('.kb-notes');
+        if (!box) return;
+        notesDrag = {
+          startX: e.clientX,
+          startW: parseFloat(box.style.getPropertyValue('--kb-nc1')) || 280,
+        };
+        document.body.classList.add('kb-wb-resizing');
+        e.currentTarget.classList.add('is-dragging');
+      });
+      document.addEventListener('mousemove', (e) => {
+        if (!notesDrag) return;
+        const box = document.querySelector('.kb-notes');
+        if (!box) return;
+        const w = Math.min(480, Math.max(180, notesDrag.startW + (e.clientX - notesDrag.startX)));
+        box.style.setProperty('--kb-nc1', `${w}px`);
+      });
+      document.addEventListener('mouseup', () => {
+        if (!notesDrag) return;
+        notesDrag = null;
+        document.body.classList.remove('kb-wb-resizing');
+        host.querySelectorAll('.kb-wb-divider').forEach((x) => x.classList.remove('is-dragging'));
+        _notesDividerSave();
       });
     }
     _loadNotes();

--- a/src/renderer/modules/kb-workbench.js
+++ b/src/renderer/modules/kb-workbench.js
@@ -25,13 +25,17 @@
     mmBg: 'dots', // 背景 dots=点阵 | plain=纯白 | none=无
     mmSearchHits: new Set(), // 脑内搜索命中节点 idx
     mmViewMode: 'graph', // graph=图形 | outline=大纲
-    treeGroups: new Set(), // 已折叠的库树组名（个人知识库/共享知识库/订阅知识库）
+    treeGroups: new Set(), // 已折叠的库树组名（个人知识库/共享知识库）
     expanded: new Set(), // 已展开的文件夹相对路径（内联展开/折叠）
     spaces: [],
     spaceId: null,
     spaceName: '',
     spaceFiles: [],
     filePerms: {}, // 共享库文件成员权限（会话内：path → view_export|view_only|hidden）
+    pendingRename: {}, // 共享库文件重命名待索引合并：oldPath → newPath（防刷新快照"消失"）
+    pendingDelete: new Set(), // 共享库文件删除待索引合并
+    sideCollapsed: false, // 知识库列表面板收起
+    treeFilter: '', // 库树搜索关键词（过滤个人库+共享库）
   };
 
   const _TYPE_LABEL = { pdf: 'PDF', excel: 'EXCEL', ppt: 'PPT', img: '图片', word: 'WORD', txt: 'TXT' };
@@ -54,15 +58,19 @@
     sort: '<path d="M8 6h13M8 12h9M8 18h5M3 6h.01M3 12h.01M3 18h.01"/>',
     refresh: '<path d="M21 12a9 9 0 1 1-2.64-6.36M21 3v6h-6"/>',
     upload: '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M17 8l-5-5-5 5M12 3v12"/>',
-    search: '<circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>',
-    send: '<path d="m22 2-7 20-4-9-9-4z"/><path d="M22 2 11 13"/>',
-    plus: '<path d="M12 5v14M5 12h14"/>',
+    search: '<circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/>',
+    send: '<path d="M3.6 4.4 20.6 12 3.6 19.6l2.4-7.6z"/><path d="M6 12h14.6"/>',
+    plus: '<rect x="4" y="4" width="16" height="16" rx="4.5"/><path d="M12 8v8M8 12h8"/>',
     trash: '<path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/>',
-    more: '<circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/>',
-    share: '<path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><path d="m16 6-4-4-4 4M12 2v13"/>',
+    more: '<circle cx="12" cy="5" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="19" r="1.6"/>',
+    share: '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>',
+    chip: '<rect x="5" y="7" width="14" height="10" rx="2.5"/><path d="M9 7V4.5M15 7V4.5M9 19.5V17M15 19.5V17M10.5 12h3"/>',
+    'chevron-down': '<path d="m6 9 6 6 6-6"/>',
+    'chevron-right': '<path d="m9 6 6 6-6 6"/>',
+    'panel-collapse': '<rect x="4" y="5" width="6" height="14" rx="1.5"/><rect x="14" y="5" width="6" height="14" rx="1.5"/>',
   };
   function _svg(name) {
-    return `<svg class="kb-ico-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${_SVGS[name] || ''}</svg>`;
+    return `<svg class="kb-ico-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${_SVGS[name] || ''}</svg>`;
   }
 
   function _extClass(name) {
@@ -157,15 +165,14 @@
     const tree = document.getElementById('kb-wb-tree');
     if (!tree) return;
     const groups = [
-      { key: '个人知识库', label: '个人知识库', plus: true, btnId: 'kb-new-lib', btnTitle: '创建个人知识库', html: _state.libs.map((l) =>
+      { key: '个人知识库', label: '个人知识库', plus: true, btnId: 'kb-new-lib', btnTitle: '创建个人知识库', html: _state.libs.filter((l) => !_state.treeFilter || l.name.toLowerCase().includes(_state.treeFilter)).map((l) =>
         `<div class="kb-tree-item${l.name === _state.currentLib && !_state.spaceId ? ' active' : ''}" data-kb-lib="${_esc(l.name)}">
-          ${_icon('book-open', 'kb-tree-ico')}<span class="kb-tree-name">${_esc(l.name)}</span></div>`
+          ${_icon('folder', 'kb-tree-ico')}<span class="kb-tree-name">${_esc(l.name)}</span></div>`
       ).join('') || '<div class="kb-tree-empty">暂无知识库，点击 ＋ 创建</div>' },
-      { key: '共享知识库', label: '共享知识库', plus: true, btnId: 'kb-new-shared-space', btnTitle: '创建共享知识库', html: _state.spaces.map((sp) =>
+      { key: '共享知识库', label: '共享知识库', plus: true, btnId: 'kb-new-shared-space', btnTitle: '创建共享知识库', html: _state.spaces.filter((sp) => !_state.treeFilter || (sp.name || sp.space_id).toLowerCase().includes(_state.treeFilter)).map((sp) =>
         `<div class="kb-tree-item${sp.space_id === _state.spaceId ? ' active' : ''}" data-kb-space="${_esc(sp.space_id)}">
-          ${_icon('folder-open', 'kb-tree-ico kb-tree-ico-space')}<span class="kb-tree-name">${_esc(sp.name || sp.space_id)}</span><span class="kb-badge-share">共享</span></div>`
-      ).join('') || '<div class="kb-tree-placeholder">暂无共享空间</div>' },
-      { key: '订阅知识库', label: '订阅知识库', plus: false, html: '<div class="kb-tree-placeholder">订阅 · S4 上线</div>' },
+          ${_icon('folder', 'kb-tree-ico kb-tree-ico-space')}<span class="kb-tree-name">${_esc(sp.name || sp.space_id)}</span><span class="kb-badge-share" title="共享知识库">${_icon('users', 'kb-share-ico')}</span></div>`
+      ).join('') || '<div class="kb-tree-placeholder">' + (_state.treeFilter ? '无匹配知识库' : '暂无共享空间') + '</div>' },
     ];
     const groupHtml = groups.map((g) => {
       const open = !_state.treeGroups.has(g.key);
@@ -228,7 +235,32 @@
     try {
       const res = await window.cogseed.invoke('spaces.files.status', { spaceId });
       if (_state.spaceId !== spaceId) return; // 已切换
-      _state.spaceFiles = (res && Array.isArray(res.files)) ? res.files : [];
+      let files = (res && Array.isArray(res.files)) ? res.files : [];
+      // 合并 pending 乐观操作（索引队列 delete/upsert 异步，快照可能短暂缺失）：
+      // 1) 重命名：快照中的旧名映射到新名；upsert 未完成（快照缺新名）用本地乐观项兜底，文件不消失
+      const pr = _state.pendingRename || {};
+      if (Object.keys(pr).length) {
+        files = files.map((f) => {
+          const key = f.path || f.name;
+          return pr[key] ? { ...f, name: pr[key], path: pr[key] } : f;
+        });
+        for (const newP of Object.values(pr)) {
+          if (!files.some((f) => (f.path || f.name) === newP)) {
+            const local = _state.spaceFiles.find((f) => (f.path || f.name) === newP);
+            if (local) files.push(local);
+          }
+        }
+        const done = Object.entries(pr).every(([oldP, newP]) =>
+          files.some((f) => (f.path || f.name) === newP) && !files.some((f) => (f.path || f.name) === oldP));
+        if (done) _state.pendingRename = {};
+      }
+      // 2) 删除：快照残留的待删项移除
+      if (_state.pendingDelete && _state.pendingDelete.size) {
+        const before = files.length;
+        files = files.filter((f) => !_state.pendingDelete.has(f.path || f.name));
+        if (files.length < before) _state.pendingDelete.clear();
+      }
+      _state.spaceFiles = files;
       _renderFiles();
       _renderRight();
     } catch (err) {
@@ -431,11 +463,11 @@
   }
 
   // 空态：居中插图 + 大号主按钮（保留库头部骨架，不一片白板）
-  // 空库（左侧无库）→ 创建知识库；库内无内容 → 「去这里添加」引导打开导入菜单
+  // 空库（左侧无库）→ 创建知识库；库内无内容 → 「添加内容」打开与工具栏一致的导入菜单
   function _emptyStateHtml(kind) {
     const createBtn = kind === 'lib'
       ? '<button type="button" class="kb-empty-btn" id="kb-empty-create">＋ 创建知识库</button>'
-      : '<button type="button" class="kb-empty-btn" id="kb-empty-add">＋ 添加内容</button><button type="button" class="kb-empty-btn kb-empty-btn-ghost" id="kb-empty-import-dir">＋ 上传文件夹</button>';
+      : '<button type="button" class="kb-empty-btn" id="kb-empty-add">＋ 添加内容</button>';
     return `<div class="kb-empty">
       <div class="kb-empty-illus">${_icon('book-open', 'kb-empty-ico')}</div>
       <div class="kb-empty-title">${kind === 'lib' ? '还没有知识库' : '知识库什么也没有，去这里添加'}</div>
@@ -444,19 +476,16 @@
     </div>`;
   }
 
-  // 空态按钮绑定：空库 → 创建；库内空 → 「添加内容」打开导入菜单 + 上传文件夹
-  function _bindEmptyActions(isSpace) {
+  // 空态按钮绑定：空库 → 创建；库内空 → 「添加内容」打开导入菜单（与工具栏同一入口）
+  function _bindEmptyActions() {
     const create = document.getElementById('kb-empty-create');
     if (create) create.addEventListener('click', _createLib);
     const add = document.getElementById('kb-empty-add');
-    if (add) add.addEventListener('click', () => {
+    if (add) add.addEventListener('click', (e) => {
+      e.stopPropagation(); // 阻止冒泡到 document 的全局菜单关闭，否则菜单刚打开就被关闭
       const b = document.getElementById('kb-wb-import');
       if (b) b.click();
     });
-    const imp = document.getElementById('kb-empty-import');
-    if (imp) imp.addEventListener('click', isSpace ? _importSpaceFiles : _importFiles);
-    const impDir = document.getElementById('kb-empty-import-dir');
-    if (impDir) impDir.addEventListener('click', isSpace ? _importSpaceDir : _importDir);
   }
 
   // 共享库（空间）上传文件：spaces.files.pickAndUpload
@@ -497,6 +526,254 @@
       _log.warn('space import dir failed', err);
       if (typeof uiToast === 'function') uiToast('导入文件夹失败', { variant: 'error' });
     }
+  }
+
+  // ── 导入内容弹窗（共享库 ← 个人知识库文件多选，对标 ima 导入对话框）──
+  let _dlgLib = '';          // 当前个人库名
+  let _dlgDir = '';          // 当前目录（相对库根的路径段，'' = 库根）
+  let _dlgHistory = []; // 目录历史（进入的子目录路径）
+  let _dlgHistIdx = -1;      // 历史游标
+  let _dlgSelected = new Set(); // 选中的文件 relPath（含库前缀，如 班级建设资料/a.pdf）
+  let _dlgFilter = '';
+
+  function _importDlgNode(libName, dirSegs) {
+    const lib = _state.tree.find((n) => n.type === 'dir' && n.name === libName);
+    if (!lib) return null;
+    let node = lib;
+    for (const seg of dirSegs) {
+      const next = (node.children || []).find((n) => n.type === 'dir' && n.name === seg);
+      if (!next) return null;
+      node = next;
+    }
+    return node;
+  }
+
+  function _importDlgRelPath(libName, dirSegs, name) {
+    return [libName, ...dirSegs, name].filter(Boolean).join('/');
+  }
+
+  function _renderImportDlgList() {
+    const overlay = document.querySelector('.kb-import-dlg-overlay');
+    if (!overlay) return;
+    const node = _importDlgNode(_dlgLib, _dlgDir.split('/').filter(Boolean));
+    const q = _dlgFilter.trim().toLowerCase();
+    // 子目录 + 文件（文件多选）
+    const dirs = (node && node.children ? node.children : [])
+      .filter((n) => n.type === 'dir')
+      .filter((n) => !q || n.name.toLowerCase().includes(q));
+    const files = (node && node.children ? node.children : [])
+      .filter((n) => n.type === 'file')
+      .filter((n) => !q || n.name.toLowerCase().includes(q));
+    let html = '';
+    for (const d of dirs) {
+      html += `<div class="kb-import-dlg-row is-dir" data-import-dir="${_esc(d.name)}">
+        ${_icon('folder', 'kb-import-dlg-ico')}
+        <span class="kb-import-dlg-name">${_esc(d.name)}</span>
+        <span class="kb-import-dlg-meta">文件夹</span>
+      </div>`;
+    }
+    for (const f of files) {
+      const rel = _importDlgRelPath(_dlgLib, _dlgDir.split('/').filter(Boolean), f.name);
+      const checked = _dlgSelected.has(rel) ? ' checked' : '';
+      html += `<div class="kb-import-dlg-row${checked}" data-import-file="${_esc(rel)}">
+        <input type="checkbox" class="kb-import-dlg-check" data-import-check="${_esc(rel)}" ${checked ? 'checked' : ''} />
+        <span class="kb-import-dlg-icon is-${_extClass(f.name)}">${_extLabel(f.name)}</span>
+        <span class="kb-import-dlg-name" title="${_esc(f.name)}">${_esc(f.name)}</span>
+        <span class="kb-import-dlg-meta">${_esc(_extLabel(f.name))}</span>
+      </div>`;
+    }
+    if (!dirs.length && !files.length) {
+      html = '<div class="kb-import-dlg-empty">' + (q ? '无匹配文件' : '此目录为空') + '</div>';
+    }
+    overlay.querySelector('.kb-import-dlg-files').innerHTML = html;
+    // 路径栏
+    const pathEl = overlay.querySelector('.kb-import-dlg-path');
+    const segs = _dlgDir.split('/').filter(Boolean);
+    pathEl.textContent = [_dlgLib, ...segs].join(' / ');
+    _syncImportDlgFooter(overlay);
+  }
+
+  function _syncImportDlgFooter(overlay) {
+    const countEl = overlay.querySelector('.kb-import-dlg-count');
+    const okBtn = overlay.querySelector('.kb-import-dlg-ok');
+    if (countEl) countEl.textContent = `已选中 ${_dlgSelected.size} 个文件`;
+    if (okBtn) okBtn.disabled = _dlgSelected.size === 0;
+  }
+
+  function _bindImportDlgEvents(overlay) {
+    overlay.querySelector('.kb-import-dlg-close')?.addEventListener('click', () => overlay.remove());
+    overlay.querySelector('.kb-import-dlg-cancel')?.addEventListener('click', () => overlay.remove());
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
+    // 返回 / 前进
+    overlay.querySelector('.kb-import-dlg-back')?.addEventListener('click', () => {
+      if (_dlgHistIdx <= 0) return;
+      _dlgHistIdx -= 1;
+      const cur = _dlgHistory[_dlgHistIdx];
+      const parts = String(cur || '').split('/');
+      _dlgLib = parts[0] || '';
+      _dlgDir = parts.slice(1).join('/');
+      _renderImportDlgList();
+      _syncImportDlgNav(overlay);
+    });
+    overlay.querySelector('.kb-import-dlg-forward')?.addEventListener('click', () => {
+      if (_dlgHistIdx >= _dlgHistory.length - 1) return;
+      _dlgHistIdx += 1;
+      const cur = _dlgHistory[_dlgHistIdx];
+      const parts = String(cur || '').split('/');
+      _dlgLib = parts[0] || '';
+      _dlgDir = parts.slice(1).join('/');
+      _renderImportDlgList();
+      _syncImportDlgNav(overlay);
+    });
+    // 搜索
+    const searchInput = overlay.querySelector('.kb-import-dlg-search input');
+    searchInput?.addEventListener('input', (e) => {
+      _dlgFilter = String(e.target.value || '').trim();
+      _renderImportDlgList();
+    });
+    // 左侧树：切换知识库
+    overlay.querySelectorAll('[data-import-lib]').forEach((el) => {
+      el.addEventListener('click', () => {
+        const name = el.dataset.importLib;
+        _pushImportDlgHistory(`${name}`);
+        _renderImportDlgList();
+        overlay.querySelectorAll('[data-import-lib]').forEach((x) => x.classList.remove('active'));
+        el.classList.add('active');
+        _syncImportDlgNav(overlay);
+      });
+    });
+    // 右侧：子目录进入 / 文件勾选
+    overlay.querySelector('.kb-import-dlg-files')?.addEventListener('click', (e) => {
+      const dirEl = e.target.closest('[data-import-dir]');
+      if (dirEl) {
+        const segs = _dlgDir.split('/').filter(Boolean);
+        segs.push(dirEl.dataset.importDir);
+        _pushImportDlgHistory(`${_dlgLib}/${segs.join('/')}`);
+        _dlgDir = segs.join('/');
+        _renderImportDlgList();
+        _syncImportDlgNav(overlay);
+        return;
+      }
+      const checkEl = e.target.closest('[data-import-check]');
+      if (checkEl) {
+        const rel = checkEl.dataset.importCheck;
+        if (_dlgSelected.has(rel)) _dlgSelected.delete(rel);
+        else _dlgSelected.add(rel);
+        // 只更新当前行选中态与底部统计，不重渲染整个列表（避免连续勾选时 DOM 重建丢事件）
+        const row = checkEl.closest('.kb-import-dlg-row');
+        if (row) row.classList.toggle('checked', _dlgSelected.has(rel));
+        _syncImportDlgFooter(overlay);
+        return;
+      }
+      const rowEl = e.target.closest('[data-import-file]');
+      if (rowEl) {
+        const rel = rowEl.dataset.importFile;
+        if (_dlgSelected.has(rel)) _dlgSelected.delete(rel);
+        else _dlgSelected.add(rel);
+        rowEl.classList.toggle('checked', _dlgSelected.has(rel));
+        const cb = rowEl.querySelector('[data-import-check]');
+        if (cb) cb.checked = _dlgSelected.has(rel);
+        _syncImportDlgFooter(overlay);
+      }
+    });
+    // 导入
+    overlay.querySelector('.kb-import-dlg-ok')?.addEventListener('click', async () => {
+      if (!_dlgSelected.size) return;
+      const files = Array.from(_dlgSelected);
+      const okBtn = overlay.querySelector('.kb-import-dlg-ok');
+      okBtn.disabled = true;
+      okBtn.textContent = '导入中…';
+      try {
+        const res = await window.cogseed.invoke('spaces.files.importFromLibFiles', { spaceId: _state.spaceId, paths: files });
+        if (!res || res.ok === false) {
+          if (typeof uiToast === 'function') uiToast('导入失败：' + ((res && res.error) || 'unknown'), { variant: 'error' });
+          return;
+        }
+        if (typeof uiToast === 'function') {
+          uiToast(`已导入 ${Number(res.imported) || 0} 个文件`, { variant: 'success', timeoutMs: 2500 });
+        }
+        overlay.remove();
+        _loadSpaceFiles(_state.spaceId);
+      } catch (err) {
+        _log.warn('import dlg files failed', err);
+        if (typeof uiToast === 'function') uiToast('导入失败', { variant: 'error' });
+        okBtn.disabled = false;
+        okBtn.textContent = '导入';
+      }
+    });
+  }
+
+  function _pushImportDlgHistory(loc) {
+    // 剪掉游标之后的旧前进记录
+    _dlgHistory = _dlgHistory.slice(0, _dlgHistIdx + 1);
+    _dlgHistory.push(loc);
+    _dlgHistIdx = _dlgHistory.length - 1;
+    _syncImportDlgNav(document.querySelector('.kb-import-dlg-overlay'));
+  }
+
+  function _syncImportDlgNav(overlay) {
+    if (!overlay) return;
+    const back = overlay.querySelector('.kb-import-dlg-back');
+    const fwd = overlay.querySelector('.kb-import-dlg-forward');
+    if (back) back.disabled = _dlgHistIdx <= 0;
+    if (fwd) fwd.disabled = _dlgHistIdx >= _dlgHistory.length - 1;
+  }
+
+  // 共享库（空间）导入个人知识库：打开「导入内容」多选弹窗（对标 ima）
+  async function _importSpaceFromLib() {
+    if (!_state.spaceId) return;
+    if (!window.cogseed || typeof window.cogseed.invoke !== 'function') return;
+    // 确保个人库树已加载
+    if (!_state.libs.length) {
+      if (typeof uiToast === 'function') uiToast('没有可导入的个人知识库', { variant: 'warning' });
+      return;
+    }
+    _dlgLib = _state.libs[0].name;
+    _dlgDir = '';
+    _dlgHistory = [_dlgLib];
+    _dlgHistIdx = 0;
+    _dlgSelected = new Set();
+    _dlgFilter = '';
+    const libItems = _state.libs.map((l, i) =>
+      `<div class="kb-import-dlg-lib${i === 0 ? ' active' : ''}" data-import-lib="${_esc(l.name)}">
+        ${_icon('folder', 'kb-import-dlg-ico')}<span class="kb-import-dlg-name">${_esc(l.name)}</span>
+      </div>`).join('') || '<div class="kb-import-dlg-empty">暂无个人知识库</div>';
+    const overlay = document.createElement('div');
+    overlay.className = 'kb-import-dlg-overlay';
+    overlay.innerHTML = `
+      <div class="kb-import-dlg">
+        <div class="kb-import-dlg-head">
+          <div class="kb-import-dlg-title"><span class="kb-import-dlg-title-ico">${_svg('upload')}</span>导入内容</div>
+          <div class="kb-import-dlg-search">
+            <span class="kb-import-dlg-search-ico">${_svg('search')}</span>
+            <input type="text" placeholder="搜索" autocomplete="off" spellcheck="false" />
+          </div>
+          <button type="button" class="kb-import-dlg-close" title="关闭">✕</button>
+        </div>
+        <div class="kb-import-dlg-nav">
+          <button type="button" class="kb-import-dlg-back" title="返回">←</button>
+          <button type="button" class="kb-import-dlg-forward" title="前进">→</button>
+          <span class="kb-import-dlg-path"></span>
+        </div>
+        <div class="kb-import-dlg-body">
+          <div class="kb-import-dlg-tree">
+            <div class="kb-import-dlg-group">个人知识库</div>
+            <div class="kb-import-dlg-libs">${libItems}</div>
+          </div>
+          <div class="kb-import-dlg-files"></div>
+        </div>
+        <div class="kb-import-dlg-foot">
+          <span class="kb-import-dlg-count">已选中 0 个文件</span>
+          <div class="kb-import-dlg-actions">
+            <button type="button" class="kb-import-dlg-cancel">取消</button>
+            <button type="button" class="kb-import-dlg-ok" disabled>导入</button>
+          </div>
+        </div>
+      </div>`;
+    document.body.appendChild(overlay);
+    _bindImportDlgEvents(overlay);
+    _renderImportDlgList();
+    _syncImportDlgNav(overlay);
   }
 
   // 导入菜单「新建文件夹」：个人库 contexts.mkdir / 空间 spaces.files.mkdir
@@ -619,8 +896,13 @@
     if (lib) _renderNodeRows(parts, lib.children || [], 0, lib.path || _state.currentLib, q);
     // 底部：没有更多内容了（对齐 ima 列表结束提示）
     const endTip = parts.length ? '<div class="kb-files-end">没有更多内容了</div>' : '';
-    list.innerHTML = (parts.join('') + endTip) || _emptyStateHtml('file');
-    if (!parts.length) _bindEmptyActions(false);
+    if (!parts.length && q) {
+      // 搜索无结果：显示"无匹配"占位，不显示空库引导（避免误导为新库）
+      list.innerHTML = '<div class="kb-empty"><div class="kb-empty-title">无匹配文档</div><div class="kb-empty-sub">换个关键词试试，支持按文件名搜索库内所有文件（含文件夹中的文件）</div></div>';
+    } else {
+      list.innerHTML = (parts.join('') + endTip) || _emptyStateHtml('file');
+      if (!parts.length) _bindEmptyActions();
+    }
 
     list.querySelectorAll('[data-kb-dir]').forEach((el) => {
       el.addEventListener('click', () => _toggleDir(el.dataset.kbDir));
@@ -664,15 +946,58 @@
     return `${d.getMonth() + 1}/${d.getDate()}`;
   }
 
+  // 搜索模式下文件行显示所在目录（相对当前库，根目录显示「库根」）
+  function _relDirLabel(parentPath) {
+    const cur = String(_state.currentLib || '');
+    const base = cur ? new RegExp('^' + _escReg(cur) + '(?:/|$)') : null;
+    const rel = base ? String(parentPath || '').replace(base, '').replace(/\/+$/, '') : String(parentPath || '');
+    return rel ? `📁 ${rel}` : '库根';
+  }
+
+  function _escReg(s) {
+    return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
   function _renderNodeRows(parts, children, level, parentPath, q) {
     const pad = 16 + level * 20;
+    // 搜索模式：无视展开状态递归全树，匹配的目录/文件都展示（文件标注所在目录）
+    if (q) {
+      const dirs = (children || [])
+        .filter((n) => n.type === 'dir' && n.name.toLowerCase().includes(q))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const files = _sortFiles((children || [])
+        .filter((n) => n.type === 'file' && n.name.toLowerCase().includes(q)));
+      for (const d of dirs) {
+        const path = `${parentPath}/${d.name}`;
+        parts.push(`<div class="kb-file-row is-dir" data-kb-dir="${_esc(path)}" style="padding-left:${pad}px">
+          ${_icon('chevron-right', 'kb-mini-ico kb-dir-caret')}
+          ${_icon('folder-open', 'kb-file-icon-svg is-dir')}
+          <span class="kb-file-name">${_esc(d.name)}</span>
+          <span class="kb-file-meta">${_countFiles(d)} 项</span>
+          <span class="kb-file-actions"><button type="button" class="kb-mini-btn" data-kb-dir-toggle="${_esc(path)}" title="展开">${_icon('chevron-right', 'kb-mini-ico')}</button></span>
+        </div>`);
+      }
+      for (const f of files) {
+        const rel = `${parentPath}/${f.name}`;
+        parts.push(`<div class="kb-file-row" data-kb-file="${_esc(rel)}" style="padding-left:${pad}px">
+          <span class="kb-file-icon is-${_extClass(f.name)}">${_extLabel(f.name)}</span>
+          <span class="kb-file-name">${_esc(f.name)}</span>
+          <span class="kb-file-meta">${_esc(_relDirLabel(parentPath))}</span>
+          <span class="kb-file-date">${_fmtDate(f.mtime)}</span>
+          ${_statusChip(rel)}
+          <span class="kb-file-actions"><button type="button" class="kb-mini-btn" title="生成思维导图（S3）">${_icon('sparkles', 'kb-mini-ico')}</button><button type="button" class="kb-mini-btn" title="更多">${_icon('more-horizontal', 'kb-mini-ico')}</button></span>
+        </div>`);
+      }
+      for (const d of (children || []).filter((n) => n.type === 'dir')) {
+        _renderNodeRows(parts, d.children || [], level + 1, `${parentPath}/${d.name}`, q);
+      }
+      return;
+    }
     const dirs = (children || [])
       .filter((n) => n.type === 'dir')
-      .filter((n) => !q || n.name.toLowerCase().includes(q))
       .sort((a, b) => a.name.localeCompare(b.name));
     const files = _sortFiles((children || [])
-      .filter((n) => n.type === 'file')
-      .filter((n) => !q || n.name.toLowerCase().includes(q)));
+      .filter((n) => n.type === 'file'));
     for (const d of dirs) {
       const path = `${parentPath}/${d.name}`;
       const open = _state.expanded.has(path);
@@ -730,9 +1055,16 @@
     }
     // 底部：没有更多内容了（对齐 ima 列表结束提示）
     if (files.length) html += '<div class="kb-files-end">没有更多内容了</div>';
+    if (!html && q) {
+      // 搜索无结果：不显示空库引导
+      list.innerHTML = '<div class="kb-empty"><div class="kb-empty-title">无匹配文档</div><div class="kb-empty-sub">换个关键词试试，支持按文件名搜索库内所有文件（含文件夹中的文件）</div></div>';
+      _renderCount(0);
+      _renderRight();
+      return;
+    }
     if (!html) html = _emptyStateHtml('file');
     list.innerHTML = html;
-    _bindEmptyActions(true);
+    _bindEmptyActions();
     list.querySelectorAll('[data-kb-space-file]').forEach((el) => {
       el.addEventListener('click', () => {
         if (typeof uiToast === 'function') uiToast('空间库原文查看：后续版本支持', { variant: 'info' });
@@ -742,6 +1074,15 @@
         e.preventDefault(); e.stopPropagation();
         _kbSpaceFileMenu(el.dataset.kbSpaceFile, e.clientX, e.clientY);
       });
+      // 「…」按钮 = 与右键同一菜单（保持入口一致）
+      const moreBtn = el.querySelector('.kb-mini-btn[title="更多"]');
+      if (moreBtn) {
+        moreBtn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const b = el.getBoundingClientRect();
+          _kbSpaceFileMenu(el.dataset.kbSpaceFile, b.x + b.width - 40, b.y + 20);
+        });
+      }
     });
     const crumb = document.getElementById('kb-wb-crumb');
     if (crumb) crumb.hidden = true;
@@ -905,7 +1246,7 @@
     }
     _state.summaryLib = key;
     if (!window.cogseed || typeof window.cogseed.invoke !== 'function') {
-      card.innerHTML = '<div class="kb-wb-right-card-title">✨ AI 解析本知识库</div><div class="kb-wb-right-placeholder">解析服务不可用</div>';
+      card.innerHTML = '<div class="kb-wb-right-card-title"><span class="kb-wb-ai-chip"></span>AI 解析本知识库</div><div class="kb-wb-right-placeholder">解析服务不可用</div>';
       return;
     }
     const holder = card.querySelector('.kb-wb-right-placeholder');
@@ -952,7 +1293,7 @@
     </span>`;
 
     let html = `<div class="kb-wb-right-card-title">
-      <span>✨ AI 解析本知识库${srcTag}<span class="kb-wb-card-src">（${docs.length} 个文档）</span></span>
+      <span><span class="kb-wb-ai-chip"></span>AI 解析本知识库${srcTag}<span class="kb-wb-card-src">（${docs.length} 个文档）</span></span>
       ${actions}
     </div>`;
 
@@ -1946,14 +2287,26 @@
     _state.rendered = true;
     host.innerHTML = `
       <div class="kb-wb">
+        <button type="button" class="kb-wb-side-expand" id="kb-wb-side-expand" title="展开知识库列表" hidden>${_svg('chevron-right')}</button>
         <aside class="kb-wb-side">
-          <div class="kb-wb-side-head"><h2>知识库列表</h2><button type="button" class="kb-wb-icon-btn" id="kb-wb-global-search" title="全局搜索（搜-读-写入口）">${_svg('search')}</button></div>
+          <div class="kb-wb-side-head">
+            <h2>知识库列表</h2>
+            <div class="kb-wb-side-actions">
+              <button type="button" class="kb-wb-icon-btn" id="kb-wb-side-collapse" title="收起 / 展开知识库面板">${_svg('panel-collapse')}</button>
+              <button type="button" class="kb-wb-icon-btn" id="kb-wb-side-search-btn" title="搜索知识库">${_svg('search')}</button>
+            </div>
+          </div>
+          <div class="kb-wb-side-search" id="kb-wb-side-search" hidden>
+            <span class="kb-wb-side-search-ico">${_svg('search')}</span>
+            <input type="text" id="kb-wb-side-search-input" placeholder="搜索知识库…" autocomplete="off" spellcheck="false" />
+          </div>
           <div class="kb-wb-tree" id="kb-wb-tree"></div>
         </aside>
+        <div class="kb-wb-divider" data-wb-divider="1" title="拖动调整宽度"></div>
         <section class="kb-wb-mid">
           <div class="kb-wb-mid-head">
             <div class="kb-wb-lib-head">
-              <div class="kb-wb-lib-cover" id="kb-wb-lib-cover"><span class="kb-wb-cover-icon">📁</span></div>
+              <div class="kb-wb-lib-cover" id="kb-wb-lib-cover"><svg class="kb-wb-cover-svg" viewBox="0 0 24 24" fill="rgba(255,255,255,.96)" stroke="rgba(255,255,255,.96)" stroke-width="1.6" stroke-linejoin="round"><path d="M3.5 7.5a2 2 0 0 1 2-2h4.2l1.8 2.2h7a2 2 0 0 1 2 2v7.3a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2z"/></svg></div>
               <div class="kb-wb-lib-meta">
                 <div class="kb-wb-lib-name" id="kb-wb-lib-name">知识库</div>
                 <div class="kb-wb-lib-owner" id="kb-wb-lib-owner"><span class="kb-wb-owner-avatar" id="kb-wb-owner-avatar">我</span><span class="kb-wb-owner-name" id="kb-wb-owner-name">我</span></div>
@@ -1988,7 +2341,7 @@
                     <div class="kb-wb-sort-item" data-sort="name">名称</div>
                   </div>
                 </div>
-                <button type="button" class="kb-wb-icon-btn" id="kb-wb-refresh" title="刷新（重新索引）">${_svg('refresh')}</button>
+                <button type="button" class="kb-wb-icon-btn" id="kb-wb-refresh" title="重置排序并刷新">${_svg('refresh')}</button>
                 <div class="kb-wb-import-wrap">
                   <button type="button" class="kb-wb-icon-btn" id="kb-wb-import" title="导入内容">${_svg('upload')}</button>
                   <div class="kb-wb-import-menu" id="kb-wb-import-menu" hidden>
@@ -2013,11 +2366,12 @@
           </div>
           <div class="kb-wb-files" id="kb-wb-files"></div>
         </section>
+        <div class="kb-wb-divider" data-wb-divider="2" title="拖动调整宽度"></div>
         <section class="kb-wb-right">
           <div class="kb-wb-right-head"><span class="kb-wb-chip">📚 <span id="kb-wb-right-lib">—</span></span><span class="kb-wb-local"><span class="kb-wb-dot"></span>本地推理 · 资料不上云</span></div>
           <div class="kb-wb-right-body" id="kb-wb-right">
             <div class="kb-wb-right-card" id="kb-wb-analysis-card">
-              <div class="kb-wb-right-card-title">✨ AI 解析本知识库</div>
+              <div class="kb-wb-right-card-title"><span class="kb-wb-ai-chip"></span>AI 解析本知识库</div>
               <div class="kb-wb-right-card-sub" id="kb-wb-analysis-sub">当前库：—</div>
               <div class="kb-wb-right-placeholder"><button type="button" class="kb-wb-a-btn" id="kb-analyze-btn">✨ 生成 AI 解析</button></div>
             </div>
@@ -2091,8 +2445,109 @@
     }
     document.getElementById('kb-wb-lib-name').textContent = _state.currentLib || '知识库';
     document.getElementById('kb-wb-right-lib').textContent = _state.currentLib || '—';
-    document.getElementById('kb-wb-global-search')?.addEventListener('click', () => {
-      if (typeof uiToast === 'function') uiToast('全局搜索（Cmd/Ctrl+K）', { variant: 'info' });
+    // 知识库列表搜索：点击放大镜展开输入框，实时过滤全部库（个人+共享）
+    const sideSearch = document.getElementById('kb-wb-side-search');
+    const sideSearchInput = document.getElementById('kb-wb-side-search-input');
+    document.getElementById('kb-wb-side-search-btn')?.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (!sideSearch) return;
+      sideSearch.hidden = !sideSearch.hidden;
+      if (!sideSearch.hidden) {
+        sideSearchInput?.focus();
+      } else {
+        _state.treeFilter = '';
+        if (sideSearchInput) sideSearchInput.value = '';
+        _renderTree();
+      }
+    });
+    sideSearchInput?.addEventListener('input', (e) => {
+      _state.treeFilter = String(e.target.value || '').trim().toLowerCase();
+      _renderTree();
+    });
+    sideSearchInput?.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        _state.treeFilter = '';
+        sideSearchInput.value = '';
+        _renderTree();
+        if (sideSearch) sideSearch.hidden = true;
+      }
+    });
+    // 侧边栏折叠：收起整个知识库列表面板，给内容区更多空间
+    const collapseBtn = document.getElementById('kb-wb-side-collapse');
+    const expandBtn = document.getElementById('kb-wb-side-expand');
+    const applySideCollapsed = () => {
+      const wb = document.querySelector('.kb-wb');
+      if (wb) wb.classList.toggle('side-collapsed', _state.sideCollapsed);
+      if (collapseBtn) collapseBtn.hidden = _state.sideCollapsed;
+      if (expandBtn) expandBtn.hidden = !_state.sideCollapsed;
+    };
+    collapseBtn?.addEventListener('click', () => {
+      _state.sideCollapsed = true;
+      applySideCollapsed();
+    });
+    expandBtn?.addEventListener('click', () => {
+      _state.sideCollapsed = false;
+      applySideCollapsed();
+    });
+    applySideCollapsed();
+    // 分隔条拖拽：aside/mid、mid/right 之间左右调整列宽（对标 ima）
+    // 宽度持久化到 localStorage（环境无 localStorage 时静默降级）
+    let dividerDrag = null;
+    const _dividerLoad = () => {
+      try {
+        const c1 = Number(localStorage.getItem('kb-wb-c1'));
+        const c2 = Number(localStorage.getItem('kb-wb-c2'));
+        const wb = document.querySelector('.kb-wb');
+        if (!wb) return;
+        if (c1 >= 140 && c1 <= 420) wb.style.setProperty('--kb-c1', `${c1}px`);
+        if (c2 >= 240 && c2 <= 620) wb.style.setProperty('--kb-c2', `${c2}px`);
+      } catch { /* no-op */ }
+    };
+    const _dividerClamp = (idx, w) => (idx === 1 ? Math.min(420, Math.max(140, w)) : Math.min(620, Math.max(240, w)));
+    const _dividerSave = () => {
+      try {
+        const wb = document.querySelector('.kb-wb');
+        if (!wb) return;
+        localStorage.setItem('kb-wb-c1', wb.style.getPropertyValue('--kb-c1') || '236');
+        localStorage.setItem('kb-wb-c2', wb.style.getPropertyValue('--kb-c2') || '372');
+      } catch { /* no-op */ }
+    };
+    _dividerLoad();
+    document.querySelectorAll('.kb-wb-divider').forEach((div) => {
+      div.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        const idx = Number(div.dataset.wbDivider) || 1;
+        const wb = document.querySelector('.kb-wb');
+        if (!wb) return;
+        if (_state.sideCollapsed && idx === 1) return; // 折叠态第 1 条不可拖
+        const startX = e.clientX;
+        const startC1 = parseFloat(wb.style.getPropertyValue('--kb-c1')) || 236;
+        const startC2 = parseFloat(wb.style.getPropertyValue('--kb-c2')) || 372;
+        const dividerIndex = idx; // 1=aside/mid，2=mid/right
+        dividerDrag = { dividerIndex, startX, startC1, startC2 };
+        document.body.classList.add('kb-wb-resizing');
+        div.classList.add('is-dragging');
+      });
+    });
+    document.addEventListener('mousemove', (e) => {
+      if (!dividerDrag) return;
+      const wb = document.querySelector('.kb-wb');
+      if (!wb) return;
+      const dx = e.clientX - dividerDrag.startX;
+      if (dividerDrag.dividerIndex === 1) {
+        const w = _dividerClamp(1, dividerDrag.startC1 + dx);
+        wb.style.setProperty('--kb-c1', `${w}px`);
+      } else {
+        const w = _dividerClamp(2, dividerDrag.startC2 + dx);
+        wb.style.setProperty('--kb-c2', `${w}px`);
+      }
+    });
+    document.addEventListener('mouseup', () => {
+      if (!dividerDrag) return;
+      dividerDrag = null;
+      document.body.classList.remove('kb-wb-resizing');
+      document.querySelectorAll('.kb-wb-divider').forEach((x) => x.classList.remove('is-dragging'));
+      _dividerSave();
     });
     document.getElementById('kb-wb-search-input')?.addEventListener('input', (e) => {
       _state.filter = e.target.value;
@@ -2142,7 +2597,15 @@
         else if (typeof uiToast === 'function') uiToast('该操作暂不可用', { variant: 'info' });
       });
     });
-    document.getElementById('kb-wb-refresh')?.addEventListener('click', () => _loadAll());
+    // 重置按钮：恢复默认排序（更新时间）+ 刷新数据 + 提示（对齐 ima 重置语义）
+    document.getElementById('kb-wb-refresh')?.addEventListener('click', () => {
+      _state.sort = 'updated';
+      document.querySelectorAll('.kb-wb-sort-item').forEach((x) => x.classList.remove('is-selected'));
+      const def = document.querySelector('.kb-wb-sort-item[data-sort="updated"]');
+      if (def) def.classList.add('is-selected');
+      _loadAll();
+      if (typeof uiToast === 'function') uiToast('已重置排序（更新时间）并刷新', { variant: 'info', timeoutMs: 2000 });
+    });
     // 导入按钮 → 多级导入菜单（对齐 ima：本地文件/文件夹/网页/笔记/新建文件夹等）
     const importMenu = document.getElementById('kb-wb-import-menu');
     const importNoteSub = document.getElementById('kb-wb-import-note-sub');
@@ -2160,7 +2623,7 @@
         if (act === 'file') { if (isSpace) _importSpaceFiles(); else _importFiles(); }
         else if (act === 'dir') { if (isSpace) _importSpaceDir(); else _importDir(); }
         else if (act === 'url') _kbImportWebUrl();
-        else if (act === 'kblib') _kbMigrateLib();
+        else if (act === 'kblib') { if (isSpace) _importSpaceFromLib(); else _kbMigrateLib(); }
         else if (act === 'note-new') _kbNewNote();
         else if (act === 'note-import') { if (isSpace) _importSpaceFiles(); else _importFiles(); }
         else if (act === 'folder') _kbNewFolder();
@@ -2606,8 +3069,9 @@
       hasSub.addEventListener('mouseenter', () => { sub.classList.add('show'); });
       hasSub.addEventListener('mouseleave', () => { sub.classList.remove('show'); });
     }
-    setTimeout(() => document.addEventListener('click', function once(e) {
-      if (!el.contains(e.target)) { close(); document.removeEventListener('click', once); }
+    // 外部关闭用 mousedown（click 时序在菜单 append 之后，会把刚弹出的菜单误关）
+    setTimeout(() => document.addEventListener('mousedown', function once(e) {
+      if (!el.contains(e.target)) { close(); document.removeEventListener('mousedown', once); }
     }), 0);
   }
 
@@ -2618,8 +3082,17 @@
     try {
       const res = await window.cogseed.invoke('spaces.files.rename', { spaceId: _state.spaceId, oldName: path, name: String(next).trim() });
       if (res && res.ok === false) throw new Error(res.error || 'rename failed');
+      // 乐观更新 + 记录 pending（刷新快照合并，索引 upsert 完成前文件不消失）
+      const parent = String(path).includes('/') ? String(path).slice(0, String(path).lastIndexOf('/') + 1) : '';
+      const newRel = parent + String(next).trim();
+      _state.pendingRename[path] = newRel;
+      _state.spaceFiles = _state.spaceFiles.map((f) => {
+        if ((f.path || f.name) === path) return { ...f, name: newRel, path: newRel };
+        return f;
+      });
+      _renderFiles();
       if (typeof uiToast === 'function') uiToast('已重命名', { variant: 'success', timeoutMs: 1500 });
-      _loadSpaceFiles(_state.spaceId);
+      _loadSpaceFiles(_state.spaceId); // 后台校正（合并逻辑保证不消失）
     } catch (err) {
       if (typeof uiToast === 'function') uiToast('重命名失败：' + ((err && err.message) || String(err)), { variant: 'error' });
     }
@@ -2637,6 +3110,10 @@
     try {
       const res = await window.cogseed.invoke('spaces.files.delete', { spaceId: _state.spaceId, name: path });
       if (res && res.ok === false) throw new Error(res.error || 'delete failed');
+      // 乐观移除 + 记录 pending（刷新快照合并，索引删除完成前不残留）
+      _state.pendingDelete.add(path);
+      _state.spaceFiles = _state.spaceFiles.filter((f) => (f.path || f.name) !== path);
+      _renderFiles();
       if (typeof uiToast === 'function') uiToast('已删除', { variant: 'success', timeoutMs: 1500 });
       _loadSpaceFiles(_state.spaceId);
     } catch (err) {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -27406,8 +27406,37 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .kb-eco-body .kb-workbench[hidden],
 .kb-eco-body .kb-eco-pane[hidden] { display: none; }
 
-/* 三栏工作台 */
-.kb-wb { display: grid; grid-template-columns: 236px 372px 1fr; flex: 1; min-width: 0; min-height: 0; }
+/* 三栏工作台（aside | 分隔条 | mid | 分隔条 | right） */
+.kb-wb {
+  display: grid;
+  grid-template-columns: var(--kb-c1, 236px) 4px var(--kb-c2, 372px) 4px minmax(0, 1fr);
+  flex: 1; min-width: 0; min-height: 0;
+}
+
+/* 分隔条：可左右拖动调整列宽 */
+.kb-wb-divider {
+  cursor: col-resize;
+  background: transparent;
+  position: relative;
+  z-index: 5;
+  min-height: 0;
+}
+.kb-wb-divider::after {
+  content: '';
+  position: absolute;
+  left: 50%; top: 0; bottom: 0;
+  width: 1px;
+  transform: translateX(-50%);
+  background: var(--kb-border);
+  transition: background .12s ease, width .12s ease;
+}
+.kb-wb-divider:hover::after,
+.kb-wb-divider.is-dragging::after {
+  background: var(--kb-green, #0E9F6E);
+  width: 3px;
+}
+body.kb-wb-resizing { cursor: col-resize; user-select: none; }
+body.kb-wb-resizing .kb-wb-divider { z-index: 60; }
 
 /* 图标统一尺寸 */
 .kb-ico { width: 16px; height: 16px; flex: none; }
@@ -27423,6 +27452,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   color: var(--kb-text3); border: 0; background: transparent; cursor: pointer;
 }
 .kb-wb-icon-btn:hover { background: var(--kb-hover); color: var(--kb-text); }
+.kb-wb-icon-btn[hidden] { display: none; }
 .kb-wb-tree { flex: 1; overflow: auto; padding: 0 8px 12px; }
 .kb-tree-group { margin-top: 6px; }
 .kb-tree-group-label { display: flex; align-items: center; gap: 4px; padding: 6px 8px; font-size: 12.5px; color: var(--kb-text3); border-radius: 6px; }
@@ -27442,7 +27472,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .kb-tree-item.active { background: var(--kb-accent-weak); color: var(--kb-accent); font-weight: 500; }
 .kb-tree-ico { color: var(--kb-text3); }
 .kb-tree-item.active .kb-tree-ico { color: var(--kb-accent); }
-.kb-tree-ico-space { color: #f59e0b; }
+.kb-tree-ico-space { color: #0E9F6E; }
 .kb-tree-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .kb-badge-share {
   margin-left: auto; flex: none; font-size: 10px; color: var(--kb-text3);
@@ -27516,7 +27546,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex: none; font-size: 9px; font-weight: 700; letter-spacing: .2px; color: #fff;
   box-shadow: inset 0 -1.5px 0 rgba(0,0,0,.14);
 }
-.kb-file-icon-svg { width: 20px; height: 20px; flex: none; color: #f59e0b; }
+.kb-file-icon-svg { width: 20px; height: 20px; flex: none; color: #0E9F6E; }
 .kb-file-icon.is-pdf { background: linear-gradient(135deg, #f87171 0%, #e5533d 100%); }
 .kb-file-icon.is-excel { background: linear-gradient(135deg, #4ade80 0%, #1a7f37 100%); }
 .kb-file-icon.is-ppt { background: linear-gradient(135deg, #fb923c 0%, #c3512d 100%); }
@@ -27722,7 +27752,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .kb-wb-quiz-foot { display: flex; justify-content: flex-end; }
 
 /* S4 笔记面板（对齐 HTML 稿 .notes-*） */
-.kb-notes { display: grid; grid-template-columns: 280px 1fr; flex: 1; min-width: 0; min-height: 0; }
+.kb-notes { display: grid; grid-template-columns: var(--kb-nc1, 280px) 4px minmax(0, 1fr); flex: 1; min-width: 0; min-height: 0; }
 .kb-notes-list { display: flex; flex-direction: column; min-width: 0; background: var(--kb-panel); border-right: 1px solid var(--kb-border); }
 .kb-notes-list-head { display: flex; align-items: center; justify-content: space-between; padding: 14px 14px 10px; }
 .kb-notes-list-head h2 { font-size: 14px; font-weight: 600; color: var(--kb-text); }
@@ -28117,10 +28147,8 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   text-align: center; color: var(--kb-muted, #9DB4A6); font-size: 11.5px;
   padding: 14px 0 8px; user-select: none;
 }
-/* 空态：按钮组（上传文件/上传文件夹 + 幽灵按钮） */
+/* 空态：按钮组 */
 .kb-empty-actions { display: flex; gap: 10px; justify-content: center; }
-.kb-empty-btn-ghost { background: #fff; border: 1px solid var(--kb-border); color: var(--kb-text2); }
-.kb-empty-btn-ghost:hover { background: var(--kb-hover); color: var(--kb-text); }
 
 /* 导入内容多级下拉菜单（对齐 ima：本地文件/文件夹/网页/笔记二级/新建文件夹） */
 .kb-wb-import-wrap { position: relative; }
@@ -28357,3 +28385,201 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   margin-left: auto; font-size: 11.5px; color: var(--kb-green, #0E9F6E);
   background: var(--kb-brand-soft, #E2F5EC); padding: 2px 10px; border-radius: 999px;
 }
+
+/* ═══ 界面图标优化（对齐现代 AI 知识库视觉：2px 线条/圆角/低饱和/尺寸规范）═══ */
+/* 尺寸规范：树图标 16px / 内容区 20px / 按钮内 18px */
+.kb-tree-ico { width: 16px; height: 16px; }
+.kb-notes-toolbar .kb-ico-svg, .kb-wb-tools .kb-ico-svg, .kb-wb-lib-actions .kb-ico-svg { width: 18px; height: 18px; }
+/* 封面：扁平渐变面性文件夹（替代写实 📁） */
+.kb-wb-cover-svg { width: 26px; height: 26px; }
+/* AI 解析卡：AI 芯片图标（替代花哨 ✨） */
+.kb-wb-ai-chip {
+  display: inline-block; width: 14px; height: 14px; margin-right: 7px; vertical-align: -2px;
+  border: 1.7px solid var(--kb-green, #0E9F6E); border-radius: 4px;
+  background: radial-gradient(circle at center, var(--kb-green, #0E9F6E) 0 2px, transparent 2.6px);
+  box-shadow: 0 0 0 3px var(--kb-brand-soft, #E2F5EC);
+}
+/* 树：三角纤细灰、加号圆角方形 */
+.kb-tree-caret { font-size: 9px; color: var(--kb-text3); font-weight: 400; }
+.kb-tree-plus { border-radius: 5px; }
+.kb-tree-plus:hover { border-radius: 5px; }
+/* 共享徽章：浅橙双人图标（替代橙色小方框） */
+.kb-badge-share {
+  margin-left: auto; flex: none; display: inline-flex; align-items: center;
+  color: #0E9F6E; background: #E2F5EC; padding: 2px 6px; border-radius: 999px;
+}
+.kb-share-ico { width: 13px; height: 13px; display: block; }
+/* 文件类型图标：浅色低饱和底 + 深字，替代高饱和色块 */
+.kb-file-icon {
+  width: 28px; height: 28px; border-radius: 8px; font-size: 9.5px; font-weight: 600;
+  color: #3E5A4C; box-shadow: none; background: #EDF3EF;
+}
+.kb-file-icon.is-pdf { background: #FDE8E8; color: #C24B3A; }
+.kb-file-icon.is-excel { background: #E4F5EA; color: #1A7F37; }
+.kb-file-icon.is-ppt { background: #FDEBDD; color: #C3512D; }
+.kb-file-icon.is-img { background: #F1E8FB; color: #8B5CF6; }
+.kb-file-icon.is-word { background: #E8F1FD; color: #2563EB; }
+.kb-file-icon.is-txt { background: #F0F2F4; color: #6B7280; }
+/* 已索引对勾：细线低饱和绿（不要艳绿） */
+.kb-file-status.is-ready { color: #2F9E6E; font-weight: 500; }
+/* 下拉箭头纤细 */
+.kb-caret { font-size: 8px; color: var(--kb-text3); }
+
+/* 知识库列表顶部：折叠图标 + 搜索图标（点击展开输入框）+ 收起面板 */
+.kb-wb-side-head { display: flex; align-items: center; justify-content: space-between; padding: 14px 12px 10px; }
+.kb-wb-side-actions { display: flex; align-items: center; gap: 4px; }
+.kb-wb-side-actions .kb-ico-svg { width: 18px; height: 18px; }
+.kb-wb-side-search {
+  display: flex; align-items: center; gap: 7px; margin: 0 10px 8px;
+  padding: 6px 10px; border: 1.5px solid var(--kb-border); border-radius: 9px; background: #fff;
+}
+.kb-wb-side-search:focus-within { border-color: var(--kb-green, #0E9F6E); box-shadow: 0 0 0 2px rgba(14, 159, 110, .12); }
+.kb-wb-side-search[hidden] { display: none; }
+.kb-wb-side-search-ico { display: flex; color: var(--kb-text3); }
+.kb-wb-side-search-ico .kb-ico-svg { width: 15px; height: 15px; }
+.kb-wb-side-search input {
+  flex: 1; min-width: 0; border: 0; outline: none; font-size: 12.5px; color: var(--kb-text);
+  background: transparent;
+}
+.kb-wb-side-search input::placeholder { color: var(--kb-text3); }
+/* 收起整个知识库列表面板：保留 grid 槽位（避免 mid/right 错位），内部内容隐藏 */
+.kb-wb { position: relative; }
+.kb-wb.side-collapsed { grid-template-columns: 0 0 var(--kb-c2, 372px) 4px minmax(0, 1fr); }
+.kb-wb.side-collapsed .kb-wb-side {
+  width: 0;
+  min-width: 0;
+  padding: 0;
+  border-right: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+.kb-wb.side-collapsed .kb-wb-divider[data-wb-divider="1"] { visibility: hidden; pointer-events: none; }
+/* 折叠后悬浮的展开把手（在 aside 外，grid 定位在左缘中部） */
+.kb-wb-side-expand {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 30px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  z-index: 30;
+  border-radius: 10px;
+  border: 1px solid var(--kb-border);
+  background: var(--kb-panel);
+  color: var(--kb-text3);
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(16, 42, 67, .08);
+}
+.kb-wb-side-expand:hover { color: var(--kb-green, #0E9F6E); border-color: var(--kb-green, #0E9F6E); }
+.kb-wb-side-expand .kb-ico-svg { width: 16px; height: 16px; }
+.kb-wb-side-expand[hidden] { display: none; }
+
+/* ── 导入内容弹窗（共享库 ← 个人知识库文件多选，对标 ima 导入对话框）── */
+.kb-import-dlg-overlay {
+  position: fixed; inset: 0; z-index: 500;
+  background: rgba(16, 30, 24, .42);
+  display: flex; align-items: center; justify-content: center;
+}
+.kb-import-dlg {
+  width: min(860px, 92vw); height: min(560px, 86vh);
+  background: #fff; border-radius: 14px;
+  display: flex; flex-direction: column;
+  box-shadow: 0 18px 60px rgba(10, 32, 20, .28);
+  overflow: hidden;
+  color: #1F2A24;
+}
+/* 顶部导航栏 */
+.kb-import-dlg-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 18px 10px; border-bottom: 1px solid #ECEFEB;
+}
+.kb-import-dlg-title { display: flex; align-items: center; gap: 7px; font-size: 15px; font-weight: 600; color: #14281E; }
+.kb-import-dlg-title-ico { display: flex; color: var(--kb-green, #0E9F6E); }
+.kb-import-dlg-title-ico .kb-ico-svg { width: 17px; height: 17px; }
+.kb-import-dlg-search {
+  flex: 1; max-width: 260px; margin-left: auto;
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border: 1.5px solid #E3E8E3; border-radius: 8px;
+  background: #F7F9F7;
+}
+.kb-import-dlg-search:focus-within { border-color: var(--kb-green, #0E9F6E); box-shadow: 0 0 0 2px rgba(14, 159, 110, .12); }
+.kb-import-dlg-search-ico { display: flex; color: #9DB4A6; }
+.kb-import-dlg-search-ico .kb-ico-svg { width: 14px; height: 14px; }
+.kb-import-dlg-search input { flex: 1; min-width: 0; border: 0; outline: none; font-size: 12.5px; background: transparent; color: #1F2A24; }
+.kb-import-dlg-close {
+  width: 26px; height: 26px; border-radius: 7px; border: 0;
+  display: grid; place-items: center; background: transparent;
+  color: #22302A; cursor: pointer; font-size: 15px;
+}
+.kb-import-dlg-close:hover { background: #EFF2EE; }
+/* 路径导航行 */
+.kb-import-dlg-nav {
+  display: flex; align-items: center; gap: 4px;
+  padding: 8px 18px; border-bottom: 1px solid #ECEFEB;
+}
+.kb-import-dlg-nav button {
+  width: 24px; height: 24px; border-radius: 6px; border: 0;
+  background: transparent; color: #5B6B62; cursor: pointer; font-size: 14px;
+  display: grid; place-items: center;
+}
+.kb-import-dlg-nav button:hover:not(:disabled) { background: #EFF2EE; color: #14281E; }
+.kb-import-dlg-nav button:disabled { opacity: .35; cursor: default; }
+.kb-import-dlg-path { margin-left: 6px; font-size: 12.5px; color: #5B6B62; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* 主体：左右分栏 */
+.kb-import-dlg-body { flex: 1; display: flex; min-height: 0; }
+.kb-import-dlg-tree {
+  width: 200px; flex: none; border-right: 1px solid #ECEFEB;
+  overflow: auto; padding: 10px 8px;
+}
+.kb-import-dlg-group { font-size: 11.5px; color: #9DB4A6; padding: 6px 8px 4px; }
+.kb-import-dlg-lib {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px; border-radius: 8px; cursor: pointer;
+  color: #33423A; font-size: 13px;
+}
+.kb-import-dlg-lib:hover { background: #F2F5F2; }
+.kb-import-dlg-lib.active { background: #E2F5EC; color: #0E6F4F; font-weight: 600; }
+.kb-import-dlg-ico { width: 16px; height: 16px; flex: none; color: #7C8F84; }
+.kb-import-dlg-lib.active .kb-import-dlg-ico { color: var(--kb-green, #0E9F6E); }
+.kb-import-dlg-files { flex: 1; min-width: 0; overflow: auto; padding: 8px 10px; }
+.kb-import-dlg-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px; border-radius: 8px; cursor: pointer;
+}
+.kb-import-dlg-row:hover { background: #F6F8F6; }
+.kb-import-dlg-row.checked { background: #EEF8F1; }
+.kb-import-dlg-row.is-dir { color: #33423A; }
+.kb-import-dlg-check { width: 15px; height: 15px; accent-color: var(--kb-green, #0E9F6E); cursor: pointer; flex: none; }
+.kb-import-dlg-icon {
+  width: 30px; height: 30px; flex: none; border-radius: 7px;
+  display: grid; place-items: center; font-size: 9px; font-weight: 700;
+  background: #F1F4F1; color: #5B6B62;
+}
+.kb-import-dlg-icon.is-pdf { background: #FDEBE7; color: #C0392B; }
+.kb-import-dlg-icon.is-excel { background: #E7F4EA; color: #1E8449; }
+.kb-import-dlg-icon.is-ppt { background: #FDEFE2; color: #C86A1A; }
+.kb-import-dlg-icon.is-img { background: #EAF2FB; color: #2E6DA4; }
+.kb-import-dlg-icon.is-word { background: #E8F1FB; color: #2F5FA8; }
+.kb-import-dlg-name { flex: 1; min-width: 0; font-size: 13px; color: #1F2A24; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kb-import-dlg-meta { flex: none; font-size: 11px; color: #9DB4A6; }
+.kb-import-dlg-empty { padding: 30px 0; text-align: center; color: #9DB4A6; font-size: 12.5px; }
+/* 底部操作栏 */
+.kb-import-dlg-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 18px; border-top: 1px solid #ECEFEB;
+}
+.kb-import-dlg-count { font-size: 12.5px; color: #5B6B62; }
+.kb-import-dlg-actions { display: flex; gap: 10px; }
+.kb-import-dlg-cancel {
+  padding: 7px 18px; border-radius: 8px; border: 1px solid #DDE4DD;
+  background: #fff; color: #33423A; font-size: 13px; cursor: pointer;
+}
+.kb-import-dlg-cancel:hover { background: #F4F6F4; }
+.kb-import-dlg-ok {
+  padding: 7px 22px; border-radius: 8px; border: 0;
+  background: var(--kb-green, #0E9F6E); color: #fff; font-size: 13px; font-weight: 600; cursor: pointer;
+}
+.kb-import-dlg-ok:disabled { background: #C9D6CE; cursor: default; }
+.kb-import-dlg-ok:not(:disabled):hover { background: #0C8A5F; }

--- a/test/main/features/space_import.test.ts
+++ b/test/main/features/space_import.test.ts
@@ -7,6 +7,11 @@ vi.mock('../../../src/main/logger', () => ({
   createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
+// 避免真实索引器加载 better-sqlite3 原生模块（本机 Node 版本与编译产物不匹配）
+vi.mock('../../../src/main/features/project_library_indexer', () => ({
+  enqueue: vi.fn(),
+}));
+
 let tmpDir: string;
 let prevWs: string | undefined;
 const UID = 'uImp';
@@ -150,5 +155,93 @@ describe('space_import › 本地文件夹整体导入（COGSEED-18）', () => {
     for (let i = 1; i < progress.length; i++) {
       expect(progress[i].done).toBeGreaterThan(progress[i - 1].done);
     }
+  });
+});
+
+describe('space_import › 个人知识库导入共享库（importLibIntoSpace）', () => {
+  async function makeLib(name: string, files: Record<string, string>): Promise<void> {
+    const paths = await import('../../../src/main/paths');
+    const libDir = path.join(paths.userContextsDir(UID), name);
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(libDir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+  }
+
+  it('把个人库多级目录镜像导入空间，保留相对结构', async () => {
+    await makeLib('源库A', {
+      'a.txt': 'a',
+      'sub/b.md': 'b',
+      'sub/deep/c.pdf': 'c',
+    });
+    const sid = await makeSpace();
+    const { importLibIntoSpace } = await import('../../../src/main/features/space_import');
+    const r = await importLibIntoSpace(UID, sid, '源库A');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.scanned).toBe(3);
+    expect(r.imported).toBe(3);
+    // 文件落到空间文件目录（spaces/<空间>/contexts/，走索引队列入口）
+    const paths = await import('../../../src/main/paths');
+    const target = paths.spaceFilesDir(UID, sid);
+    expect(fs.existsSync(path.join(target, 'a.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(target, 'sub', 'b.md'))).toBe(true);
+    expect(fs.existsSync(path.join(target, 'sub', 'deep', 'c.pdf'))).toBe(true);
+  });
+
+  it('源个人库不存在 / 非法库名 → 明确失败', async () => {
+    const sid = await makeSpace();
+    const { importLibIntoSpace } = await import('../../../src/main/features/space_import');
+    const missing = await importLibIntoSpace(UID, sid, '不存在的库');
+    expect(missing).toEqual({ ok: false, error: 'source_lib_not_found' });
+    const empty = await importLibIntoSpace(UID, sid, '');
+    expect(empty).toEqual({ ok: false, error: 'missing_lib_name' });
+  });
+
+  it('个人库内无白名单文件 → 导入 0 个但不报错', async () => {
+    await makeLib('空库', { 'image.png': 'not-really-png' }); // png 在 contexts 白名单内
+    const sid = await makeSpace();
+    const { importLibIntoSpace } = await import('../../../src/main/features/space_import');
+    const r = await importLibIntoSpace(UID, sid, '空库');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.imported).toBe(1); // png 属白名单（图片类）
+  });
+});
+
+describe('space_import › 弹窗勾选文件导入（importFilesIntoSpace）', () => {
+  it('只导入选中的文件（含子目录路径），未选的不导入', async () => {
+    const paths = await import('../../../src/main/paths');
+    const libDir = path.join(paths.userContextsDir(UID), '挑选库');
+    fs.mkdirSync(path.join(libDir, 'sub'), { recursive: true });
+    fs.writeFileSync(path.join(libDir, '选A.md'), 'a');
+    fs.writeFileSync(path.join(libDir, '不选B.txt'), 'b');
+    fs.writeFileSync(path.join(libDir, 'sub', '选C.pdf'), 'c');
+
+    const sid = await makeSpace();
+    const { importFilesIntoSpace } = await import('../../../src/main/features/space_import');
+    const absByRel = new Map([
+      ['挑选库/选A.md', path.join(libDir, '选A.md')],
+      ['挑选库/sub/选C.pdf', path.join(libDir, 'sub', '选C.pdf')],
+    ]);
+    const r = await importFilesIntoSpace(UID, sid, absByRel);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.scanned).toBe(2);
+    expect(r.imported).toBe(2);
+    const target = paths.spaceFilesDir(UID, sid);
+    expect(fs.existsSync(path.join(target, '挑选库', '选A.md'))).toBe(true);
+    expect(fs.existsSync(path.join(target, '挑选库', 'sub', '选C.pdf'))).toBe(true);
+    expect(fs.existsSync(path.join(target, '挑选库', '不选B.txt'))).toBe(false);
+  });
+
+  it('空选中列表 → ok 且 imported 0', async () => {
+    const sid = await makeSpace();
+    const { importFilesIntoSpace } = await import('../../../src/main/features/space_import');
+    const r = await importFilesIntoSpace(UID, sid, new Map());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.imported).toBe(0);
   });
 });

--- a/test/renderer/kb-workbench.test.ts
+++ b/test/renderer/kb-workbench.test.ts
@@ -168,7 +168,7 @@ describe('KB workbench (S1 skeleton)', () => {
     expect(els['kb-wb-tree'].innerHTML).toContain('挑战资料');
     expect(els['kb-wb-tree'].innerHTML).toContain('个人知识库');
     expect(els['kb-wb-tree'].innerHTML).toContain('共享知识库');
-    expect(els['kb-wb-tree'].innerHTML).toContain('订阅知识库');
+    expect(els['kb-wb-tree'].innerHTML).not.toContain('订阅知识库');
   });
 
   it('defaults to the first library and renders files with kb status chips', async () => {
@@ -270,5 +270,54 @@ describe('KB workbench (S1 skeleton)', () => {
     expect(els['kb-wb-tree'].innerHTML).toContain('data-kb-space="sp1"');
     expect(els['kb-wb-tree'].innerHTML).toContain('共享');
     expect(els['kb-wb-tree'].innerHTML).not.toContain('空间库 · S4 上线');
+  });
+
+  it('collapses the side panel and reveals the floating expand handle (round trip)', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbWorkbench();
+    const collapse = els['kb-wb-side-collapse'];
+    const expand = els['kb-wb-side-expand'];
+    expect(collapse).toBeTruthy();
+    expect(expand).toBeTruthy();
+    // 初始：收起按钮可见，展开把手隐藏
+    expect(collapse.hidden).toBe(false);
+    expect(expand.hidden).toBe(true);
+    // 折叠 → 收起按钮隐藏、展开把手出现
+    collapse._listeners.click();
+    expect(collapse.hidden).toBe(true);
+    expect(expand.hidden).toBe(false);
+    // 点悬浮把手展开 → 恢复
+    expand._listeners.click();
+    expect(collapse.hidden).toBe(false);
+    expect(expand.hidden).toBe(true);
+    // 再折叠一次（往返稳定）
+    collapse._listeners.click();
+    expect(collapse.hidden).toBe(true);
+    expect(expand.hidden).toBe(false);
+  });
+
+  it('search finds files inside unexpanded folders (recursive)', async () => {
+    const { windowMock, els } = loadScript();
+    windowMock.renderKbWorkbench();
+    // 等待初始渲染（默认库：班级建设资料，含子目录/子文件.txt 未展开）
+    await vi.waitFor(() => {
+      expect(els['kb-wb-files'].innerHTML).toContain('a.pdf');
+    });
+    // 搜索「子文件」：文件夹未展开，也应命中深层文件
+    const input = els['kb-wb-search-input'];
+    input.value = '子文件';
+    input._listeners.input({ target: input });
+    expect(els['kb-wb-files'].innerHTML).toContain('子文件.txt');
+    expect(els['kb-wb-files'].innerHTML).toContain('📁 子目录');
+    // 搜索根目录文件：meta 显示「库根」
+    input.value = 'a.pdf';
+    input._listeners.input({ target: input });
+    expect(els['kb-wb-files'].innerHTML).toContain('a.pdf');
+    expect(els['kb-wb-files'].innerHTML).toContain('库根');
+    // 无匹配时显示「无匹配文档」而非空库引导
+    input.value = '不存在的关键词xyz';
+    input._listeners.input({ target: input });
+    expect(els['kb-wb-files'].innerHTML).toContain('无匹配文档');
+    expect(els['kb-wb-files'].innerHTML).not.toContain('＋ 添加内容');
   });
 });


### PR DESCRIPTION
## 动机（Why）
共享知识库此前无法将个人知识库内容导入；导入体验为"整库直接导入"，且导入后列表短暂为空（索引异步）。

## 改动（What）
- **「导入内容」多选弹窗**（对标腾讯 ima 导入对话框）：左侧个人库树 + 右侧文件多选列表 + 搜索/返回前进/勾选统计/底部「已选中 N 个文件 + 取消/导入」
- **文件级导入**：新增 `spaces.files.importFromLibFiles` IPC，按勾选的文件路径列表导入共享库；`importFilesIntoSpace` 6 路并发 + pending 占位行，导入后列表立即可见
- **性能**：空间批量导入跳过无用 SHA-1 全文件哈希（`skipHash`），40 个 512KB 文件约 125ms
- **配套修复**：侧栏折叠布局错位 + 悬浮展开把手；空态统一为「添加内容」打开导入菜单；搜索递归匹配文件夹内文件；重置按钮恢复默认排序并刷新

## 验证（How）
- 单测：kb-workbench 9/9、space_import 11/11 全绿；`tsc` typecheck、`eslint` 干净
- CDP 端到端：新建共享库 → 导入弹窗打开 → 目录导航/多选/搜索/勾选统计 → 导入后列表立即可见（pending/processing 状态过渡正常）

## 检查清单
- [x] 开源审计 `cogseed-open-source-audit --mode diff`：PASS_WITH_WARNINGS（sherpa-onnx 为基线豁免）
- [x] 任务提示词扫描：敏感词/内网地址/密钥/个人邮箱/内部文件 0 命中（gitleaks 23 项均为历史遗留，非本次改动）
- [x] 提交邮箱 noreply（275507383+cx677）