### PR TITLE
fix(skills): trust hash-valid local receipts when deep scanner absent

### DIFF
--- a/src/main/features/skill_reverify.ts
+++ b/src/main/features/skill_reverify.ts
@@ -35,6 +35,28 @@ import {
 
 const log = createLogger('skill-reverify');
 
+/**
+ * Whether this build ships without the deep scanner (`SCANNER_ABSENT` marker).
+ *
+ * Cached per process: the packaging decision cannot change at runtime. In such
+ * a build a local receipt can never be upgraded to `scanner: 'deep'`, so the
+ * deep path must trust a hash-valid local receipt instead of rescanning the
+ * whole library on every call (each rescan re-runs the absent-scanner path and
+ * LLM instruction audits, then writes the same `scanner: 'local'` verdict —
+ * which the next call treats as stale again, forever).
+ */
+let _scannerAbsentByBuild: boolean | null = null;
+async function _isScannerAbsentByBuild(): Promise<boolean> {
+  if (_scannerAbsentByBuild !== null) return _scannerAbsentByBuild;
+  try {
+    const { scannerAvailability } = await import('./security/sentry-adapter');
+    _scannerAbsentByBuild = scannerAvailability() === 'absent_by_build';
+  } catch {
+    _scannerAbsentByBuild = false;
+  }
+  return _scannerAbsentByBuild;
+}
+
 export interface ReverifyResult {
   skillId: string;
   decision: ReceiptDecision | 'unknown';
@@ -279,7 +301,13 @@ async function _reverifyDeep(
   // in place; otherwise a `local` verdict — written by the sync path, or by a
   // build predating deep re-verification — would permanently short-circuit deep
   // scanning for that skill, reopening this very hole one layer down.
-  if (cached && cached.scanner === 'deep') {
+  //
+  // Exception: a build that ships without the deep scanner (`SCANNER_ABSENT`)
+  // can never upgrade a local receipt, so this condition would rescan the whole
+  // library on every call and never converge. For such builds a hash-valid
+  // local receipt is the best evidence available — trust it the same way the
+  // sync path (`reverifySkill`) already trusts any non-stale receipt.
+  if (cached && (cached.scanner === 'deep' || await _isScannerAbsentByBuild())) {
     return {
       skillId,
       decision: cached.decision ?? 'unknown',


### PR DESCRIPTION
## 问题

工作空间 Tab 打开要等 55–60 秒，`skills.list` 单次调用耗时 ~59s。

根因链条：

1. 源码发行版不带深度扫描引擎（`resources/guardrail/SCANNER_ABSENT` 标记，无 `skill-sentry/sandbox/agent_gate.py`）
2. `listSkills()` → `_overlaySkillSecurity()` → `partitionSkillsByTrustDeep()` 对全部 58 个 marketplace 技能逐个复核
3. 引擎缺失时每次扫描只能写 `scanner: 'local'` 的收据；`_reverifyDeep` 规定非 `deep` 收据一律视为过期（等深扫升级）
4. 结果：**每次调用都全量重扫整个技能库，永不命中缓存**。每个技能还附带指令风险 LLM 审计（~1s/技能），58 技能 ≈ 55–60s
5. 工作空间首屏被 `skills.list` gate 住 → 用户感知"Tab 打不开"

## 修复

`_reverifyDeep` 在构建声明 `absent_by_build`（`SCANNER_ABSENT`）时，直接信任 hash 有效的 local 收据——与同步路径 `reverifySkill` 对任意非过期收据的行为一致。引擎缺失时重扫永远无法升级收据，重复扫描只产生相同结论，零新信息。

## 验证

| 指标 | 修复前 | 修复后 |
|---|---|---|
| `skills.list` | 55,525ms / 59,570ms | 48ms / 37ms |
| 工作空间 Tab 首屏 | ~1 分钟 | ~50ms |

- `npm run typecheck` 通过
- 引擎完整（`scanner: 'deep'`）的构建不受影响：`deep` 收据仍直接命中缓存，行为不变
