### PR TITLE
test(run-center): pin failureCategory branches and boundaries

### DIFF
--- a/PROJECT_HANDOFF.md
+++ b/PROJECT_HANDOFF.md
@@ -1,0 +1,56 @@
+# 项目交接
+
+本文件是项目承接入口。当前代码和 Git 状态是事实来源；详细未来方案见 `docs/plans/`，详细实际开发见 `docs/changes/`。
+
+## 项目快照
+
+- 当前目标：为 Run Center 的纯函数补齐分支与边界测试覆盖。
+- 当前阶段：`2026-09-01-001` 已实施完成，待随本分支提交。
+- 当前分支或提交：`feature/spec-workflow-project-memory`，基线 `origin/develop` @ `220b5fe5`（MR 前已 rebase；任务开始时基线为 `71453450`）。
+- 最后更新：2026-09-01。
+
+## 正在进行
+
+| 任务 ID | 状态 | 记录 |
+| --- | --- | --- |
+| `2026-09-01-001-failure-category-boundaries` | `completed` | [change](docs/changes/2026-09-01-001-failure-category-boundaries.md) |
+
+该任务为 direct work，没有对应 plan；`spec-work` 允许范围明确的直接实施，未事后补造 plan。
+
+## 下一阶段
+
+1. 本分支已 rebase 到 `220b5fe5` 并 force-with-lease 推送，待开 MR 合入 `develop`。
+2. 全量 JS 测试已在 `220b5fe5` 重跑并做了 A/B 对照，本任务对失败数无影响；33 个既有失败待另案处理。
+3. 后续任务由 `spec-plan` / `spec-work` 按 `YYYY-MM-DD-NNN-<topic>` 继续登记。
+
+## 关键决策与约束
+
+- `PROJECT_HANDOFF.md` 保存当前状态和索引，`docs/plans/` 保存未来方案，`docs/changes/` 保存实际开发。
+- 事实优先级：当前代码与 Git > 实际命令结果 > change 记录 > handoff 摘要 > plan。
+- 历史摘要只追加；每人只修改自己任务的条目，不改写他人条目。
+- task ID 取当日 `NNN` 最大值加一（跨 handoff / plans / archive / changes 统计）；冲突时顺延，禁止覆盖他人记录。归档的 ID 保持占用，不回收。
+- 命令未实际执行不得记为 `passed`；未执行即 `not run`。
+- `spec-plan` / `spec-work` 由各人自行安装于个人 Claude 配置，**不要求团队成员安装**；本仓库的 `AGENTS.md` 未做任何改动。
+
+## 验证基线
+
+| 检查 | 命令 | 最近结果 | 证据状态 |
+| --- | --- | --- | --- |
+| 类型检查 | `npm run typecheck` | `passed` | 2026-09-01 rebase 到 `220b5fe5` 后重跑，exit 0 |
+| 目标测试 | `npm run test:js -- test/renderer/run-center-attempts.test.ts` | `passed` | 2026-09-01 rebase 后重跑，4/4 |
+| 记录校验 | `node scripts/check-spec-records.mjs` | `passed` | 2026-09-01 rebase 后重跑，1 条 change 记录 |
+| 全量 JS 测试 | `npm run test:js` | `failed` | 2026-09-01 在 `220b5fe5` 实跑：9953 passed / 33 failed / 13 文件。同基线对照组（不含本任务提交）为 9952 passed / 33 failed / 同一组文件，差值恰为本任务新增的 1 条通过用例 |
+| Python 资源测试 | `npm run test:resources` | `not run` | 本轮未执行；`npm test` 的完整结果因此无证据 |
+
+## 已知问题与风险
+
+- `npm test` 存在 30 个既有失败，分布于 11 个文件。主因是本机 PDF 栈环境损坏：`@napi-rs/canvas` 原生绑定缺失、`DOMMatrix is not defined`，波及 `extract-pdf`、`file_indexer`、`file-tools`、`chat_attachments`。
+- `test/renderer/run-center.test.ts > builds an overview with health, trend, source, and Agent load signals` 失败，趋势数组整体错位（`[0,0,0,0,1,1,0]` vs `[1,0,0,0,0,1,1]`），疑似按固定日期写死、随日历漂移。
+- `test/main/features/skill-trust.test.ts` 2 条 deep re-verification 失败，已验证与本工作流无关（移除本地 skill 后失败不变）。
+- 上游 `220b5fe5` 带入两处新失败：`packaged-resource-gate.test.ts`（3 条）与 `messaging.test.ts`（1 条）。在不含本任务提交的对照组中同样失败，与本任务无关。
+- 部分用例 flaky：`chat_attachments.test.ts` 在两次运行间为 1↔2 条，`cogseed_backend/runtime-controller.test.ts` 早前失败、后续通过。统计失败数时需留意。
+- 以上均非 `2026-09-01-001` 引入，本任务未修复，也未使其恶化。
+
+## 开发历史
+
+- 2026-09-01 · `2026-09-01-001-failure-category-boundaries` · `completed` · 无 plan（direct work）· [change](docs/changes/2026-09-01-001-failure-category-boundaries.md) — 为 `failureCategory` 补齐 5 个分支与 3 类边界断言，仅改测试文件，未动源码。

