### PR TITLE
fix(release): enforce package.json version match with release tag

### DIFF
--- a/.github/workflows/build-macos-signed.yml
+++ b/.github/workflows/build-macos-signed.yml
@@ -1,11 +1,12 @@
 # GitHub Actions Workflow: 自动构建、签名、公证 macOS .dmg
 #
-# 发布流程: 在 main 分支上打 tag (如 v0.1.3) 触发本流程
-#           本地迭代 → 阶段节点合并进 main → 打 v* tag → CD 打包发布
+# 发布流程: 在 main 分支上打 tag (如 v0.6.0) 触发本流程
+#           发布前先把 package.json 的 version 改成与 tag 一致 → 合并进 main → 打 v* tag → CD 打包发布
 # 产物: 签名+公证后的 .dmg,自动发布到 GitHub Release
 #
-# 注意: tag 不绑定分支,所以下面加了防呆检查,
-#       只有指向 main 分支的 tag 才允许构建发布(见 "校验 tag 来源分支" 步骤)
+# 注意: tag 不绑定分支,所以下面加了防呆检查:
+#       1) 只有指向 main 分支的 tag 才允许构建发布(见 "Verify tag comes from main branch" 步骤)
+#       2) tag 版本必须与 package.json 的 version 一致(见 "Verify package.json version matches tag" 步骤)
 
 name: Build & Sign macOS
 
@@ -58,6 +59,25 @@ jobs:
             echo "   正确流程: 先把代码合并进 main 分支,再在 main 上打 tag"
             exit 1
           fi
+
+      # 步骤 1.1c: 校验 tag 版本与源码版本一致(防呆)
+      # 版本号的唯一来源是源码里的 package.json:打 tag 前必须先把 version 改成
+      # 与 tag 相同并合入 main。不一致直接失败,避免出现"源码还是旧版本、
+      # 靠流水线构建时改写"的版本追溯断档(如 v0.6.0 标签里的 package.json 仍是 0.0.5)。
+      # 这里用 sed 提取版本号,不依赖 Node,放在 setup-node 之前也能跑。
+      - name: Verify package.json version matches tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          SRC_VERSION="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -n1)"
+          echo "tag 版本: $TAG_VERSION / package.json 版本: $SRC_VERSION"
+          if [ "$TAG_VERSION" != "$SRC_VERSION" ]; then
+            echo "❌ package.json 的 version ($SRC_VERSION) 与 tag ($GITHUB_REF_NAME) 不一致,拒绝发布"
+            echo "   正确流程: 把 package.json 的 version 改成 $TAG_VERSION 并合并进 main,"
+            echo "   然后删掉旧 tag 重打: git push origin :refs/tags/$GITHUB_REF_NAME && git tag $GITHUB_REF_NAME && git push origin $GITHUB_REF_NAME"
+            exit 1
+          fi
+          echo "✅ 源码版本与 tag 版本一致,继续构建"
 
       # 步骤 1.2: 安装 Node.js
       - name: Setup Node.js
@@ -124,20 +144,11 @@ jobs:
           rm certificate.p12
 
       # ========================================
-      # 阶段 3: 版本号对齐
+      # 阶段 3: 写入构建元信息
       # ========================================
-
-      # 步骤 3.0: 把 package.json 的 version 改成和 tag 一致
-      # 比如推的 tag 是 v0.0.7,就把 package.json 的 version 改成 0.0.7
-      # 这样打包出来的文件名 (CogSeed-0.0.7-mac-*.dmg) 才会和 tag 对上
-      # 只在推 tag 触发时才改;手动触发 (workflow_dispatch) 时不改,保持原样
-      - name: Sync package.json version with tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          # github.ref_name 例如 "v0.0.7",去掉开头的 "v" 得到 "0.0.7"
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          echo "将 package.json 的 version 设置为: $TAG_VERSION"
-          npx json -I -f package.json -e "this.version = \"$TAG_VERSION\""
+      # (原步骤 3.0 "构建时把 package.json 的 version 改成 tag 版本"已移除:
+      #  版本号以源码为唯一来源,发布前改好,流水线只在步骤 1.1c 校验一致性,
+      #  保证 "源代码版本—标签—构建产物" 三者可直接对上)
 
       # 步骤 3.1: 写入发布渠道标记(关键!)
       # 客户端用包内渠道决定 API 基址:release/packaged-dev → 生产官网,

--- a/docs/design/auto-update-release.md
+++ b/docs/design/auto-update-release.md
@@ -19,8 +19,9 @@ GitHub main 打 tag vX.Y.Z（发布节奏由团队决定，防呆只允许 main 
 
 ## 发布步骤
 
