### PR TITLE
chore(release): bump version to 0.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cogseed",
-  "version": "0.6.0",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cogseed",
-      "version": "0.6.0",
+      "version": "0.7.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogseed",
-  "version": "0.6.0",
+  "version": "0.7.6",
   "private": true,
   "description": "CogSeed desktop — personal cognition asset workspace",
   "main": "bootstrap.cjs",


### PR DESCRIPTION
## 背景

0.7.6 发版日（重点：教育插件、Windows 版本），按 #131 的发布硬校验（release tag 必须与 package.json version 完全一致，不一致构建直接失败），打 tag 前必须先把版本号合入。

## 改动内容

- `package.json`：0.6.0 → 0.7.6
- `package-lock.json`：root 与 packages."" 两处同步（用 `npm version` 生成，未触碰依赖自身版本）

## 说明

- 合并后即可在出包分支打 `v0.7.6` tag
- 纯版本号变更，不影响任何运行时行为