### PR TITLE
test(messaging): make touchpoint intent expiry relative to now

### DIFF
--- a/test/main/features/messaging.test.ts
+++ b/test/main/features/messaging.test.ts
@@ -1461,7 +1461,7 @@ describe('messaging manager adapter flow', () => {
         template: 'task_approval',
         priority: 'high',
         availableFrom: '2026-08-10T13:00:00.000Z',
-        expiresAt: '2026-09-01T13:00:00.000Z',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
         dedupeKey: 'task:task-1:approval:event-1',
         actionContract: { version: 1, allowedActions: ['approve', 'reject'] },
       });
@@ -1566,7 +1566,7 @@ describe('messaging manager adapter flow', () => {
         template: 'task_approval',
         priority: 'normal',
         availableFrom: '2026-08-10T13:00:00.000Z',
-        expiresAt: '2026-09-01T13:00:00.000Z',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
         dedupeKey: 'task:task-2:approval:event-2',
         actionContract: { version: 1, allowedActions: ['approve'] },
       });


### PR DESCRIPTION
## 问题

`test/main/features/messaging.test.ts` 中两处 touchpoint 意图的 `expiresAt` 硬编码为 `2026-09-01T13:00:00.000Z`。真实时间越过该时刻（北京时间 09-01 21:00）后，测试构造的意图一出生就已过期，卡片点击被拒（`accepted: false`），断言 `accepted: true` 永久失败。

表现为：CI verify 从该时刻起确定性变红（含 PR #147 复用的 push run，rerun 两次均挂同一断言；本地检出 bf8d971b 连跑三遍稳定复现）。发版终扫与 #143 合并前的 PR CI 均在过期时刻之前运行，因此当时全绿——**非 0.7.6 产品代码缺陷，仅测试数据缺陷**。

## 修复

两处 `expiresAt` 改为相对当前时间 +1 小时（测试全程秒级完成，余量充足）：

- 第一处（signed card click 场景）：修复确定性失败；
- 第二处（未送达意图拒绝场景）：该场景测的是"非 sent 状态被拒"，过期时间应在未来——原写法导致"过期"与"未送达"两个拒绝原因叠加，语义被污染，本次一并消除。

仅改动测试数据 2 行，不触碰任何产品代码与 workflow 配置。

## 验证

- 本地（bf8d971b + 本修复）：`messaging.test.ts` 全文件连跑三遍，76/76 全绿；
- 修复前同环境三连挂同一断言，修复后稳定通过。

## 关联

- 解除 PR #147（cicd → main，0.7.6 推进对外主线）的 verify 阻塞：本 PR 合并后 #147 head 自动前进至含修复提交，verify 将对新提交重跑；
- 同一 run 中曾出现的 runtime-controller / boot-recovery 红为 ci.yml 注释已承认的负载型时序抖动（maxWorkers 已从 4 降至 2 仍偶发），与本修复无关，按既有先例 rerun 处理。
