### PR TITLE
fix(windows): whichBin skips bare #! shim so npm CLIs resolve to .cmd

### DIFF
--- a/scripts/diagnose-local-agents.mjs
+++ b/scripts/diagnose-local-agents.mjs
@@ -289,10 +289,30 @@ async function isExecutableFile(p, platform) {
   try {
     const st = await fsp.stat(p);
     if (!st.isFile()) return false;
-    if (platform === 'win32') return true;
+    if (platform === 'win32') {
+      // 镜像 which.ts：npm 会同时生成无扩展名的 `#!/bin/sh` bash shim 和
+      // `<name>.cmd`。bare shim 无法被 spawn 执行，跳过让 whichBin 命中 .cmd。
+      if (path.extname(p) === '' && await isShebangScript(p)) return false;
+      return true;
+    }
     return (st.mode & 0o111) !== 0;
   } catch {
     return false;
+  }
+}
+
+/** 文件是否以 `#!` 开头（Unix shebang）；Windows spawn 无法直接执行。 */
+async function isShebangScript(p) {
+  let handle;
+  try {
+    handle = await fsp.open(p, 'r');
+    const buf = Buffer.alloc(2);
+    const { bytesRead } = await handle.read(buf, 0, 2, 0);
+    return bytesRead >= 2 && buf[0] === 0x23 /* # */ && buf[1] === 0x21 /* ! */;
+  } catch {
+    return false;
+  } finally {
+    if (handle) await handle.close().catch(() => { /* ignore */ });
   }
 }
 

--- a/src/main/features/local_agents/which.ts
+++ b/src/main/features/local_agents/which.ts
@@ -12,7 +12,9 @@
  * Windows: scan PATH (split by ';'), multiply each candidate by
  * `process.env.PATHEXT` (e.g. `.COM;.EXE;.BAT;.CMD`); first stat hit
  * wins. The empty extension is also tried first because some installs
- * drop bare names (PowerShell shims, MinGW, etc.).
+ * drop bare names (MinGW, etc.). A bare name that is a Unix shebang
+ * script (npm's `#!/bin/sh` shim) is NOT spawnable on Windows and is
+ * skipped so the `.cmd` shim npm generates alongside it wins instead.
  */
 
 import * as fs from 'node:fs/promises';
@@ -90,10 +92,33 @@ async function isExecutableFile(p: string): Promise<boolean> {
   try {
     const st = await fs.stat(p);
     if (!st.isFile()) return false;
-    if (isWindows) return true;
+    if (isWindows) {
+      // npm generates a `<name>` bash shim (`#!/bin/sh`) alongside every
+      // `<name>.cmd`/`<name>.ps1`. The bare shim is a Unix script Windows
+      // cannot spawn; skip it so whichBin falls through to the real `.cmd`.
+      if (path.extname(p) === '' && await isShebangScript(p)) return false;
+      return true;
+    }
     // 0o111 = any of user/group/other execute.
     return (st.mode & 0o111) !== 0;
   } catch {
     return false;
+  }
+}
+
+/** True when the file starts with `#!` (a Unix shebang). Windows spawn
+ *  cannot execute these directly. Reads at most two bytes; returns false
+ *  on any read error rather than throwing. */
+async function isShebangScript(p: string): Promise<boolean> {
+  let handle: fs.FileHandle | null = null;
+  try {
+    handle = await fs.open(p, 'r');
+    const buf = Buffer.alloc(2);
+    const { bytesRead } = await handle.read(buf, 0, 2, 0);
+    return bytesRead >= 2 && buf[0] === 0x23 /* # */ && buf[1] === 0x21 /* ! */;
+  } catch {
+    return false;
+  } finally {
+    if (handle) await handle.close().catch(() => { /* ignore */ });
   }
 }

--- a/test/main/features/local_agents/which.test.ts
+++ b/test/main/features/local_agents/which.test.ts
@@ -97,6 +97,17 @@ describe('local_agents/which › whichBin', () => {
       expect((await whichBin('tool'))?.toLowerCase()).toBe(bare.toLowerCase());
     });
 
+    it('skips a bare npm bash shim and falls through to the .cmd shim', async () => {
+      const bare = path.join(tmpDir, 'claude');
+      const cmd = path.join(tmpDir, 'claude.CMD');
+      fs.writeFileSync(bare, '#!/bin/sh\necho hi\n');
+      fs.writeFileSync(cmd, '@echo off\r\n');
+      process.env.PATH = tmpDir;
+      process.env.PATHEXT = '.CMD';
+
+      expect((await whichBin('claude'))?.toLowerCase()).toBe(cmd.toLowerCase());
+    });
+
     it('accepts forward-slash explicit paths on Windows', async () => {
       const binPath = path.join(tmpDir, 'forward.cmd');
       fs.writeFileSync(binPath, '@echo hi\r\n');

--- a/test/scripts/diagnose-local-agents.test.ts
+++ b/test/scripts/diagnose-local-agents.test.ts
@@ -93,7 +93,7 @@ describe('diagnose-local-agents: search dirs mirror registry.ts', () => {
 });
 
 describe('diagnose-local-agents: binary lookup mirrors which.ts', () => {
-  it('finds an executable via extraDirs and skips non-executables on POSIX', async () => {
+  it.runIf(process.platform !== 'win32')('finds an executable via extraDirs and skips non-executables on POSIX', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'diag-which-'));
     const good = path.join(tmp, 'claude');
     const bad = path.join(tmp, 'codex');
@@ -107,13 +107,23 @@ describe('diagnose-local-agents: binary lookup mirrors which.ts', () => {
     expect(notFound).toBeNull();
   });
 
-  it('honors an absolute override path exactly like COGSEED_<TYPE>_PATH', async () => {
+  it.runIf(process.platform !== 'win32')('honors an absolute override path exactly like COGSEED_<TYPE>_PATH', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'diag-which-abs-'));
     const abs = path.join(tmp, 'my-claude');
     fs.writeFileSync(abs, '#!/bin/sh\n');
     fs.chmodSync(abs, 0o755);
     expect(await whichBin(abs, { env: { PATH: '' } })).toBe(abs);
     expect(await whichBin(path.join(tmp, 'missing'), { env: { PATH: '' } })).toBeNull();
+  });
+
+  it.runIf(process.platform === 'win32')('skips a bare npm bash shim and falls through to the .cmd shim', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'diag-which-win-'));
+    const bare = path.join(tmp, 'claude');
+    const cmd = path.join(tmp, 'claude.CMD');
+    fs.writeFileSync(bare, '#!/bin/sh\necho hi\n');
+    fs.writeFileSync(cmd, '@echo off\r\n');
+    const found = await whichBin('claude', { extraDirs: [tmp], env: { PATH: '', PATHEXT: '.CMD' } });
+    expect(found?.toLowerCase()).toBe(cmd.toLowerCase());
   });
 });
 


### PR DESCRIPTION
On Windows, npm-global installs ship a bare #!/bin/sh bash shim alongside <name>.cmd and <name>.ps1. whichBin tried the extension-less candidate first, matched the unspawnable bash shim, version probes failed (version_unknown), and onboarding session detection returned empty. Skip extension-less Unix shebang scripts so whichBin falls through to the real .cmd shim. Mirrored in the diagnostic script, with Windows/POSIX test coverage.