-1. **GitHub**：把代码合并进 `main` → Releases → Draft a new release → tag 填 `vX.Y.Z`
-   （"Create new tag on publish"，target=main）→ Publish。
+1. **GitHub**：把 `package.json` 的 `version` 改成 `X.Y.Z`（必须与即将打的 tag 一致，
+   发布流水线最前面会硬校验，不一致直接拒绝构建）随代码合并进 `main` → Releases →
+   Draft a new release → tag 填 `vX.Y.Z`（"Create new tag on publish"，target=main）→ Publish。
 2. 等 Actions 跑完（约 10 分钟），Release 页应有两个资产：`CogSeed-X.Y.Z-mac-arm64.dmg` 与
    `CogSeed-X.Y.Z-mac-arm64.zip`。复制两者的下载直链（右键 → 复制链接地址）。
 3. **内网 GitLab**（hub 项目）：CI/CD → Run pipeline（main 分支）：
@@ -53,3 +54,7 @@ GitHub main 打 tag vX.Y.Z（发布节奏由团队决定，防呆只允许 main 
 - 首次把用户从 DMG 版本切到自动更新版本需要一次手动安装；之后的升级才全自动。
 - 自动更新包的签名必须与安装包同一开发者证书；换证书会触发"更新失败"。
 - feed 的 `pub_date` 取发布时刻；同版本重复发布（补 zip）不会重复提醒。
+- tag 必须与 `package.json` 的 `version` 完全一致（含预发布后缀，如 `v0.7.0-rc.1` 对应
+  `"version": "0.7.0-rc.1"`）；流水线在构建最前面校验，不一致直接失败。
+  历史版本（≤ v0.6.0）的源码版本号停留在 0.0.5、靠构建时改写，该做法已废弃，
+  历史标签不做回改；后续补 Release Manifest 固化映射（US-GO-17A）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cogseed",
-  "version": "0.0.5",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cogseed",
-      "version": "0.0.5",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogseed",
-  "version": "0.0.5",
+  "version": "0.6.0",
   "private": true,
   "description": "CogSeed desktop — personal cognition asset workspace",
   "main": "bootstrap.cjs",


### PR DESCRIPTION
## 问题（外部评审指出，已核实属实）

`v0.6.0` 标签中的 `package.json` 版本号仍是 `0.0.5`，develop / main 源码同理。发布流水线 `build-macos-signed.yml` 原步骤 3.0「Sync package.json version with tag」在**构建时**才把版本号改写成 tag 版本。最终安装包版本正确，但「源代码版本—标签—构建产物」三者对不上，版本追溯只能靠流水线过程解释。

## 修复方案

把版本号的唯一来源拉回源码，流水线只做校验不做改写：

1. **新增硬校验**（`Verify package.json version matches tag`，紧随现有「tag 必须在 main 上」防呆之后、证书导入之前）：tag 触发时比对 `package.json` 的 `version` 与 tag 版本，不一致直接拒绝构建，并输出整改指引。用 `sed` 提取，不依赖 Node。
2. **删除构建时改写步骤**（原 Sync 步骤）：源码版本 = 标签版本 = 产物版本，三者直接对上。
3. **版本号补齐**：`package.json` / `package-lock.json` 从 `0.0.5` 补到 `0.6.0`（当前线上最新发布，已用更新 feed 核实），下次发布在此基础上递增。
4. **发布手册同步**（`docs/design/auto-update-release.md`）：发布步骤第 1 步补上「发布前改版本号」，关键约束补充一致性校验说明。

## 边界说明

- 已发布的 `v0.6.0` 标签**不做回改**：安装包已从该标签构建并发布，重打标签反而破坏标签与产物的对应关系。历史断档在手册中如实记录。
- Release Manifest 固化映射属 US-GO-17A（可信版本获取与验证）范围，不在本 PR 展开。
- ⚠️ **对发布流程的影响**：此 PR 合入后，下次打 tag 发布前必须先把 `package.json` 的 `version` 改成与 tag 一致并合入 main，否则流水线会快速失败（这正是防呆目的）；错误信息里带具体整改命令。

## 验证

- workflow YAML 语法校验通过（js-yaml 解析）。
- 版本提取与比对逻辑本地实测：一致场景放行、不一致场景（`0.0.5` vs `0.7.0`）正确拒绝。
- `npm ci` / 构建链路不受影响：校验步骤在 `setup-node` 之前，仅读文件；删除的 Sync 步骤在源码版本一致后本就是空操作。