### PR TITLE
Run Center: fix restart dead cards, conversation cleanup, and duplicate scans

### DIFF
--- a/src/main/features/chats.ts
+++ b/src/main/features/chats.ts
@@ -2434,6 +2434,20 @@ async function _purgeDeletedConversationFiles(userId: string, cid: string, remov
     await cliSessions.clearForConversation(userId, cid);
   } catch (err) { log.warn(`purge cli sessions user=${userId} cid=${cid}: ${(err as Error).message}`); }
 
+  // Purge the Group Chat shadow tasks this conversation projected into the
+  // CogSeed backend (task JSON + events JSONL + projection cache + request
+  // claim). The Run Center already hides them once the conversation is gone,
+  // but hidden is not deleted: they stayed on disk forever, kept being read by
+  // every dashboard scan, and left request claims that still resolved. Tasks
+  // holding an undelivered terminal result are retained by the primitive.
+  try {
+    const cogseedTasks = await import('./cogseed_backend/task-store');
+    const purge = await cogseedTasks.purgeCogSeedGroupChatTasksByConversation(userId, cid);
+    if (purge.failedTaskIds.length) {
+      log.warn(`purge cogseed tasks user=${userId} cid=${cid}: unreadable ${purge.failedTaskIds.join(',')}`);
+    }
+  } catch (err) { log.warn(`purge cogseed tasks user=${userId} cid=${cid}: ${(err as Error).message}`); }
+
   // Pending terminal results remain execution-owned after the destination is
   // deleted. Recovery may report the missing destination, but must not destroy
   // the only durable copy or recreate the conversation implicitly.

--- a/src/main/features/cogseed_backend/ipc-service.ts
+++ b/src/main/features/cogseed_backend/ipc-service.ts
@@ -3,7 +3,7 @@ import {
   subscribeCogSeedDashboardChanges,
   type CogSeedDashboardChange,
 } from './event-store';
-import { archiveCogSeedTask, markCogSeedTaskRecoverable, retryCogSeedTask } from './lifecycle';
+import { archiveCogSeedTask, markCogSeedTaskRecoverable, retryCogSeedTask, transitionCogSeedTask } from './lifecycle';
 import type { CogSeedRuntimeController, ResumeCogSeedTaskInput, StartCogSeedTaskInput } from './runtime-controller';
 import { assertCogSeedAgentId, assertCogSeedConnectorId, assertCogSeedKbSourceId, assertCogSeedRequestId, assertCogSeedSessionId, assertCogSeedTaskId, assertCogSeedUserId } from './paths';
 import { listCogSeedConnectors } from './connector-store';
@@ -59,6 +59,7 @@ export interface CogSeedIpcServiceDeps {
   admitTask?: typeof createCogSeedTask;
   retryTask?: typeof retryCogSeedTask;
   archiveTask?: typeof archiveCogSeedTask;
+  transitionTask?: typeof transitionCogSeedTask;
   readEvents?: typeof readCogSeedTaskEvents;
   subscribeDashboardChanges?: typeof subscribeCogSeedDashboardChanges;
   resolveAgentExecutionContext?: typeof resolveCogSeedAgentExecutionContext;
@@ -537,7 +538,11 @@ function taskActions(task: Pick<CogSeedTaskRecord, 'status' | 'executionKind' | 
       skip: false,
       resume: false,
       recoverResult: false,
-      abort: status === 'created' || status === 'queued' || status === 'running',
+      // `recoverable` is included even though there is no live turn to stop.
+      // A restart leaves Group Chat runs there, and Group Chat cannot resume
+      // them, so abort is the user's only way to dismiss the card — see the
+      // matching branch in `action()`, which settles the task itself.
+      abort: status === 'created' || status === 'queued' || status === 'running' || status === 'recoverable',
       archive,
     };
   }
