### PR TITLE
docs(design): drop internal GitLab mentions from update/release docs

### DIFF
--- a/docs/design/auto-update-local-verify.md
+++ b/docs/design/auto-update-local-verify.md
@@ -9,7 +9,7 @@
 
 本地闭环验证通过后，可再做一次「真实 hub」联动：hub 后台点发布 → 桌面端
 提醒。制品用 `scripts/build-hub-verify-artifacts.mjs` 构建（真实产品配置、
-无证书 ad-hoc 密封），走内网 GitLab Release 资产直链 + `release:installer`
+无证书 ad-hoc 密封），走 hub 项目 CI 的 Release 资产直链 + `release:installer`
 管道登记草稿包 → hub 后台发布 → 桌面测试客户端（release 渠道，默认指向
 生产 API）验证 → 立即「下线」。hub 后端契约对齐点见
 `updates-hub-integration-checklist.md`。

--- a/docs/design/auto-update-release.md
+++ b/docs/design/auto-update-release.md
@@ -8,7 +8,7 @@
 GitHub main 打 tag vX.Y.Z（发布节奏由团队决定，防呆只允许 main 上的 tag）
   → Build & Sign macOS：签名+公证产出 dmg（手动安装）+ zip（自动更新）
   → GitHub Release 挂两个文件
-  → 内网 GitLab release:installer（INSTALLER_URL=dmg 直链，AUTO_UPDATE_ZIP_URL=zip 直链）
+  → hub 项目 CI release:installer（INSTALLER_URL=dmg 直链，AUTO_UPDATE_ZIP_URL=zip 直链）
   → 服务器登记为运营平台「草稿包」（系统计算 SHA-256，不直写 catalog）
   → 发布员在运营平台核对后点「发布」
   → releases.json（老版本客户端提醒通道，dmg）+ /updates/feed/mac-arm64（新客户端自动更新）
@@ -24,7 +24,7 @@ GitHub main 打 tag vX.Y.Z（发布节奏由团队决定，防呆只允许 main 
    Draft a new release → tag 填 `vX.Y.Z`（"Create new tag on publish"，target=main）→ Publish。
 2. 等 Actions 跑完（约 10 分钟），Release 页应有两个资产：`CogSeed-X.Y.Z-mac-arm64.dmg` 与
    `CogSeed-X.Y.Z-mac-arm64.zip`。复制两者的下载直链（右键 → 复制链接地址）。
-3. **内网 GitLab**（hub 项目）：CI/CD → Run pipeline（main 分支）：
+3. **hub 项目**（CI/CD）：Run pipeline（main 分支）：
    - `INSTALLER_URL` = dmg 直链
    - `AUTO_UPDATE_ZIP_URL` = zip 直链
    - （无 AUTO_UPDATE_ZIP_URL 也能登记，但用户将收不到自动更新）

--- a/docs/design/updates-hub-integration-checklist.md
+++ b/docs/design/updates-hub-integration-checklist.md
@@ -37,10 +37,10 @@
 ```
 ① 制品：CogSeed-X.Y.Z-darwin-arm64.dmg + .zip（正式走 GitHub Release 直链；
    验证阶段：本机 .hub-verify/artifacts/ 直接经 hub 后台表单上传，
-   不必经过内网 GitLab 管道）
+   不必经过 hub 项目 CI 管道）
 ②【验证阶段】hub 后台 admin/updates：新建版本 → 上传 dmg（主安装包）+
    zip（自动更新包）→ 核对 SHA-256 → 点「发布」
-  【正式流程】内网 GitLab：Run pipeline（main）：
+  【正式流程】hub 项目 CI：Run pipeline（main）：
    INSTALLER_URL=<dmg 直链>、AUTO_UPDATE_ZIP_URL=<zip 直链>
    → release:installer 登记草稿包（文件名须 CogSeed-<version>-darwin-arm64.<ext>）
 ③ hub 后台 admin/updates（发布员）：核对版本/文件名/SHA-256 → 点「发布」
@@ -50,7 +50,7 @@
 
 ## 5. hub 侧修复 MR
 
-- 内网 GitLab hub 项目 MR !45：
+- hub 项目 MR !45：
   `fix(updates): feed 按 User-Agent 版本门控，已是最新回 204`
   （feed 无更新回 204 而非 `200+{}`；从 CFNetwork UA 解析版本做门控；
   合并到 main 自动部署）。合并前请 hub 侧 review。


### PR DESCRIPTION
## 背景

0.7.6 发版自查清单遗留项 **#8 docs 内部引用**：3 个发布/更新流程文档仍含「内网 GitLab」字样（共 6 处）。

## 改动内容

仅措辞替换，将「内网 GitLab」改为「hub 项目 CI」等中性表述，消除对内部代码托管设施的指向：

| 文件 | 处数 |
|---|---|
| docs/design/updates-hub-integration-checklist.md | 3 |
| docs/design/auto-update-release.md | 2 |
| docs/design/auto-update-local-verify.md | 1 |

- 不改变任何流程步骤与操作含义（hub 后台、运营平台、release:installer 管道等公开产品组件的描述原样保留）
- 纯文档改动，无代码影响

## 验证

- `grep -rn "内网 GitLab" docs/` 复扫为 0
- 全库其余「内网」命中均为测试合成样本或通用安全注释，不在本次范围