--- a/docs/changes/2026-09-01-001-failure-category-boundaries.md
+++ b/docs/changes/2026-09-01-001-failure-category-boundaries.md
@@ -1,0 +1,85 @@
+# 2026-09-01-001-failure-category-boundaries
+
+- status: completed
+- date: 2026-09-01
+- branch: `feature/spec-workflow-project-memory`
+- baseline at start: `develop` @ `71453450`
+- baseline at MR: rebased onto `origin/develop` @ `220b5fe5` before review; no conflicts, all six files replayed intact
+- commit: recorded in this branch's history; this record does not restate its own hash
+- plan: none — direct work, allowed by `spec-work` step 1.4 for a settled request; no plan was back-filled
+- handoff: [PROJECT_HANDOFF.md](../../PROJECT_HANDOFF.md)
+
+## Goal
+
+Pin the full branch and boundary behaviour of `failureCategory`, a pure classifier in
+`src/renderer/modules/run-center.js:576` exposed through `window.CogSeedRunCenterAttempts`.
+
+## Verified starting state
+
+`test/renderer/run-center-attempts.test.ts` passed 3/3 before the change. It asserted only
+2 of the 5 branches (`provider`, `other`), both piggybacked inside an unrelated test about
+attempt selection. `none`, `model` and `collaboration` had no coverage.
+
+## Files changed
+
+- `test/renderer/run-center-attempts.test.ts` — one added `it` block, +25 lines. No source
+  file touched; the existing two assertions were left where they are to keep the diff minimal.
+
+## Behaviour pinned
+
+All five branches, plus three boundary classes confirmed by probing the real function first:
+falsy inputs (`undefined`, `null`, `''`, `0`, `false`, `NaN`) collapse to `none`; case or
+whitespace near-misses (`Provider_Error`, `' provider_error'`) fall to `other`; truthy
+non-strings (`42`, `{}`) return `other` instead of throwing.
+
+## Verification
+
+Re-run after the rebase onto `220b5fe5` unless noted; the pre-rebase run on `71453450` gave the
+same results for the first four rows.
+
+| Check | Command | Result | Baseline |
+| --- | --- | --- | --- |
+| target file | `npm run test:js -- test/renderer/run-center-attempts.test.ts` | `passed` 4/4 (was 3/3) | `220b5fe5` |
+| record validator | `node scripts/check-spec-records.mjs` | `passed`, exit 0 | `220b5fe5` |
+| typecheck | `npm run typecheck` | `passed`, exit 0 no output | `220b5fe5` |
+| run-center suite | `npm run test:js -- test/renderer/run-center` | 29 passed, 1 pre-existing failure | `71453450` — not re-run after rebase |
+| lint | `npx eslint test/renderer/run-center-attempts.test.ts` | `passed`, exit 0 | `71453450` — not re-run after rebase |
+| full JS suite | `npm run test:js` | `failed` — 9953 passed / 33 failed across 13 files, none introduced here (A/B below) | `220b5fe5` |
+| Python resources | `npm run test:resources` | `not run` | — |
+
+## Remaining risks
+
+`test/renderer/run-center.test.ts > builds an overview with health, trend, source, and Agent
+load signals` fails with a rotated trend array
+(`[0,0,0,0,1,1,0]` vs `[1,0,0,0,0,1,1]`), which looks calendar-dependent. It was already
+failing in this session's earlier full run, before this change, and lives in a file this
+task did not touch. Left alone — diagnosing it is separate work.
+
+The rebase pulled in `220b5fe5` (builtin-packages seeding plus four builtin skills, 71679 lines).
+It touches no path this task changed.
+
+The full JS suite was re-run on `220b5fe5` against a control, so the 33 failures are attributed
+by measurement rather than by inference:
+
+| Run | Command | Result |
+| --- | --- | --- |
+| control — `develop` @ `220b5fe5`, without this commit | `npm run test:js` | 9952 passed / 33 failed / 10082 total, 13 files |
+| this branch — same baseline, with this commit | `npm run test:js` | 9953 passed / 33 failed / 10083 total, same 13 files |
+
+The delta is exactly `+1 test, +1 passed, +0 failed` — the test added here. The failing file set
+is identical, so this change introduces no failure.
+
+Two of those files are new relative to the task's starting baseline `71453450`:
+`packaged-resource-gate.test.ts` (3) and `messaging.test.ts` (1). Both fail in the control too,
+so they arrived with `220b5fe5`.
+
+Some cases are flaky and the failure count is not stable across runs:
+`chat_attachments.test.ts` gave 1 then 2 failures on consecutive runs, and
+`cogseed_backend/runtime-controller.test.ts` failed earlier in the day and passed in both runs
+above. Treat 33 as approximate.
+
+## Recovery entry point
+
+`git log feature/spec-workflow-project-memory` for the commit that carries this record, and
+`git show <commit> -- test/renderer/run-center-attempts.test.ts` for the change itself. The task is
+registered in [PROJECT_HANDOFF.md](../../PROJECT_HANDOFF.md) under 开发历史. Not pushed; no MR opened.

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -1,0 +1,8 @@
+# Changes
+
+Actual development results, one file per task: `<YYYY-MM-DD-NNN-topic>.md`, written by the `spec-work` skill.
+
+- Each record carries its own terminal status (`completed`, `partial`, `blocked`), date, branch or commit, plan link, files changed, and every verification command with `passed`, `failed`, or `not run`.
+- A planned but unexecuted command is `not run`, never `passed`.
+- Records are append-only history: never edit another task's record.
+- No secrets, full logs, chat transcripts, or line-by-line diffs.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,8 @@
+# Plans
+
+Proposed future work, one file per task: `<YYYY-MM-DD-NNN-topic>-plan.md`, written by the `spec-plan` skill.
+
+- A plan is `proposed` until a matching `docs/changes/<task-id>.md` exists. Nothing here is accepted or started.
+- Task ID: highest existing `NNN` for that date across `plans/`, `plans/archive/`, and `changes/`, plus one. Never overwrite another task's file.
+- A plan older than 30 days with no matching change record is stale. Superseded or abandoned plans move to `archive/` with the user's approval; they are never deleted.
+- Plans are historical proposals. Once implementation starts, the change record carries the truth and the plan is left untouched.