@@ -720,6 +725,7 @@ export function createCogSeedIpcService(deps: CogSeedIpcServiceDeps = {}) {
   const admitTask = deps.admitTask ?? createCogSeedTask;
   const retryTask = deps.retryTask ?? retryCogSeedTask;
   const archiveTask = deps.archiveTask ?? archiveCogSeedTask;
+  const transitionTask = deps.transitionTask ?? transitionCogSeedTask;
   const readEvents = deps.readEvents ?? readCogSeedTaskEvents;
   const listSessions = deps.listSessions ?? listCogSeedSessions;
   const readSession = deps.readSession ?? readCogSeedSession;
@@ -1181,15 +1187,25 @@ export function createCogSeedIpcService(deps: CogSeedIpcServiceDeps = {}) {
       const groupChatModes = await conversationAgentCountsForTasks(userId, tasks);
       const directTasks = tasks.filter((task) => task.sessionId === session.sessionId);
       const collaboration = directTasks.length
-        ? await this.collaborationSnapshot(userId, taskId ? { taskId } : { sessionId: session.sessionId })
+        // Hand down the scan we already paid for. Both sides derive the same
+        // `visibleDashboardTasks(listTasks(...))` set, and a session read is a
+        // hot path — the watch stream replays it on every task change.
+        ? await this.collaborationSnapshot(userId, taskId ? { taskId } : { sessionId: session.sessionId }, tasks)
         : null;
       return { session: sessionSummary(session, directTasks, groupChatModes), collaboration };
     },
 
-    async collaborationSnapshot(userId: string, payload: unknown): Promise<CogSeedRendererCollaborationSnapshot> {
+    /** `visibleTasks` lets a caller that has already scanned pass its result
+     * down instead of paying for a second full task-directory read. Omit it
+     * and the snapshot scans for itself, as every external caller does. */
+    async collaborationSnapshot(
+      userId: string,
+      payload: unknown,
+      visibleTasks?: CogSeedTaskRecord[],
+    ): Promise<CogSeedRendererCollaborationSnapshot> {
       assertCogSeedUserId(userId);
       const input = normalizeProjectionInput(payload);
-      const allTasks = await visibleDashboardTasks(userId, await listTasks(userId));
+      const allTasks = visibleTasks ?? await visibleDashboardTasks(userId, await listTasks(userId));
       const visibleTaskById = new Map(allTasks.map((task) => [task.taskId, task]));
       if (input.taskId && !visibleTaskById.has(input.taskId)) {
         throw new Error('CogSeed collaboration task not found');
@@ -1445,6 +1461,15 @@ export function createCogSeedIpcService(deps: CogSeedIpcServiceDeps = {}) {
         if (!task.conversationId) throw new Error('Group Chat task has no conversation');
         if (input.action === 'abort') {
           await abortGroupChat(userId, task.conversationId);
+          // A run parked in `recoverable` by a restart has no live turn for
+          // the delegated abort to stop, so nothing would ever move the card
+          // out of the attention column. Settle it here — the state machine
+          // already allows `recoverable -> cancelled`. Runs that are still
+          // created/queued/running are left alone: Group Chat owns their
+          // terminal transition and forcing one would race it.
+          if (task.status === 'recoverable') {
+            await transitionTask(userId, input.taskId, 'cancelled');
+          }
         } else if (input.action === 'retry') {
           if (!input.requestId) throw new Error('requestId required');
           if (!task.groupChatMessageId) throw new Error('Group Chat retry target is unavailable');

--- a/src/main/features/cogseed_backend/task-store.ts
+++ b/src/main/features/cogseed_backend/task-store.ts
@@ -12,7 +12,9 @@ import {
   assertCogSeedTaskId,
   assertCogSeedUserId,
   cogseedRequestClaimFile,
+  cogseedTaskEventsFile,
   cogseedTaskFile,
+  cogseedTaskProjectionFile,
   cogseedTasksDirectory,
 } from './paths';
 import {
@@ -559,6 +561,73 @@ export async function listCogSeedTasks(userId: string): Promise<CogSeedTaskRecor
     tasks.push(await readCogSeedTask(userId, taskId).then((task) => { if (!task) throw new Error('CogSeed task disappeared during recovery'); return task; }));
   }
   return tasks.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+export interface CogSeedConversationPurgeReport {
+  /** Tasks whose durable files were removed. */
+  purgedTaskIds: string[];
+  /** Held back because a terminal result has not reached its destination yet. */
+  retainedTaskIds: string[];
+  /** Could not be read or removed. Reported, never blindly deleted. */
+  failedTaskIds: string[];
+}
+
+/** Remove the Group Chat shadow tasks a deleted conversation leaves behind.
+ *
+ * Only `group-chat` tasks whose `conversationId` matches exactly are touched.
+ * A per-agent follow-up carries the same conversation id but runs as
+ * `local-cli` / `cogseed-native`; that record is the user's work, not the
+ * conversation's projection, and the Run Center already withholds its dead
+ * conversation exit. Tasks whose terminal result is still undelivered are kept
+ * for the reconciler — the destination being gone must not destroy the only
+ * reference to a result it never received.
+ *
+ * Judged per task, never through the parent chain: a child can outlive a
+ * missing parent and still belong to the conversation it names.
+ */
+export async function purgeCogSeedGroupChatTasksByConversation(
+  userId: string,
+  conversationId: string,
+): Promise<CogSeedConversationPurgeReport> {
+  assertCogSeedUserId(userId);
+  const cid = assertCogSeedConversationId(conversationId);
+  const report: CogSeedConversationPurgeReport = { purgedTaskIds: [], retainedTaskIds: [], failedTaskIds: [] };
+
+  let entries: import('node:fs').Dirent[];
+  try { entries = await fs.readdir(cogseedTasksDirectory(userId), { withFileTypes: true }); }
+  catch (error) { if (isEnoent(error)) return report; throw error; }
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const taskId = entry.name.slice(0, -'.json'.length);
+    let task: CogSeedTaskRecord | null = null;
+    try { task = await readCogSeedTask(userId, taskId); }
+    catch { report.failedTaskIds.push(taskId); continue; }
+    if (!task) continue;
+    if (task.executionKind !== 'group-chat' || task.conversationId !== cid) continue;
+    if (task.resultDeliveryState === 'pending' || task.resultDeliveryState === 'pending-recovery') {
+      report.retainedTaskIds.push(taskId);
+      continue;
+    }
+    try {
+      // Claims are keyed by request id, so drop one only while it still points
+      // at this task. Removing it before the record keeps the failure modes
+      // ordered: a claim without a task falls back to a scan, while a task
+      // without a claim would make `readCogSeedTaskByRequestId` throw.
+      if (task.requestId) {
+        const claimFile = cogseedRequestClaimFile(userId, task.requestId);
+        try {
+          const claim = JSON.parse(await fs.readFile(claimFile, 'utf8')) as { taskId?: unknown };
+          if (claim?.taskId === taskId) await fs.rm(claimFile, { force: true });
+        } catch (error) { if (!isEnoent(error) && !(error instanceof SyntaxError)) throw error; }
+      }
+      await fs.rm(cogseedTaskEventsFile(userId, taskId), { force: true });
+      await fs.rm(cogseedTaskProjectionFile(userId, taskId), { force: true });
+      await fs.rm(cogseedTaskFile(userId, taskId), { force: true });
+      report.purgedTaskIds.push(taskId);
+    } catch { report.failedTaskIds.push(taskId); }
+  }
+  return report;
 }
 
 export async function readLatestCogSeedTaskForAgent(

--- a/src/renderer/modules/icons.js
+++ b/src/renderer/modules/icons.js
@@ -124,6 +124,11 @@
     live: '<path d="M12 4a8 8 0 1 1-8 8"></path><path d="M12 4v8h8"></path>',
     box: '<path d="M21 16V8a2 2 0 0 0-1-1.7l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.7l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><path d="M3.3 7 12 12l8.7-5"></path><path d="M12 22V12"></path>',
     star: '<path d="M12 2.5l2.9 5.9 6.5.9-4.7 4.6 1.1 6.5L12 17.8 6.1 20.9l1.1-6.5L2.5 9.8l6.5-.9z"></path>',
+    activity: '<path d="M22 12h-4l-3 9L9 3l-3 9H2"></path>',
+    cpu: '<rect x="7" y="7" width="10" height="10" rx="1.5"></rect><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M9 2v2M15 2v2M9 20v2M15 20v2M2 9h2M2 15h2M20 9h2M20 15h2"></path>',
+    // Distinct from the FILE_ICONS entry of the same name: that one is the
+    // file-kind glyph for an archive file, this is the UI action.
+    archive: '<rect x="3" y="4" width="18" height="4" rx="1"></rect><path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8"></path><path d="M10 12h4"></path>',
     // Hub account surface icons (lucide-style, matching the library above).
     user: '<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle>',
     monitor: '<rect x="3" y="4" width="18" height="12" rx="2"></rect><path d="M8 20h8M12 16v4"></path>',

--- a/src/renderer/modules/run-center-board.js
+++ b/src/renderer/modules/run-center-board.js
@@ -445,6 +445,23 @@
     </div>`;
   }
 
+  // A recommended action is only worth showing when the projection actually
+  // offers it. The queue and the run detail pane both gate on this; when they
+  // drifted apart a restart-orphaned card recommended "Resume" in the list
+  // while the detail pane rendered no button at all.
+  function recommendedActionAvailable(actions, userState, context = {}) {
+    const action = String(userState?.action || '');
+    if (!action) return false;
+    const set = actions || {};
+    if (action === 'configure-model') return true;
+    if (action === 'open-task') return !!context.conversationId;
+    if (action === 'open-handling') return !!context.hasCollaboration || !!context.conversationId;
+    if (action === 'retry') return !!set.retry;
+    if (action === 'resume') return !!set.resume;
+    if (action === 'recover-result') return !!set.recoverResult;
+    return false;
+  }
+
   function queueGroups(runs, options = {}) {
     const groups = { attention: [], active: [], completed: [] };
     for (const run of Array.isArray(runs) ? runs : []) {
@@ -486,7 +503,7 @@
         <strong>${esc(display.title)}</strong>
         ${userState.attention ? `<span class="run-center-queue-reason">${esc(text(userState.reasonKey))}</span>` : ''}
         <span class="run-center-queue-meta"><span>${esc(sequenceLabel)}</span><span>${icon('terminal')}${esc(agent)}</span>${display.shortId ? `<span>${esc(display.shortId)}</span>` : ''}</span>
-        ${userState.actionKey ? `<span class="run-center-queue-recommendation">${esc(text('run_center.recommended_action'))}<b>${esc(text(userState.actionKey))}</b>${icon('chevron-right')}</span>` : ''}
+        ${userState.actionKey && recommendedActionAvailable(task.actions, userState, { conversationId: task.conversationId }) ? `<span class="run-center-queue-recommendation">${esc(text('run_center.recommended_action'))}<b>${esc(text(userState.actionKey))}</b>${icon('chevron-right')}</span>` : ''}
       </button>`;
     };
     const sections = [
@@ -505,6 +522,6 @@
     filteredLogicalTasks, taskForSession, shouldShowSessionTitle, uniqueCardMeta,
     logicalRunKey, logicalTasks, buildRunSequence, shortRunId, userStateForTask,
     displayColumnForTask, matchesTimeFilter, displayRun, buildDisplayRuns, queueGroups,
-    renderQueue, render,
+    recommendedActionAvailable, renderQueue, render,
   });
 })(window);

--- a/src/renderer/modules/run-center.js
+++ b/src/renderer/modules/run-center.js
@@ -631,9 +631,11 @@
       if (hasCollaboration) return `<button type="button" class="btn btn-sm btn-primary" data-run-center-detail-tab="collaboration">${icon('users')}<span>${esc(text(userState.actionKey))}</span></button>`;
       if (task?.conversationId) return `<button type="button" class="btn btn-sm btn-primary" data-run-center-open="${esc(task.conversationId)}">${icon('message-square')}<span>${esc(text(userState.actionKey))}</span></button>`;
     }
-    const allowed = action === 'retry' ? actions.retry
-      : action === 'resume' ? actions.resume
-        : action === 'recover-result' ? actions.recoverResult : false;
+    // Same gate the queue applies, so the two surfaces cannot promise
+    // different things about one card.
+    const allowed = rootWindow.CogSeedRunCenterBoard?.recommendedActionAvailable?.(
+      actions, userState, { conversationId: task?.conversationId, hasCollaboration },
+    ) ?? false;
     if (allowed) {
       const iconName = action === 'resume' ? 'play-triangle' : 'refresh';
       return `<button type="button" class="btn btn-sm btn-primary" data-run-center-action="${esc(action)}" ${busy ? 'disabled' : ''}>${busy === action ? icon('loader', 'ui-icon is-spinning') : icon(iconName)}<span>${esc(text(busy === action ? 'run_center.action_working' : userState.actionKey))}</span></button>`;

--- a/test/main/features/cogseed_backend/conversation-task-purge.test.ts
+++ b/test/main/features/cogseed_backend/conversation-task-purge.test.ts
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2026 CogSeed contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Deleting a conversation used to hide its Group Chat shadow tasks without
+ * removing them: the task JSON, its event log and its request claim stayed on
+ * disk forever, kept being read by every dashboard scan, and the claim still
+ * resolved to a task nobody could reach.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const USER = 'cogseed-purge-user';
+const CID = 'conv-purge-target';
+const OTHER_CID = 'conv-purge-bystander';
+let tmpDir: string;
+let previousWorkspaceRoot: string | undefined;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-purge-'));
+  previousWorkspaceRoot = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (previousWorkspaceRoot === undefined) delete process.env.COGSEED_WORKSPACE_ROOT;
+  else process.env.COGSEED_WORKSPACE_ROOT = previousWorkspaceRoot;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function modules() {
+  return {
+    tasks: await import('../../../../src/main/features/cogseed_backend/task-store'),
+    lifecycle: await import('../../../../src/main/features/cogseed_backend/lifecycle'),
+    paths: await import('../../../../src/main/features/cogseed_backend/paths'),
+  };
+}
+
+async function groupChatTask(requestId: string, conversationId: string) {
+  const { tasks, lifecycle } = await modules();
+  const created = await tasks.createCogSeedTask(USER, {
+    requestId,
+    task: 'group chat turn',
+    executionKind: 'group-chat',
+    conversationId,
+    agentId: 'agent-reviewer',
+    groupChatRunId: `gcrun-${requestId}`,
+  });
+  const taskId = created.task.taskId;
+  await lifecycle.transitionCogSeedTask(USER, taskId, 'queued');
+  await lifecycle.transitionCogSeedTask(USER, taskId, 'running');
+  await lifecycle.transitionCogSeedTask(USER, taskId, 'completed');
+  return taskId;
+}
+
+function artifactsOf(paths: Awaited<ReturnType<typeof modules>>['paths'], taskId: string, requestId: string) {
+  return {
+    task: paths.cogseedTaskFile(USER, taskId),
+    events: paths.cogseedTaskEventsFile(USER, taskId),
+    projection: paths.cogseedTaskProjectionFile(USER, taskId),
+    claim: paths.cogseedRequestClaimFile(USER, requestId),
+  };
+}
+
+describe('purging CogSeed tasks for a deleted conversation', () => {
+  it('removes every durable file of a matching Group Chat task', async () => {
+    const { tasks, paths } = await modules();
+    const taskId = await groupChatTask('req-purge-1', CID);
+    const files = artifactsOf(paths, taskId, 'req-purge-1');
+
+    expect(fs.existsSync(files.task)).toBe(true);
+    expect(fs.existsSync(files.events)).toBe(true);
+    expect(fs.existsSync(files.claim)).toBe(true);
+
+    const report = await tasks.purgeCogSeedGroupChatTasksByConversation(USER, CID);
+
+    expect(report.purgedTaskIds).toEqual([taskId]);
+    expect(report.failedTaskIds).toEqual([]);
+    expect(fs.existsSync(files.task)).toBe(false);
+    expect(fs.existsSync(files.events)).toBe(false);
+    expect(fs.existsSync(files.projection)).toBe(false);
+    expect(fs.existsSync(files.claim)).toBe(false);
+    expect(await tasks.readCogSeedTask(USER, taskId)).toBeNull();
+    expect(await tasks.listCogSeedTasks(USER)).toEqual([]);
+  });
+
+  it('leaves the request claim resolvable for nothing rather than pointing at a missing task', async () => {
+    const { tasks } = await modules();
+    await groupChatTask('req-purge-2', CID);
+    await tasks.purgeCogSeedGroupChatTasksByConversation(USER, CID);
+
+    // The dangling-claim failure mode: a claim outliving its task makes this
+    // throw 'references a missing task'.
+    await expect(tasks.readCogSeedTaskByRequestId(USER, 'req-purge-2')).resolves.toBeNull();
+  });
+
+  it('touches nothing that belongs to another conversation', async () => {
+    const { tasks, paths } = await modules();
+    const target = await groupChatTask('req-purge-3', CID);
+    const bystander = await groupChatTask('req-purge-4', OTHER_CID);
+    const bystanderFiles = artifactsOf(paths, bystander, 'req-purge-4');
+
+    const report = await tasks.purgeCogSeedGroupChatTasksByConversation(USER, CID);
+
+    expect(report.purgedTaskIds).toEqual([target]);
+    expect(fs.existsSync(bystanderFiles.task)).toBe(true);
+    expect(fs.existsSync(bystanderFiles.events)).toBe(true);
+    expect(fs.existsSync(bystanderFiles.claim)).toBe(true);
+    expect((await tasks.listCogSeedTasks(USER)).map((task) => task.taskId)).toEqual([bystander]);
+  });
+
+  it('keeps non Group Chat work that merely shares the conversation id', async () => {
+    const { tasks, lifecycle, paths } = await modules();
+    // A follow-up asked inside the conversation carries the same conversation
+    // id but is the user's own run, not a projection of the conversation.
+    const created = await tasks.createCogSeedTask(USER, {
+      requestId: 'req-purge-5',
+      task: 'follow-up asked inside the conversation',
+      executionKind: 'cogseed-native',
+      conversationId: CID,
+      agentId: 'agent-reviewer',
+    });
+    const nativeId = created.task.taskId;
+    await lifecycle.transitionCogSeedTask(USER, nativeId, 'queued');
+    await lifecycle.transitionCogSeedTask(USER, nativeId, 'running');
+    await lifecycle.transitionCogSeedTask(USER, nativeId, 'completed');
+    const shadow = await groupChatTask('req-purge-6', CID);
+
+    const report = await tasks.purgeCogSeedGroupChatTasksByConversation(USER, CID);
+
+    expect(report.purgedTaskIds).toEqual([shadow]);
+    expect(fs.existsSync(paths.cogseedTaskFile(USER, nativeId))).toBe(true);
+    expect(await tasks.readCogSeedTask(USER, nativeId)).toMatchObject({ taskId: nativeId });
+  });
+
+  it('retains a task whose terminal result has not been delivered', async () => {
+    const { tasks, paths } = await modules();
+    const taskId = await groupChatTask('req-purge-7', CID);
+    await tasks.updateCogSeedTask(USER, taskId, (task) => ({ ...task, resultDeliveryState: 'pending-recovery' }));
+
+    const report = await tasks.purgeCogSeedGroupChatTasksByConversation(USER, CID);
+
+    expect(report.purgedTaskIds).toEqual([]);
+    expect(report.retainedTaskIds).toEqual([taskId]);
+    expect(fs.existsSync(paths.cogseedTaskFile(USER, taskId))).toBe(true);
+  });
+
+  it('is idempotent and safe on a conversation that never had tasks', async () => {
+    const { tasks } = await modules();
+    const taskId = await groupChatTask('req-purge-8', CID);
+
+    const first = await tasks.purgeCogSeedGroupChatTasksByConversation(USER, CID);
+    const second = await tasks.purgeCogSeedGroupChatTasksByConversation(USER, CID);
+    const unknown = await tasks.purgeCogSeedGroupChatTasksByConversation(USER, 'conv-never-existed');
+
+    expect(first.purgedTaskIds).toEqual([taskId]);
+    expect(second.purgedTaskIds).toEqual([]);
+    expect(second.failedTaskIds).toEqual([]);
+    expect(unknown).toEqual({ purgedTaskIds: [], retainedTaskIds: [], failedTaskIds: [] });
+  });
+
+  it('reports an unreadable record instead of deleting it blind', async () => {
+    const { tasks, paths } = await modules();
+    const taskId = await groupChatTask('req-purge-9', CID);
+    const file = paths.cogseedTaskFile(USER, taskId);
+    fs.writeFileSync(file, '{ not json');
+
+    const report = await tasks.purgeCogSeedGroupChatTasksByConversation(USER, CID);
+
+    expect(report.failedTaskIds).toEqual([taskId]);
+    expect(report.purgedTaskIds).toEqual([]);
+    expect(fs.existsSync(file)).toBe(true);
+  });
+});

--- a/test/main/features/cogseed_backend/group-chat-restart-recovery.test.ts
+++ b/test/main/features/cogseed_backend/group-chat-restart-recovery.test.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 CogSeed contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * A Group Chat run that is mid-flight when the process dies comes back as
+ * `recoverable`. Group Chat cannot resume such a run, and the turn never
+ * reached `finishTask`, so `groupChatMessageId` is absent and retry is
+ * impossible too. Without an abort that actually settles the task, the card
+ * has no exit at all and sits in the attention column forever.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const USER = 'cogseed-restart-exit-user';
+const CID = 'conv-restart-exit';
+let tmpDir: string;
+let previousWorkspaceRoot: string | undefined;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-restart-exit-'));
+  previousWorkspaceRoot = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (previousWorkspaceRoot === undefined) delete process.env.COGSEED_WORKSPACE_ROOT;
+  else process.env.COGSEED_WORKSPACE_ROOT = previousWorkspaceRoot;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function orphanedGroupChatRun(requestId: string) {
+  const tasks = await import('../../../../src/main/features/cogseed_backend/task-store');
+  const lifecycle = await import('../../../../src/main/features/cogseed_backend/lifecycle');
+  const boot = await import('../../../../src/main/features/cogseed_backend/boot-recovery');
+  const created = await tasks.createCogSeedTask(USER, {
+    requestId,
+    task: 'group chat run interrupted by a restart',
+    executionKind: 'group-chat',
+    conversationId: CID,
+    agentId: 'agent-reviewer',
+    groupChatRunId: `gcrun-${requestId}`,
+  });
+  const taskId = created.task.taskId;
+  await lifecycle.transitionCogSeedTask(USER, taskId, 'queued');
+  await lifecycle.transitionCogSeedTask(USER, taskId, 'running');
+  await boot.recoverCogSeedTasksAtBoot(USER);
+  return { taskId, tasks };
+}
+
+function service(ipc: typeof import('../../../../src/main/features/cogseed_backend/ipc-service'), overrides = {}) {
+  return ipc.createCogSeedIpcService({
+    isConversationAvailable: async () => true,
+    countConversationAgents: async () => 2,
+    abortGroupChat: async () => {},
+    ...overrides,
+  });
+}
+
+describe('Group Chat runs orphaned by an app restart', () => {
+  it('offers abort as the exit and actually settles the task when it is taken', async () => {
+    const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+    const { taskId, tasks } = await orphanedGroupChatRun('req-restart-exit-1');
+
+    const orphaned = (await tasks.readCogSeedTask(USER, taskId))!;
+    expect(orphaned.status).toBe('recoverable');
+    // The precondition that makes retry impossible: the turn never finished.
+    expect(orphaned.groupChatMessageId).toBeUndefined();
+
+    const svc = service(ipc);
+    const before = (await svc.boardProjection(USER)).tasks.find((task) => task.taskId === taskId);
+    expect(before?.column).toBe('attention');
+    expect(before?.actions.abort).toBe(true);
+
+    await svc.action(USER, { taskId, action: 'abort' });
+
+    const settled = (await tasks.readCogSeedTask(USER, taskId))!;
+    expect(settled.status).toBe('cancelled');
+    const after = (await svc.boardProjection(USER)).tasks.find((task) => task.taskId === taskId);
+    expect(after?.column).toBe('archived');
+    expect(after?.column).not.toBe('attention');
+  });
+
+  it('still delegates to Group Chat so a live turn is stopped before the task is settled', async () => {
+    const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+    const { taskId } = await orphanedGroupChatRun('req-restart-exit-2');
+
+    const delegated: string[] = [];
+    const svc = service(ipc, { abortGroupChat: async (_userId: string, cid: string) => { delegated.push(cid); } });
+    await svc.action(USER, { taskId, action: 'abort' });
+
+    expect(delegated).toEqual([CID]);
+  });
+
+  it('leaves a live Group Chat run for Group Chat to terminate instead of forcing it cancelled', async () => {
+    const tasks = await import('../../../../src/main/features/cogseed_backend/task-store');
+    const lifecycle = await import('../../../../src/main/features/cogseed_backend/lifecycle');
+    const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+
+    const created = await tasks.createCogSeedTask(USER, {
+      requestId: 'req-restart-exit-3',
+      task: 'live group chat run',
+      executionKind: 'group-chat',
+      conversationId: CID,
+      agentId: 'agent-reviewer',
+      groupChatRunId: 'gcrun-live',
+    });
+    const taskId = created.task.taskId;
+    await lifecycle.transitionCogSeedTask(USER, taskId, 'queued');
+    await lifecycle.transitionCogSeedTask(USER, taskId, 'running');
+
+    await service(ipc).action(USER, { taskId, action: 'abort' });
+
+    // Group Chat owns the terminal transition for a run it is still driving.
+    expect((await tasks.readCogSeedTask(USER, taskId))!.status).toBe('running');
+  });
+
+  it('records the abort as an ordinary cancellation, keeping the restart on the event log', async () => {
+    const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+    const events = await import('../../../../src/main/features/cogseed_backend/event-store');
+    const { taskId } = await orphanedGroupChatRun('req-restart-exit-6');
+
+    await service(ipc).action(USER, { taskId, action: 'abort' });
+
+    const log = await events.readCogSeedTaskEvents(USER, taskId);
+    const types = log.map((event) => event.type);
+
+    // The terminal event is the same one a user-initiated cancel writes, so the
+    // timeline has no bespoke shape for this path.
+    expect(types.at(-1)).toBe('task.cancelled');
+    expect(types).not.toContain('task.failed');
+    // The cancel clears `errorCode` from the record, so the event log is the
+    // only place that still says the run was cut short by a restart.
+    const recoverable = log.find((event) => event.type === 'task.recoverable');
+    expect(recoverable?.payload).toMatchObject({ errorCode: 'worker_restart' });
+  });
+
+  it('never offers resume for a Group Chat task, in any status', async () => {
+    const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+    const { taskId } = await orphanedGroupChatRun('req-restart-exit-4');
+    const svc = service(ipc);
+
+    const card = (await svc.boardProjection(USER)).tasks.find((task) => task.taskId === taskId);
+    expect(card?.actions.resume).toBe(false);
+    expect(card?.resumable).toBe(false);
+    await expect(svc.action(USER, { taskId, action: 'resume', requestId: 'req-resume-attempt' }))
+      .rejects.toThrow(/cannot be resumed/i);
+  });
+
+  it('keeps abort closed for terminal Group Chat tasks', async () => {
+    const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+    const { taskId, tasks } = await orphanedGroupChatRun('req-restart-exit-5');
+    const svc = service(ipc);
+    await svc.action(USER, { taskId, action: 'abort' });
+    expect((await tasks.readCogSeedTask(USER, taskId))!.status).toBe('cancelled');
+
+    const card = (await svc.boardProjection(USER)).tasks.find((task) => task.taskId === taskId);
+    expect(card?.actions.abort).toBe(false);
+  });
+});

--- a/test/main/features/cogseed_backend/task-scan-reuse.test.ts
+++ b/test/main/features/cogseed_backend/task-scan-reuse.test.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 CogSeed contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * `listCogSeedTasks` reads every task file in the directory, so the number of
+ * times one Run Center refresh calls it is a direct multiplier on disk cost —
+ * and the dashboard watch stream replays that refresh on every task change.
+ * A session read used to scan twice: once for itself, then again inside the
+ * collaboration snapshot it delegates to.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { CogSeedTaskRecord } from '../../../../src/main/features/cogseed_backend/types';
+
+const USER = 'cogseed-scan-reuse-user';
+let tmpDir: string;
+let previousWorkspaceRoot: string | undefined;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-scan-reuse-'));
+  previousWorkspaceRoot = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (previousWorkspaceRoot === undefined) delete process.env.COGSEED_WORKSPACE_ROOT;
+  else process.env.COGSEED_WORKSPACE_ROOT = previousWorkspaceRoot;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function seedTasks(count: number) {
+  const tasks = await import('../../../../src/main/features/cogseed_backend/task-store');
+  const lifecycle = await import('../../../../src/main/features/cogseed_backend/lifecycle');
+  const seeded: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const created = await tasks.createCogSeedTask(USER, {
+      requestId: `req-scan-reuse-${index}`,
+      task: `task ${index}`,
+      executionKind: 'cogseed-native',
+      agentId: 'agent-reviewer',
+    });
+    await lifecycle.transitionCogSeedTask(USER, created.task.taskId, 'queued');
+    await lifecycle.transitionCogSeedTask(USER, created.task.taskId, 'running');
+    seeded.push(created.task.taskId);
+  }
+  return { tasks, seeded };
+}
+
+async function countingService(listTasks: typeof import('../../../../src/main/features/cogseed_backend/task-store').listCogSeedTasks) {
+  const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+  const scans: number[] = [];
+  const service = ipc.createCogSeedIpcService({
+    listTasks: async (userId: string) => {
+      const result = await listTasks(userId);
+      scans.push(result.length);
+      return result;
+    },
+    isConversationAvailable: async () => true,
+    countConversationAgents: async () => 1,
+  });
+  return { service, scans };
+}
+
+describe('task-directory scans per Run Center read', () => {
+  it('reads the task directory once per session projection', async () => {
+    const { tasks, seeded } = await seedTasks(4);
+    const { service, scans } = await countingService(tasks.listCogSeedTasks);
+    const sessionId = (await tasks.readCogSeedTask(USER, seeded[0]))!.sessionId;
+
+    scans.length = 0;
+    const projection = await service.sessionProjection(USER, { sessionId });
+
+    expect(projection.session).not.toBeNull();
+    expect(projection.collaboration).not.toBeNull();
+    expect(scans).toHaveLength(1);
+  });
+
+  it('reads it once when the session projection is scoped to a task', async () => {
+    const { tasks, seeded } = await seedTasks(4);
+    const { service, scans } = await countingService(tasks.listCogSeedTasks);
+
+    scans.length = 0;
+    const projection = await service.sessionProjection(USER, { taskId: seeded[1] });
+
+    expect(projection.collaboration).not.toBeNull();
+    expect(scans).toHaveLength(1);
+  });
+
+  it('reads it once per board projection', async () => {
+    const { tasks } = await seedTasks(4);
+    const { service, scans } = await countingService(tasks.listCogSeedTasks);
+
+    scans.length = 0;
+    await service.boardProjection(USER);
+
+    expect(scans).toHaveLength(1);
+  });
+
+  it('still scans for itself when a caller supplies nothing', async () => {
+    const { tasks, seeded } = await seedTasks(3);
+    const { service, scans } = await countingService(tasks.listCogSeedTasks);
+
+    scans.length = 0;
+    await service.collaborationSnapshot(USER, { taskId: seeded[0] });
+
+    expect(scans).toHaveLength(1);
+  });
+
+  it('produces the same snapshot whether the task set is handed down or re-read', async () => {
+    const { tasks, seeded } = await seedTasks(3);
+    const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+    const service = ipc.createCogSeedIpcService({
+      isConversationAvailable: async () => true,
+      countConversationAgents: async () => 1,
+    });
+    const sessionId = (await tasks.readCogSeedTask(USER, seeded[0]))!.sessionId;
+
+    const viaSession = (await service.sessionProjection(USER, { sessionId })).collaboration;
+    const standalone = await service.collaborationSnapshot(USER, { sessionId });
+
+    expect(viaSession).toEqual(standalone);
+  });
+
+  it('honours the caller-supplied set rather than silently re-reading', async () => {
+    const { tasks, seeded } = await seedTasks(3);
+    const ipc = await import('../../../../src/main/features/cogseed_backend/ipc-service');
+    const service = ipc.createCogSeedIpcService({
+      listTasks: async () => { throw new Error('collaborationSnapshot must not scan when handed a task set'); },
+      isConversationAvailable: async () => true,
+      countConversationAgents: async () => 1,
+    });
+    const preloaded = await Promise.all(seeded.map((id) => tasks.readCogSeedTask(USER, id))) as CogSeedTaskRecord[];
+
+    const snapshot = await service.collaborationSnapshot(USER, { taskId: seeded[0] }, preloaded);
+
+    expect(snapshot.task?.taskId).toBe(seeded[0]);
+  });
+});

--- a/test/main/features/conversation-deletion-cogseed-purge.test.ts
+++ b/test/main/features/conversation-deletion-cogseed-purge.test.ts
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 CogSeed contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The CogSeed task purge is only worth anything if the real conversation
+ * deletion path reaches it. A previous attempt at this cleanup was hung off a
+ * function with no callers, so it never ran in production while its unit tests
+ * stayed green — these drive `chats.deleteConversation()` itself.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { drainMainRuntimeForTest } from '../../helpers/drain-main-runtime';
+
+vi.mock('../../../src/main/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const TEST_UID = 'u-purge-hook';
+let tmpDir: string;
+let prevWs: string | undefined;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-purge-hook-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+  const users = await import('../../../src/main/features/users');
+  users.activateUser(TEST_UID);
+});
+
+afterEach(async () => {
+  await drainMainRuntimeForTest();
+  vi.doUnmock('../../../src/main/features/cogseed_backend/task-store');
+  process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** A Group Chat shadow task pointing at a real conversation. */
+async function shadowTask(cid: string, requestId: string) {
+  const tasks = await import('../../../src/main/features/cogseed_backend/task-store');
+  const lifecycle = await import('../../../src/main/features/cogseed_backend/lifecycle');
+  const paths = await import('../../../src/main/features/cogseed_backend/paths');
+  const created = await tasks.createCogSeedTask(TEST_UID, {
+    requestId,
+    task: 'group chat turn',
+    executionKind: 'group-chat',
+    conversationId: cid,
+    agentId: 'agent-reviewer',
+    groupChatRunId: `gcrun-${requestId}`,
+  });
+  const taskId = created.task.taskId;
+  await lifecycle.transitionCogSeedTask(TEST_UID, taskId, 'queued');
+  await lifecycle.transitionCogSeedTask(TEST_UID, taskId, 'running');
+  await lifecycle.transitionCogSeedTask(TEST_UID, taskId, 'completed');
+  return {
+    taskId,
+    files: {
+      task: paths.cogseedTaskFile(TEST_UID, taskId),
+      events: paths.cogseedTaskEventsFile(TEST_UID, taskId),
+      claim: paths.cogseedRequestClaimFile(TEST_UID, requestId),
+    },
+  };
+}
+
+describe('conversation deletion reaches the CogSeed task purge', () => {
+  it('removes the shadow task through the real deleteConversation path', async () => {
+    const chats = await import('../../../src/main/features/chats');
+    const created = await chats.createConversation(TEST_UID, 'purge hook target');
+    const cid = created.conversation_id;
+    const { taskId, files } = await shadowTask(cid, 'req-hook-1');
+
+    expect(fs.existsSync(files.task)).toBe(true);
+    expect(fs.existsSync(files.events)).toBe(true);
+    expect(fs.existsSync(files.claim)).toBe(true);
+
+    expect(await chats.deleteConversation(TEST_UID, cid)).toBe(true);
+
+    // No mocking anywhere above: if the purge were hung off an uncalled
+    // function these would all still exist.
+    expect(fs.existsSync(files.task)).toBe(false);
+    expect(fs.existsSync(files.events)).toBe(false);
+    expect(fs.existsSync(files.claim)).toBe(false);
+    const tasks = await import('../../../src/main/features/cogseed_backend/task-store');
+    expect(await tasks.readCogSeedTask(TEST_UID, taskId)).toBeNull();
+  });
+
+  it('leaves another conversation untouched when one is deleted', async () => {
+    const chats = await import('../../../src/main/features/chats');
+    const doomed = (await chats.createConversation(TEST_UID, 'doomed')).conversation_id;
+    const kept = (await chats.createConversation(TEST_UID, 'kept')).conversation_id;
+    const doomedTask = await shadowTask(doomed, 'req-hook-2');
+    const keptTask = await shadowTask(kept, 'req-hook-3');
+
+    expect(await chats.deleteConversation(TEST_UID, doomed)).toBe(true);
+
+    expect(fs.existsSync(doomedTask.files.task)).toBe(false);
+    expect(fs.existsSync(keptTask.files.task)).toBe(true);
+    expect(fs.existsSync(keptTask.files.events)).toBe(true);
+    expect(fs.existsSync(keptTask.files.claim)).toBe(true);
+  });
+
+  it('still deletes the conversation when the purge throws', async () => {
+    let attempted = 0;
+    vi.doMock('../../../src/main/features/cogseed_backend/task-store', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../../../src/main/features/cogseed_backend/task-store')>();
+      return {
+        ...actual,
+        purgeCogSeedGroupChatTasksByConversation: async () => {
+          attempted += 1;
+          throw new Error('purge blew up');
+        },
+      };
+    });
+
+    const chats = await import('../../../src/main/features/chats');
+    const cid = (await chats.createConversation(TEST_UID, 'purge throws')).conversation_id;
+    await shadowTask(cid, 'req-hook-4');
+
+    // best-effort: the failure is swallowed and logged, the deletion still
+    // reports success and the conversation is gone from the index.
+    expect(await chats.deleteConversation(TEST_UID, cid)).toBe(true);
+    expect(attempted).toBe(1);
+    expect(await chats.getConversation(TEST_UID, cid)).toBeFalsy();
+  });
+});

--- a/test/renderer/icon-registry-contract.test.ts
+++ b/test/renderer/icon-registry-contract.test.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 CogSeed contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * `uiIconHtml()` resolves an unknown name to the `info` glyph without warning,
+ * so a markup reference to an icon nobody registered renders the wrong picture
+ * and no test notices. The Run Center's sidebar button shipped that way. Pin
+ * the static references in `index.html` against what the module actually
+ * renders — the registry itself is module-private and stays that way.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+
+const root = path.join(__dirname, '../..');
+const read = (relativePath: string) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+function loadIcons(): (name: string, className?: string) => string {
+  const context: any = { window: {}, Object, String, Array, Map, Set, JSON, Number };
+  context.window.window = context.window;
+  vm.createContext(context);
+  vm.runInContext(read('src/renderer/modules/icons.js'), context);
+  const render = context.window.uiIconHtml;
+  if (typeof render !== 'function') throw new Error('icons.js did not expose uiIconHtml');
+  return render;
+}
+
+/** The wrapper carries `is-<name>`, so only the inner markup reveals a
+ * fallback. Brand icons return their own complete element and are reported as
+ * `null` — they are registered, just not through UI_ICONS. */
+function innerMarkup(html: string): string | null {
+  const match = /^<svg class="[^"]*" viewBox="0 0 24 24"[^>]*>([\s\S]*)<\/svg>$/.exec(html);
+  return match ? match[1] : null;
+}
+
+function staticIconNames(): string[] {
+  const html = read('src/renderer/index.html');
+  const names = new Set<string>();
+  // Skip template interpolation — only literal names are checkable here.
+  for (const match of html.matchAll(/data-ui-icon="([^"${}]+)"/g)) names.add(match[1]);
+  return [...names].sort();
+}
+
+describe('UI icon registry contract', () => {
+  it('renders a distinct glyph for every icon the static markup asks for', () => {
+    const uiIconHtml = loadIcons();
+    const referenced = staticIconNames();
+    const fallback = innerMarkup(uiIconHtml('info'));
+
+    expect(referenced.length).toBeGreaterThan(0);
+    expect(fallback).toBeTruthy();
+
+    const fellBack = referenced.filter((name) => {
+      if (name === 'info') return false;
+      const inner = innerMarkup(uiIconHtml(name));
+      return inner !== null && inner === fallback;
+    });
+    expect(fellBack).toEqual([]);
+  });
+
+  it('never renders an empty glyph for a referenced icon', () => {
+    const uiIconHtml = loadIcons();
+    const blank = staticIconNames().filter((name) => {
+      const html = uiIconHtml(name);
+      const inner = innerMarkup(html);
+      return inner !== null ? !inner.trim() : !html.trim();
+    });
+    expect(blank).toEqual([]);
+  });
+
+  it('gives the Run Center sidebar entry its own glyph rather than the fallback', () => {
+    const uiIconHtml = loadIcons();
+    const html = read('src/renderer/index.html');
+
+    expect(html).toMatch(/id="run-center-btn"[^>]*>\s*<span data-ui-icon="activity"/);
+    expect(innerMarkup(uiIconHtml('activity'))).not.toBe(innerMarkup(uiIconHtml('info')));
+  });
+
+  it('detects a fallback, so the check cannot silently pass', () => {
+    const uiIconHtml = loadIcons();
+    // Guard against the assertions above going vacuous: an unregistered name
+    // must be observable through exactly the comparison they rely on.
+    expect(innerMarkup(uiIconHtml('definitely-not-registered'))).toBe(innerMarkup(uiIconHtml('info')));
+  });
+});