--- a/docs/plans/archive/README.md
+++ b/docs/plans/archive/README.md
@@ -1,0 +1,3 @@
+# Archived Plans
+
+Superseded or abandoned proposals, kept for history. Moved here only with explicit user approval; never deleted. Their task IDs stay reserved.

--- a/test/renderer/run-center-attempts.test.ts
+++ b/test/renderer/run-center-attempts.test.ts
@@ -60,6 +60,31 @@ describe('Run Center run and attempt identity', () => {
     expect(attemptsApi.failureCategory('private-unmapped-code')).toBe('other');
   });
 
+  it('maps every failure code to its category and treats near-miss codes as unmapped', () => {
+    const attemptsApi = loadAttemptsApi();
+
+    expect(attemptsApi.failureCategory('model_preflight')).toBe('model');
+    expect(attemptsApi.failureCategory('provider_error')).toBe('provider');
+    expect(attemptsApi.failureCategory('group_chat_run_failed')).toBe('collaboration');
+    expect(attemptsApi.failureCategory('unknown_code')).toBe('other');
+
+    // An absent code is "no failure", not an unmapped one: the detail pane keys
+    // its error banner off 'none', so a succeeded run must never reach 'other'.
+    for (const empty of [undefined, null, '', 0, false, NaN]) {
+      expect(attemptsApi.failureCategory(empty)).toBe('none');
+    }
+
+    // Matching is exact: a code that differs only by case or padding falls to
+    // 'other' and loses its category, so producers must emit the literal code.
+    for (const nearMiss of ['Provider_Error', 'PROVIDER_ERROR', ' provider_error', 'provider_error ']) {
+      expect(attemptsApi.failureCategory(nearMiss)).toBe('other');
+    }
+
+    // A truthy non-string is unmapped rather than throwing.
+    expect(attemptsApi.failureCategory(42)).toBe('other');
+    expect(attemptsApi.failureCategory({})).toBe('other');
+  });
+
   it('uses queue and board modes, embeds summary/history, reveals collaboration on demand, and retains stable selection', async () => {
     const panelListeners = new Map<string, (event: any) => void>();
     const documentListeners = new Map<string, (event: any) => void>();


### PR DESCRIPTION
Add one test block covering all five branches of `failureCategory` (src/renderer/modules/run-center.js:576) plus three boundary classes that previously had no coverage: falsy inputs collapsing to 'none', case and whitespace near-misses falling to 'other', and truthy non-strings returning 'other' rather than throwing. Assertions were derived by probing the real function, not from reading the implementation. No source file changed.

Also introduce repo-native project memory so this and later tasks can be picked up across sessions, devices, and collaborators:

- PROJECT_HANDOFF.md: current state and index, seeded from verified facts.
- docs/plans/, docs/plans/archive/, docs/changes/: per-task records with their conventions, one YYYY-MM-DD-NNN-<topic> ID spanning all three.

These are plain Markdown project documents. They add no hook, script, or CI step, AGENTS.md is untouched, and they impose no workflow on anyone who does not install the spec-plan / spec-work skills.

Task: 2026-09-01-001-failure-category-boundaries (direct work, no plan)

Claude-Session: https://claude.ai/code/session_01GTPJTjR1LpxxkyWzNTGUgn

## What does this PR do?

Describe the change and why it is needed.

## Related issue

Fixes #(issue)

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Tests added/updated for the change
- [ ] Signed off with `git commit -s` (DCO)