--- a/test/renderer/run-center-recommended-action.test.ts
+++ b/test/renderer/run-center-recommended-action.test.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 CogSeed contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The queue's "recommended action" and the run detail pane's primary button
+ * must agree. They are computed from different inputs — the queue from
+ * `userStateForTask`, the detail pane from the projection's action set — so
+ * without a shared gate a restart-orphaned card recommends "Resume" in the
+ * list while the detail pane renders no button at all.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+
+const root = path.join(__dirname, '../..');
+const read = (relativePath: string) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+function loadBoard() {
+  const context: any = { window: {}, Object, String, Array, Map, Set, Date, Math, JSON, Number };
+  context.window.window = context.window;
+  vm.createContext(context);
+  vm.runInContext(read('src/renderer/modules/run-center-board.js'), context);
+  return context.window.CogSeedRunCenterBoard;
+}
+
+const renderOptions = {
+  text: (key: string, vars?: Record<string, unknown>) => vars ? `${key}:${JSON.stringify(vars)}` : key,
+  esc: (value: unknown) => String(value ?? ''),
+  icon: (name: string) => `[${name}]`,
+  formatDate: (value: string) => String(value).slice(11, 16),
+  stateView: (key: string) => `<p>${key}</p>`,
+};
+
+const noActions = { retry: false, skip: false, resume: false, recoverResult: false, abort: false, archive: false };
+
+describe('Run Center recommended-action gate', () => {
+  it('withholds an action the projection does not offer', () => {
+    const board = loadBoard();
+
+    // A Group Chat run left `recoverable` by a restart: the user state asks for
+    // Resume, but Group Chat can never resume one.
+    expect(board.recommendedActionAvailable(noActions, { action: 'resume' })).toBe(false);
+    expect(board.recommendedActionAvailable({ ...noActions, resume: true }, { action: 'resume' })).toBe(true);
+
+    expect(board.recommendedActionAvailable(noActions, { action: 'retry' })).toBe(false);
+    expect(board.recommendedActionAvailable({ ...noActions, retry: true }, { action: 'retry' })).toBe(true);
+
+    expect(board.recommendedActionAvailable(noActions, { action: 'recover-result' })).toBe(false);
+    expect(board.recommendedActionAvailable({ ...noActions, recoverResult: true }, { action: 'recover-result' })).toBe(true);
+  });
+
+  it('treats navigation actions as available on their own terms, not on the action set', () => {
+    const board = loadBoard();
+
+    // Opening a conversation is not a task action; it needs a conversation.
+    expect(board.recommendedActionAvailable(noActions, { action: 'open-task' }, { conversationId: 'conv-1' })).toBe(true);
+    expect(board.recommendedActionAvailable(noActions, { action: 'open-task' }, {})).toBe(false);
+
+    expect(board.recommendedActionAvailable(noActions, { action: 'open-handling' }, { hasCollaboration: true })).toBe(true);
+    expect(board.recommendedActionAvailable(noActions, { action: 'open-handling' }, { conversationId: 'conv-1' })).toBe(true);
+    expect(board.recommendedActionAvailable(noActions, { action: 'open-handling' }, {})).toBe(false);
+
+    expect(board.recommendedActionAvailable(noActions, { action: 'configure-model' })).toBe(true);
+  });
+
+  it('returns false for an empty or unknown action instead of guessing', () => {
+    const board = loadBoard();
+    expect(board.recommendedActionAvailable(noActions, { action: '' })).toBe(false);
+    expect(board.recommendedActionAvailable(noActions, {})).toBe(false);
+    expect(board.recommendedActionAvailable(undefined, { action: 'resume' })).toBe(false);
+    expect(board.recommendedActionAvailable(noActions, { action: 'teleport' })).toBe(false);
+  });
+
+  it('does not print a recommendation on a queue card whose action is unavailable', () => {
+    const board = loadBoard();
+    const orphaned = {
+      taskId: 'task-orphan',
+      sessionId: 'session-orphan',
+      executionId: 'execution-orphan',
+      conversationId: 'conv-orphan',
+      column: 'attention',
+      status: 'recoverable',
+      updatedAt: '2026-08-27T09:00:00.000Z',
+      actions: { ...noActions },
+    };
+    const runs = board.buildRunModels({ tasks: [orphaned] });
+    // The card lands in the attention group and asks for Resume — the state
+    // the queue would render from if it did not consult the action set.
+    expect(board.queueGroups(runs).attention[0].userState.action).toBe('resume');
+
+    const html = board.renderQueue(runs, renderOptions);
+    expect(html).toContain('data-run-center-queue-task="task-orphan"');
+    // The card still states what is going on…
+    expect(html).toContain('run_center.user_state_recoverable');
+    // …but does not promise an action the backend refuses.
+    expect(html).not.toContain('run_center.recommended_action');
+    expect(html).not.toContain('run_center.resume');
+  });
+
+  it('still prints a recommendation when the projection does offer the action', () => {
+    const board = loadBoard();
+    const resumable = {
+      taskId: 'task-native',
+      sessionId: 'session-native',
+      executionId: 'execution-native',
+      column: 'attention',
+      status: 'recoverable',
+      updatedAt: '2026-08-27T09:00:00.000Z',
+      actions: { ...noActions, resume: true },
+    };
+    const html = board.renderQueue(board.buildRunModels({ tasks: [resumable] }), renderOptions);
+    expect(html).toContain('run_center.recommended_action');
+    expect(html).toContain('run_center.resume');
+  });
+});

--- a/test/renderer/run-center.test.ts
+++ b/test/renderer/run-center.test.ts
@@ -73,7 +73,7 @@ describe('Run Center renderer contract', () => {
     expect(source).toContain("invoke('cogseed.session.read'");
     expect(source).toContain("invoke('cogseed.agent.list')");
     expect(source).toContain("invoke('cogseed.task.action'");
-    expect(source).toContain("action === 'recover-result' ? actions.recoverResult : false");
+    expect(source).toContain('CogSeedRunCenterBoard?.recommendedActionAvailable?.(');
     expect(source).toContain('data-run-center-action="archive"');
     expect(source).toContain("text('run_center.archive_confirm')");
     expect(source).toContain("invoke(isReassign ? 'cogseed.task.reassign' : 'cogseed.task.start'");


### PR DESCRIPTION
What does this PR do?

Fixes several Run Center issues confirmed against the current develop implementation.

1. Restart dead-card exit

A Group Chat task interrupted by app restart can enter recoverable, while resume/retry are unavailable.

Simply enabling abort is not sufficient: the Group Chat abort path delegates to abortGroupChat() but does not transition the CogSeed task, so the card remains stuck.

This PR:

* enables abort for the recoverable restart case;
* transitions the task to cancelled after abort so it actually leaves attention;
* keeps live created / queued / running tasks on the existing Group Chat lifecycle;
* shares recommendedActionAvailable() between the queue and detail view so recommended actions cannot drift between the two surfaces.

2. Conversation deletion cleanup

Previously, deleting a conversation hid its Run Center tasks but left durable artifacts behind.

This PR adds physical cleanup for:

* task JSON;
* task events;
* projection cache;
* request claims.

The cleanup is attached to the real conversation deletion path and is best-effort, so cleanup failure does not block conversation deletion.

Tasks with pending / pending-recovery result delivery are intentionally retained to avoid deleting the only durable reference before reconciliation completes.

3. Duplicate task-scan reuse

sessionProjection() already loads the visible task set, but collaborationSnapshot() previously scanned the task store again.

The loaded task set is now reused internally.

Runtime verification:

* 10 tasks: 30 → 20 reads
* 50 tasks: 150 → 100 reads
* 200 tasks: 600 → 400 reads

This reduces the refresh path from 3N to 2N. Full retention/query bounds are intentionally out of scope.

4. UI icon registry contract

Adds missing UI icon registrations for:

* activity
* cpu
* archive

Also adds a registry contract test so static data-ui-icon values cannot silently fall back to the generic info icon unnoticed.

Validation

Covered by automated tests

* recoverable → abort → cancelled;
* card moves from attention to archived;
* terminal event is task.cancelled;
* prior task.recoverable event retains worker_restart;
* live Group Chat runs are not forcibly transitioned;
* queue and detail view share the same action-availability logic;
* conversation deletion invokes CogSeed purge;
* purge failure does not block conversation deletion;
* durable task artifacts are removed without cross-conversation deletion;
* pending delivery tasks are retained;
* preloaded task reuse does not change projection semantics;
* static UI icon references are backed by registered icons.

tsc --noEmit passes and modified files pass ESLint.

Relevant test run: 2916 passed / 2 existing failures.

The two remaining failures are in kb-notes and top-drag-regions; both reproduce on the clean base and are unrelated to this PR.

Known follow-ups

Highest priority: retained pending-task cleanup

pending / pending-recovery tasks must be retained during conversation deletion, but there is currently no later sweep that removes them after reconciliation.

These states are reachable in the result-delivery reconciler, so this is a real lifecycle follow-up rather than a theoretical edge case.

A later hardening pass should re-run cleanup for Group Chat tasks whose conversation no longer exists after boot/result reconciliation.

Other deferred hardening includes:

* re-reading task state after async abort before applying the restart cancellation transition;
* preserving restart provenance directly on the final task snapshot;
* replacing remaining source-string renderer assertions when the RC-T01 harness is available;
* full retention/query-window work.

Out of scope

This PR does not:

* cherry-pick the old Run Center hardening branch;
* restore polling or old tree/orphan fixes;
* implement full retention/query bounds;
* implement RC-T01;
* change Run Center product/title decisions.