### PR TITLE
fix(kb): 脑图生成超时降级修复 + 会话历史快照 + 发现模块待开发

### DIFF
--- a/src/main/features/kb_mindmap.ts
+++ b/src/main/features/kb_mindmap.ts
@@ -21,8 +21,12 @@ const log = createLogger('kb-mindmap');
 const CACHE_MAX = 50;
 /** 基于对话文本生成时的输入截断（防止超长回答撑爆 LLM 上下文） */
 const DOC_CHAR_CAP = 4000;
-/** LLM 单次脑图生成超时（网络不可达/模型卡住时降级为单节点，避免 UI 无限等待） */
-const MIND_LLM_TIMEOUT_MS = 45 * 1000;
+/** LLM 单次脑图生成超时（网络不可达/模型卡住时降级为单节点，避免 UI 无限等待）。
+ *  注意该预算包含「模型 turn 排队等待 + 模型推理 + 流式输出」全程：实测
+ *  DeepSeek 高峰期单次响应可达 60–90s，若用户同时跑 agent 长对话还会叠加排队，
+ *  45s 会把正常请求误杀成单节点，故放宽到 120s。超时仍降级，且迟到结果会被缓存
+ *  （见 runMindAttempt 的 late-cache），重试可秒出，不会每次都干等。 */
+const MIND_LLM_TIMEOUT_MS = 120 * 1000;
 
 /** 给 Promise 加超时：超时 reject（调用方 catch 后降级）。 */
 function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
@@ -45,6 +49,11 @@ export interface KbMindNode {
 export interface KbMindResult {
   root: KbMindNode;
   source: 'generated' | 'cached' | 'degraded';
+  /** 降级原因（source='degraded' 时存在），供 UI 区分提示与重试引导：
+   *  - empty        ：库内没有 ready 文档要点，根本没调 LLM；
+   *  - timeout      ：LLM 排队+推理超过 MIND_LLM_TIMEOUT_MS 被掐断；
+   *  - model-failed ：模型调用返回失败（provider down / 解析失败等）。 */
+  reason?: 'empty' | 'timeout' | 'model-failed';
   fingerprint: string;
 }
 
@@ -96,6 +105,15 @@ export function loadMindmap(key: string): KbMindNode | null {
   return hit && hit.root ? hit.root : null;
 }
 
+/** 删除一条存档（key 不存在返回 false）。会话历史删除时用于清理其脑图快照。 */
+export function deleteMindmap(key: string): boolean {
+  const store = readStore();
+  if (!(key in store)) return false;
+  delete store[key];
+  writeStore(store);
+  return true;
+}
+
 const MIND_SYSTEM_PROMPT = `你是知识库结构整理助手。根据提供的文档要点，输出一个层级思维导图 JSON（协议对齐 NotebookLM mind-map 的层级结构）：
 {"root":{"label":"中心主题","children":[{"label":"分支1","children":[{"label":"子节点1a","children":[]},{"label":"子节点1b","children":[]}]},{"label":"分支2","children":[{"label":"子节点2a","children":[]}]}]}}
 要求：
@@ -106,6 +124,11 @@ const MIND_SYSTEM_PROMPT = `你是知识库结构整理助手。根据提供的�
 5. 只输出 JSON，不要任何额外文字。`;
 
 const cache = new Map<string, KbMindResult>();
+
+/** 同一指纹的在途生成（single-flight）。用户连点生成 / 后台预热 + 手动点击并发时，
+ *  只发起一次 LLM 调用，后到者复用同一 Promise 等待真实结果——避免重复请求
+ *  挤占模型队列（此前"点击两次 = 两个 45s 排队超时"的根因之一）。 */
+const inflight = new Map<string, Promise<KbMindResult>>();
 
 function fingerprint(docLines: string[]): string {
   return createHash('sha256').update(docLines.join('\u0000')).digest('hex').slice(0, 16);
@@ -142,32 +165,84 @@ export async function kbMindmap(
   if (hit && !opts?.force) return { ...hit, source: 'cached' };
 
   if (!docLines.length) {
-    return { root: { label: '知识库', children: [] }, source: 'degraded', fingerprint: fp };
+    return { root: { label: '知识库', children: [] }, source: 'degraded', reason: 'empty', fingerprint: fp };
   }
 
+  const existing = inflight.get(fp);
+  if (existing && !opts?.force) return existing;
+
+  const attempt = runMindAttempt(userId, docLines, fp, deps);
+  inflight.set(fp, attempt);
   try {
-    const res = await withTimeout(deps.complete({
-      userId,
-      message: `请根据以下知识库文档要点生成层级思维导图：\n\n${docLines.join('\n\n')}`,
-      systemPrompt: MIND_SYSTEM_PROMPT,
-      sessionId: `aside-kbmind-${userId}`,
-    }), MIND_LLM_TIMEOUT_MS);
+    return await attempt;
+  } finally {
+    if (inflight.get(fp) === attempt) inflight.delete(fp);
+  }
+}
+
+/** 发起一次真实的 LLM 脑图生成（带超时降级 + 迟到结果兜底缓存）。 */
+async function runMindAttempt(
+  userId: string,
+  docLines: string[],
+  fp: string,
+  deps: KbMindDeps,
+): Promise<KbMindResult> {
+  const startedAt = Date.now();
+  const completion = deps.complete({
+    userId,
+    message: `请根据以下知识库文档要点生成层级思维导图：\n\n${docLines.join('\n\n')}`,
+    systemPrompt: MIND_SYSTEM_PROMPT,
+    sessionId: `aside-kbmind-${userId}`,
+  });
+
+  try {
+    const res = await withTimeout(completion, MIND_LLM_TIMEOUT_MS);
     if (!res.ok) throw new Error(res.error || 'model failed');
     const root = parseMindJson(res.text);
     const result: KbMindResult = { root, source: 'generated', fingerprint: fp };
     cache.set(fp, result);
-    if (cache.size > CACHE_MAX) {
-      const first = cache.keys().next().value;
-      if (first) cache.delete(first);
-    }
+    trimCache();
     return result;
   } catch (err) {
+    const message = (err as Error).message || String(err);
+    const reason = message.startsWith('LLM timeout') ? 'timeout' as const : 'model-failed' as const;
     log.warn('kb mindmap failed, degrading to single node', {
       user_id: maskId(userId),
-      error: (err as Error).message,
+      error: message,
+      wait_ms: Date.now() - startedAt,
     });
-    return { root: { label: '知识库', children: [] }, source: 'degraded', fingerprint: fp };
+    // 迟到结果兜底缓存：仅在超时降级时挂接——底层请求仍在跑，若最终成功就把结果
+    // 写入缓存；用户随即重试（同指纹）即可命中秒出，而不是再等一次完整 LLM。
+    if (reason === 'timeout') {
+      completion.then((res) => {
+        if (!res?.ok || !res.text) return;
+        try {
+          const late = parseMindJson(res.text);
+          if (late && late.label) {
+            cache.set(fp, { root: late, source: 'generated', fingerprint: fp });
+            log.info('kb mindmap late result cached (arrived after timeout)', {
+              user_id: maskId(userId),
+              wait_ms: Date.now() - startedAt,
+            });
+          }
+        } catch { /* 迟到的文本解析失败不影响已返回的降级结果 */ }
+      }).catch(() => { /* 底层请求失败已由降级路径覆盖 */ });
+    }
+    return { root: { label: '知识库', children: [] }, source: 'degraded', reason, fingerprint: fp };
   }
 }
 
-export const _internals = { parseMindJson, fingerprint, clearCacheForTests: () => cache.clear() };
+function trimCache(): void {
+  if (cache.size <= CACHE_MAX) return;
+  const first = cache.keys().next().value;
+  if (first) cache.delete(first);
+}
+
+export const _internals = {
+  parseMindJson,
+  fingerprint,
+  clearCacheForTests: () => {
+    cache.clear();
+    inflight.clear();
+  },
+};

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -4105,6 +4105,13 @@ const invokeHandlers: Record<string, InvokeHandler> = {
     const root = kbMindmap.loadMindmap(typeof key === 'string' ? key : '');
     return { ok: root !== null, root };
   },
+  // 删除一条存档（渲染层删除会话时清理其脑图快照用）。
+  'kb.mindmap.delete': async ({ key }, ctx) => {
+    const k = typeof key === 'string' && key ? key : '';
+    if (!k) return { ok: false, deleted: false };
+    const deleted = kbMindmap.deleteMindmap(k);
+    return { ok: true, deleted };
+  },
 
   // 脑图弹出独立窗口：新开一个无边框 BrowserWindow 展示 SVG，适合大屏深度查看
   'kb.mindmap.popout': async ({ html }) => {

--- a/src/renderer/modules/kb-discover.js
+++ b/src/renderer/modules/kb-discover.js
@@ -1,174 +1,18 @@
 // ─── 知识库生态 · 发现面板（S4）— classic script (window.renderKbDiscover) ───
 // 计划书 v1.3 §四.8/9：知识库市场（精选/分类/推荐）+ MCP 市场 + Skills 市场。
-// 市场数据为**内置自造示例**（不搬运外部内容，不出现 ima 字样）；Skills 列表
-// 反映本地已装技能（resources/builtin/system/skills 的真实能力名）。
+// 状态：**待开发** —— 不展示内置示例市场数据，进入发现页显示占位提示。
 (function () {
-  function _esc(s) {
-    return String(s == null ? '' : s)
-      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-  }
-
-  const FEATURED = [
-    { name: '地方法规知识库', desc: '收录全国各地区地方法规，包含地方性法规、自治条例与实施细则。', subs: '2.1万', cnt: '100万', src: '法律数据组' },
-    { name: 'AI+X Elite 20 案例库', desc: '历届 AI+X 项目真实案例：从需求征集到挑战落地的完整路径。', subs: '1.4万', cnt: '5.5万', src: 'AI+X 社区' },
-    { name: 'CogSeed 使用手册合集', desc: '开源社区整理的 CogSeed 玩法：知识库、Agent、Skills 配置。', subs: '1.4万', cnt: '5.6万', src: 'CogSeed 社区' },
-    { name: '班级管理方法论', desc: '学生自治 + AI 协作的班级管理实践合集，含月度更新。', subs: '3.6万', cnt: '5.2万', src: '教育实践组' },
-  ];
-  const MARKET = [
-    { name: 'AI 知识库·入门', desc: '分享 AI 的最新知识和资料，一起赶上 AI 大浪潮', subs: '8417', cnt: '94', src: '陈老师AIHome' },
-    { name: 'AI 做副业', desc: '分享 AI 怎么用来做副业，完整资料合集', subs: '1.0万', cnt: '36', src: '清晰者' },
-    { name: '人民法院案例库', desc: '【官方原版同步更新】收录人民法院案例', subs: '1.1万', cnt: '5538', src: '壹典法阅' },
-    { name: '国家智慧教育平台资料', desc: '共同学习国家中小学智慧教育平台', subs: '6767', cnt: '242', src: '大眼鱼' },
-    { name: '研究股票池', desc: '持续追踪优质上市公司研究资料', subs: '1.0万', cnt: '1707', src: '千研' },
-    { name: '全过程工程咨询实战', desc: '遴选权威公众资讯，融合专业知识', subs: '5754', cnt: '6.5万', src: '诚城' },
-    { name: 'PPT 模板免费下载', desc: '各行业 PPT 模板精选', subs: '2.3万', cnt: '147', src: '无忧哥' },
-    { name: '数学人生', desc: '数学知识分享与讨论社区', subs: '8613', cnt: '4520', src: '数学人生' },
-    { name: '科技前沿周报', desc: '每周精选 AI / 芯片 / 航天领域前沿进展', subs: '7210', cnt: '310', src: '前沿观察' },
-    { name: 'A股港股研报分享', desc: '研报隔离更新，出于版权原因不公开', subs: '6609', cnt: '1.5万', src: '投研面包树' },
-  ];
-  const MCPS = [
-    { icon: '📈', name: '进门投研', desc: '覆盖券商研究所、上市公司、资管机构公开路演内容', n1: '95', n2: '15', src: '进门' },
-    { icon: '🏢', name: '启信慧眼', desc: '企业全景数据：企业搜索、工商画像、风险识别', n1: '779', n2: '22', src: '启信慧眼' },
-    { icon: '⚖️', name: '法律数据', desc: '检索与核验中国法律法规和司法案例', n1: '4240', n2: '61', src: '法律平台' },
-    { icon: '📊', name: '指数估值分析', desc: '沪深指数估值分析工具接口', n1: '1.4万', n2: '122', src: '券商' },
-    { icon: '💹', name: '财务分析', desc: 'A 股财务数据对比分析', n1: '9810', n2: '33', src: '券商' },
-    { icon: '📜', name: '龙虎榜', desc: '沪深股市龙虎榜数据分析', n1: '7978', n2: '39', src: '券商' },
-    { icon: '🧾', name: '热门 ETF 榜单', desc: '沪深市场 ETF 热点排行', n1: '8619', n2: '48', src: '券商' },
-    { icon: '🔮', name: '智能投研套件', desc: '自然语言查询的金融投研工具套件', n1: '8406', n2: '127', src: '投研平台' },
-    { icon: '🧬', name: '专利&文献融合检索', desc: '融合专利与科技文献的跨库检索与语义分析', n1: '3201', n2: '58', src: '智慧芽' },
-    { icon: '📚', name: '企业全景查询', desc: '企业工商信息、司法风险、经营动态全景查询', n1: '5210', n2: '74', src: '企查平台' },
-  ];
-  const SKILLS = [
-    { icon: '🧩', name: 'grounded-material-qa', desc: '资料边界内的可靠问答与答案核验（COGSEED-39 已合入 develop）' },
-    { icon: '🌐', name: 'web-search', desc: '联网检索资料，纳入资料边界后可参与问答' },
-    { icon: '📄', name: 'pdf-reader', desc: 'PDF 解析与锚点定位' },
-    { icon: '🖼', name: 'image-analyze', desc: '图片 OCR 与视觉理解' },
-  ];
-  const TAGS = ['推荐', '科技', '教育', '职场', '财经', '产业', '健康', '法律', '人文', '生活'];
-
-  const _state = { rendered: false, list: [...MARKET], tag: '推荐' };
-
   function renderKbDiscover() {
     const host = document.getElementById('kb-discover');
-    if (!host || host.querySelector('.kb-discover')) return;
-    _state.rendered = true;
+    if (!host) return;
     host.innerHTML = `
-      <div class="kb-discover">
-        <div class="kb-discover-tabs">
-          <button type="button" class="kb-dtab on" data-kb-mtab="kb">📚 知识库市场</button>
-          <button type="button" class="kb-dtab" data-kb-mtab="mcp">🔌 MCP 市场</button>
-          <button type="button" class="kb-dtab" data-kb-mtab="skills">⚡ Skills 市场</button>
-        </div>
-        <div class="kb-discover-pane" id="kb-dpane-kb"></div>
-        <div class="kb-discover-pane" id="kb-dpane-mcp" hidden></div>
-        <div class="kb-discover-pane" id="kb-dpane-skills" hidden></div>
+      <div class="kb-eco-coming">
+        <div class="kb-eco-coming-ico">🧭</div>
+        <div class="kb-eco-coming-title">发现 · 待开发</div>
+        <div class="kb-eco-coming-sub">知识库市场 / MCP 市场 / Skills 市场正在规划中，
+          上线后将在「发现」中聚合可订阅的知识库与工具。当前可先在「知识库」中使用
+          个人库 / 共享库的问答、解析与脑图功能。</div>
       </div>`;
-    host.querySelectorAll('[data-kb-mtab]').forEach((b) => b.addEventListener('click', () => {
-      host.querySelectorAll('[data-kb-mtab]').forEach((x) => x.classList.toggle('on', x === b));
-      host.querySelectorAll('.kb-discover-pane').forEach((p) => { p.hidden = p.id !== `kb-dpane-${b.dataset.kbMtab}`; });
-    }));
-    _renderMarket();
-    _renderMcp();
-    _renderSkills();
-  }
-
-  function _renderMarket() {
-    const pane = document.getElementById('kb-dpane-kb');
-    if (!pane) return;
-    pane.innerHTML = `
-      <div class="kb-market-head">
-        <div class="kb-market-search">⌕ <input id="kb-market-q" placeholder="搜索知识库" autocomplete="off"><span class="kb-market-shuffle" id="kb-market-shuffle">换一换</span></div>
-        <button type="button" class="kb-wb-icon-btn" id="kb-market-notify" title="通知">🔔</button>
-      </div>
-      <div class="kb-market-sec"><div class="kb-market-sec-title">✨ 精选</div><div class="kb-market-featured" id="kb-market-featured"></div></div>
-      <div class="kb-market-sec"><div class="kb-market-sec-title">推荐分类</div><div class="kb-market-tags" id="kb-market-tags"></div></div>
-      <div class="kb-market-sec"><div class="kb-market-sec-title">🔥 推荐知识库</div><div class="kb-market-grid" id="kb-market-grid"></div></div>`;
-    // 精选
-    const feat = document.getElementById('kb-market-featured');
-    feat.innerHTML = FEATURED.map((x) => `
-      <div class="kb-market-card is-feat" data-kb-sub="${_esc(x.name)}">
-        <div class="kb-market-card-name">📖 ${_esc(x.name)}</div>
-        <div class="kb-market-card-desc">${_esc(x.desc)}</div>
-        <div class="kb-market-card-meta"><b>${x.subs}</b>人已订阅｜<b>${x.cnt}</b>个内容｜@<span class="kb-market-card-src">${_esc(x.src)}</span></div>
-      </div>`).join('');
-    // 标签
-    const tags = document.getElementById('kb-market-tags');
-    tags.innerHTML = TAGS.map((t) => `<span class="kb-market-tag${t === '推荐' ? ' on' : ''}" data-tag="${_esc(t)}">${_esc(t)}</span>`).join('');
-    tags.querySelectorAll('[data-tag]').forEach((el) => el.addEventListener('click', () => {
-      _state.tag = el.dataset.tag;
-      tags.querySelectorAll('[data-tag]').forEach((x) => x.classList.toggle('on', x === el));
-      _renderMarketList();
-    }));
-    document.getElementById('kb-market-q')?.addEventListener('input', _renderMarketList);
-    document.getElementById('kb-market-shuffle')?.addEventListener('click', () => {
-      for (let i = _state.list.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [_state.list[i], _state.list[j]] = [_state.list[j], _state.list[i]];
-      }
-      _renderMarketList();
-      _toast('已换一批推荐');
-    });
-    document.getElementById('kb-market-notify')?.addEventListener('click', () => {
-      _toast('通知：你订阅的「开源社区·CogSeed 使用手册」已更新 3 个内容');
-    });
-    feat.querySelectorAll('[data-kb-sub]').forEach((el) => el.addEventListener('click', () => _toast(`订阅知识库：${el.dataset.kbSub}`)));
-    _renderMarketList();
-  }
-
-  function _renderMarketList() {
-    const grid = document.getElementById('kb-market-grid');
-    if (!grid) return;
-    const q = (document.getElementById('kb-market-q')?.value || '').trim().toLowerCase();
-    const list = _state.list.filter((x) => {
-      const okTag = _state.tag === '推荐' || x.name.includes(_state.tag) || x.desc.includes(_state.tag);
-      return okTag && (!q || x.name.toLowerCase().includes(q) || x.desc.toLowerCase().includes(q));
-    });
-    grid.innerHTML = list.length ? list.map((x) => `
-      <div class="kb-market-card" data-kb-open="${_esc(x.name)}">
-        <div class="kb-market-card-name">📚 ${_esc(x.name)}</div>
-        <div class="kb-market-card-desc">${_esc(x.desc)}</div>
-        <div class="kb-market-card-meta"><b>${x.subs}</b>人已订阅｜<b>${x.cnt}</b>个内容｜@<span class="kb-market-card-src">${_esc(x.src)}</span></div>
-      </div>`).join('')
-      : '<div class="kb-market-empty">没有匹配的知识库</div>';
-    grid.querySelectorAll('[data-kb-open]').forEach((el) => el.addEventListener('click', () => _toast(`打开知识库：${el.dataset.kbOpen}`)));
-  }
-
-  function _renderMcp() {
-    const pane = document.getElementById('kb-dpane-mcp');
-    if (!pane) return;
-    pane.innerHTML = `
-      <div class="kb-market-sec-title">🔁 MCP</div>
-      <div class="kb-market-sub">接入可用的 MCP 工具，点击 ＋ 添加到你的智能体。</div>
-      <div class="kb-mcp-grid">${MCPS.map((m) => `
-        <div class="kb-mcp-card">
-          <button type="button" class="kb-mcp-add" data-kb-mcp="${_esc(m.name)}">＋</button>
-          <div class="kb-mcp-icon">${m.icon}</div>
-          <div class="kb-mcp-name">${_esc(m.name)}</div>
-          <div class="kb-mcp-desc">${_esc(m.desc)}</div>
-          <div class="kb-mcp-foot"><span><span class="kb-mcp-num">${m.n1}</span> 使用 · <span class="kb-mcp-num">${m.n2}</span> 收藏</span><span class="kb-mcp-src">${_esc(m.src)}</span></div>
-        </div>`).join('')}
-      </div>`;
-    pane.querySelectorAll('[data-kb-mcp]').forEach((el) => el.addEventListener('click', () => _toast(`已添加「${el.dataset.kbMcp}」到智能体`, 'success')));
-  }
-
-  function _renderSkills() {
-    const pane = document.getElementById('kb-dpane-skills');
-    if (!pane) return;
-    pane.innerHTML = `
-      <div class="kb-market-sec-title">⚡ Skills 市场</div>
-      <div class="kb-market-sub">已安装的技能来自本地 resources/builtin/system/skills 目录；安装更多技能即将开放。</div>
-      <div class="kb-skills-list">${SKILLS.map((s) => `
-        <div class="kb-skill-item">
-          <div class="kb-skill-icon">${s.icon}</div>
-          <div><div class="kb-skill-name">${_esc(s.name)}</div><div class="kb-skill-desc">${_esc(s.desc)}</div></div>
-          <span class="kb-skill-state">✓ 已安装</span>
-        </div>`).join('')}
-      </div>`;
-  }
-
-  function _toast(msg, variant) {
-    if (typeof uiToast === 'function') uiToast(msg, variant ? { variant } : undefined);
   }
 
   window.renderKbDiscover = renderKbDiscover;

--- a/src/renderer/modules/kb-eco.js
+++ b/src/renderer/modules/kb-eco.js
@@ -3,11 +3,11 @@
 // v2（按产品评审建议）：移除 52px 图标竖栏 → 6 个入口迁移为**第二栏顶部的横向
 // 工具栏**（图标+文字，可切紧凑「仅图标」，localStorage 记忆），释放横向空间。
 (function () {
-  // 只保留已落地入口（知识库/笔记/发现）；浏览/Agent/菜单为预留项，不展示避免误导。
+  // 知识库/笔记已落地；发现模块当前为「待开发」占位（不展示内置示例市场数据，避免误导）。
   const ECO_NAV = [
     { key: 'kb', icon: 'folder', label: '知识库', status: 'ok' },
     { key: 'notes', icon: 'file-text', label: '笔记', status: 'ok' },
-    { key: 'discover', icon: 'globe', label: '发现', status: 'ok' },
+    { key: 'discover', icon: 'globe', label: '发现', status: 'soon' },
   ];
   const COMPACT_KEY = 'cogseed.kb.eco.compact';
   let _compact = false;
@@ -25,9 +25,10 @@
   }
 
   function _navBtn(item, active) {
+    const badge = item.status === 'soon' ? '<span class="kb-eco-tab-soon">待开发</span>' : '';
     return `<button type="button" class="kb-eco-tab is-${item.status}${active ? ' active' : ''}" data-kb-eco="${item.key}"
       title="${item.label}" aria-label="${item.label}">
-      <span class="kb-sdot"></span>${_kbIcon(item.icon)}<span class="kb-eco-tab-label">${_mainLabel(item.label)}</span></button>`;
+      <span class="kb-sdot"></span>${_kbIcon(item.icon)}<span class="kb-eco-tab-label">${_mainLabel(item.label)}</span>${badge}</button>`;
   }
 
   function _applyCompact() {

--- a/src/renderer/modules/kb-workbench.js
+++ b/src/renderer/modules/kb-workbench.js
@@ -38,7 +38,7 @@
     sideCollapsed: false, // 知识库列表面板收起
     treeFilter: '', // 库树搜索关键词（过滤个人库+共享库）
     qaAttachments: [], // 本次提问挂载的附件 [{name, path, size}]（最多 5 个）
-    qaHistory: [], // 当前会话消息 [{role, content}]（多轮上下文）
+    qaHistory: [], // 当前会话消息 [{role, content}]（多轮上下文）；脑图条目 {role:'assistant', kind:'mindmap', key, label, ts}
     qaSessions: [], // 会话列表 [{id, title, msgs, ts}]（持久化 localStorage）
     qaSessionId: null, // 当前会话 id
   };
@@ -1473,6 +1473,77 @@
     }
   }
 
+  // 降级/失败提示（source='degraded'）：说明原因并给重试入口，
+  // 避免把「单节点知识库」当正常脑图展示（此前用户以为模型只生成了这么点）。
+  function _mmDegradedHtml(reason) {
+    const texts = {
+      empty: '当前知识库暂无已解析文档要点，无法生成多级脑图（仅显示中心节点）。请先在知识库中导入并解析文档。',
+      timeout: '脑图生成超时：本地模型排队/推理超过 2 分钟未返回，已降级为仅中心节点。模型通道繁忙，请稍后点击重试。',
+      'model-failed': '脑图生成失败（模型暂不可用），已降级为仅中心节点。请稍后点击重试。',
+    };
+    const tip = texts[reason] || texts['model-failed'];
+    const withRetry = reason !== 'empty';
+    return '<div class="kb-mm-fail">' + tip
+      + (withRetry ? '<br><button type="button" class="kb-mm-retry-btn">🔄 重新生成</button>' : '')
+      + '</div>';
+  }
+
+  // ── 脑图入会话历史（方案 A）：快照 key + kind:'mindmap' 消息条目 ──
+  // 快照 key 与手动存档（space:xxx / dir:xxx）分开：`<base>#<会话>-<时间戳>`，
+  // 每次生成独立快照，历史里的旧脑图不被新生成覆盖；'#' 标记在存档列表中被过滤。
+  function _mmSnapshotKey() {
+    const base = _state.spaceId ? `space:${_state.spaceId}` : `dir:${_state.currentLib || 'global'}`;
+    const sid = String(_state.qaSessionId || 'solo').replace(/[^0-9a-zA-Z_-]/g, '');
+    return `${base}#${sid}-${Date.now()}`;
+  }
+
+  // 生成成功（非降级）后：自动存档快照并写入当前会话历史，刷新/切会话可还原
+  function _mmRecordToHistory(root) {
+    if (!root || !root.label) return;
+    if (!window.cogseed || typeof window.cogseed.invoke !== 'function') return;
+    const key = _mmSnapshotKey();
+    window.cogseed.invoke('kb.mindmap.save', { key, root })
+      .then((r) => {
+        if (!r || !r.ok) return;
+        _state.qaHistory.push({ role: 'assistant', kind: 'mindmap', content: '', key, label: root.label, ts: Date.now() });
+        if (_state.qaHistory.length > 40) _state.qaHistory.splice(0, _state.qaHistory.length - 40);
+        _qaSaveCurrentSession();
+      })
+      .catch(() => { /* 快照失败不阻塞展示；手动存档通道不受影响 */ });
+  }
+
+  // 从会话历史还原一条脑图消息：先占位，再按 key 异步读档渲染
+  function _appendMindmapMessage(box, m) {
+    const ai = document.createElement('div');
+    ai.className = 'kb-qa-msg is-ai';
+    const headLabel = m && m.label ? ' · ' + String(m.label).slice(0, 20) : '';
+    const body = document.createElement('div');
+    body.className = 'kb-qa-msg-body kb-mm-msg';
+    body.innerHTML = '<div class="kb-mm-msg-head">🧠 脑图预览' + _esc(headLabel) + '</div>'
+      + '<div class="kb-wb-mm-canvas"><div class="kb-mm-loading">正在载入脑图…</div></div>';
+    ai.appendChild(body);
+    if (box) box.appendChild(ai);
+    const canvas = body.querySelector('.kb-wb-mm-canvas');
+    if (!m || !m.key || !window.cogseed || typeof window.cogseed.invoke !== 'function') {
+      if (canvas) canvas.innerHTML = '<div class="kb-mm-fail">脑图存档不可用</div>';
+      return;
+    }
+    window.cogseed.invoke('kb.mindmap.load', { key: m.key })
+      .then((r) => {
+        if (!canvas) return;
+        if (!r || !r.ok || !r.root) {
+          canvas.innerHTML = '<div class="kb-mm-fail">脑图存档已失效（可能已被删除）</div>';
+          return;
+        }
+        const root = r.root;
+        _state.mmCollapsed.clear();
+        canvas.innerHTML = _mmTreeSvg(root, _state.mmCollapsed, _mmRenderOpts());
+        canvas._mmRoot = root;
+        _bindMindCanvas(canvas);
+      })
+      .catch(() => { if (canvas) canvas.innerHTML = '<div class="kb-mm-fail">脑图载入失败</div>'; });
+  }
+
   // 生成脑图 → 作为产物追加到**对话消息区**（kb-qa-messages），
   // 与问答流同区可见、可滚动，不藏在解析卡的折叠区。
   // 生成脑图 → 调本地 kb.mindmap（多级层级 JSON）→ 对话区渲染精致树形脑图
@@ -1487,7 +1558,7 @@
     body.className = 'kb-qa-msg-body kb-mm-msg';
     body.innerHTML = '<div class="kb-mm-msg-head">🧠 脑图预览</div>'
       + '<div class="kb-wb-mm-canvas" id="kb-wb-mm-canvas">'
-      + '<div class="kb-mm-loading">正在生成多级脑图（本地模型推理中，约 30–60 秒）…</div></div>';
+      + '<div class="kb-mm-loading">正在生成多级脑图（本地模型推理中，约 30–60 秒，复杂知识库最长约 2 分钟）…</div></div>';
     ai.appendChild(body);
     box.appendChild(ai);
     const canvas = body.querySelector('.kb-wb-mm-canvas');
@@ -1502,12 +1573,23 @@
       .then((res) => {
         _mmGenerating = false;
         if (!res || !res.root) throw new Error('empty mindmap');
+        if (res.source === 'degraded') {
+          canvas.innerHTML = _mmDegradedHtml(res.reason);
+          const retryBtn = canvas.querySelector('.kb-mm-retry-btn');
+          if (retryBtn) retryBtn.addEventListener('click', () => {
+            ai.remove();
+            _genMindmap();
+          });
+          return;
+        }
         _state.lastMind = res.root;
         _state.mmCollapsed.clear();
         _state.mmFocus = null;
         _state.mmSearchHits = new Set();
         canvas.innerHTML = _mmTreeSvg(res.root, _state.mmCollapsed, _mmRenderOpts());
+        canvas._mmRoot = res.root;
         _bindMindCanvas(canvas);
+        if (res.source === 'generated') _mmRecordToHistory(res.root);
       })
       .catch(() => {
         _mmGenerating = false;
@@ -1540,12 +1622,23 @@
       .then((res) => {
         btn.disabled = false;
         if (!res || !res.root) throw new Error('empty mindmap');
+        if (res.source === 'degraded') {
+          canvas.innerHTML = _mmDegradedHtml(res.reason);
+          const retryBtn = canvas.querySelector('.kb-mm-retry-btn');
+          if (retryBtn) retryBtn.addEventListener('click', () => {
+            holder.remove();
+            _genMindmapFromText(text, btn);
+          });
+          return;
+        }
         _state.lastMind = res.root;
         _state.mmCollapsed.clear();
         _state.mmFocus = null;
         _state.mmSearchHits = new Set();
         canvas.innerHTML = _mmTreeSvg(res.root, _state.mmCollapsed, _mmRenderOpts());
+        canvas._mmRoot = res.root;
         _bindMindCanvas(canvas);
+        if (res.source === 'generated') _mmRecordToHistory(res.root);
       })
       .catch(() => {
         btn.disabled = false;
@@ -1555,7 +1648,11 @@
 
   // 对话区脑图 = 缩略预览：点击 → 唤起弹窗（完整阅读/折叠/编辑/导出都在弹窗内）
   function _bindMindCanvas(canvas) {
-    canvas.addEventListener('click', () => _openMindPreview());
+    canvas.addEventListener('click', () => {
+      // 历史里可能有多张脑图：优先打开当前画布对应的快照树
+      if (canvas._mmRoot) _state.lastMind = canvas._mmRoot;
+      _openMindPreview();
+    });
   }
 
   // 折叠 / 展开一级分支（数据驱动重渲染）
@@ -1865,7 +1962,7 @@
     if (!window.cogseed || typeof window.cogseed.invoke !== 'function') return;
     _mmGenerating = true;
     const wrap = document.getElementById('kb-mm-overlay-wrap');
-    if (wrap) wrap.innerHTML = '<div class="kb-mm-fail" style="color:var(--kb-muted,#6E8578)">正在重新生成脑图（本地模型推理中，约 30–60 秒）…</div>';
+    if (wrap) wrap.innerHTML = '<div class="kb-mm-fail" style="color:var(--kb-muted,#6E8578)">正在重新生成脑图（本地模型推理中，约 30–60 秒，复杂知识库最长约 2 分钟）…</div>';
     window.cogseed.invoke('kb.mindmap', {
       dir: _state.spaceId ? null : (_state.currentLib || null),
       spaceId: _state.spaceId || null,
@@ -1874,6 +1971,17 @@
       .then((res) => {
         _mmGenerating = false;
         if (!res || !res.root) throw new Error('empty mindmap');
+        if (res.source === 'degraded') {
+          const wrap = document.getElementById('kb-mm-overlay-wrap');
+          if (wrap) {
+            wrap.innerHTML = _mmDegradedHtml(res.reason)
+              + '<div class="kb-mm-refresh-hint" style="color:var(--kb-muted,#6E8578);font-size:12px;margin-top:8px">原脑图已保留，未受影响</div>';
+            const retryBtn = wrap.querySelector('.kb-mm-retry-btn');
+            if (retryBtn) retryBtn.addEventListener('click', _mmRefreshMindmap);
+          }
+          if (typeof uiToast === 'function') uiToast('重新生成未完成，已保留原脑图', { variant: 'warning' });
+          return;
+        }
         _state.lastMind = res.root;
         _state.mmCollapsed.clear();
         _state.mmFocus = null;
@@ -1898,7 +2006,10 @@
       return;
     }
     window.cogseed.invoke('kb.mindmap.list').then((r) => {
-      const items = (r && Array.isArray(r.items) ? r.items : []).sort((a, b) => (b.savedAt || 0) - (a.savedAt || 0));
+      // 历史快照（key 含 '#'）只随会话历史还原，不混进手动存档列表
+      const items = (r && Array.isArray(r.items) ? r.items : [])
+        .filter((m) => !String(m.key || '').includes('#'))
+        .sort((a, b) => (b.savedAt || 0) - (a.savedAt || 0));
       if (!items.length) {
         menu.innerHTML = '<div class="kb-mm-open-item is-empty">还没有保存的脑图</div>';
         return;
@@ -2578,16 +2689,24 @@
     _clearQa();
     if (typeof uiToast === 'function') uiToast('已新建对话', { variant: 'info' });
   }
-  // 载入历史会话：恢复消息区 + 上下文
+  // 载入历史会话：恢复消息区 + 上下文（脑图消息按 kind 走快照读档渲染）
   function _qaLoadSession(id) {
     const s = _state.qaSessions.find((x) => x.id === id);
     if (!s) return;
     _state.qaSessionId = id;
-    _state.qaHistory = (s.msgs || []).map((m) => ({ role: m.role, content: m.content }));
+    _state.qaHistory = (s.msgs || []).map((m) => (
+      m && m.kind === 'mindmap'
+        ? { role: m.role, content: m.content, kind: 'mindmap', key: m.key, label: m.label, ts: m.ts }
+        : { role: m.role, content: m.content }
+    ));
     _clearQa();
     const box = document.getElementById('kb-qa-messages');
     if (!box) return;
     for (const m of _state.qaHistory) {
+      if (m.kind === 'mindmap') {
+        _appendMindmapMessage(box, m);
+        continue;
+      }
       const el = document.createElement('div');
       el.className = m.role === 'user' ? 'kb-qa-msg is-user' : 'kb-qa-msg is-ai';
       el.innerHTML = `<div class="kb-qa-msg-body">${_esc(m.content)}</div>`;
@@ -2631,8 +2750,17 @@
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
         const id = btn.dataset.histDel;
+        const gone = _state.qaSessions.find((x) => x.id === id);
         _state.qaSessions = _state.qaSessions.filter((x) => x.id !== id);
         if (_state.qaSessionId === id) { _state.qaSessionId = null; _state.qaHistory = []; _clearQa(); }
+        // 删除会话时同步清理其脑图快照存档（key 含 '#' 的条目）
+        if (gone && window.cogseed && typeof window.cogseed.invoke === 'function') {
+          (gone.msgs || []).forEach((m) => {
+            if (m && m.kind === 'mindmap' && m.key) {
+              window.cogseed.invoke('kb.mindmap.delete', { key: m.key }).catch(() => { /* ignore */ });
+            }
+          });
+        }
         _qaPersist();
         _qaOpenHistory(); // 刷新列表
       });
@@ -2718,7 +2846,7 @@
         _state.qaAttachments = [];
         _renderQaAttachments();
       }
-      const handle = window.cogseed.stream('kbqa.askStream', { question: q, space_id: _state.spaceId || null, k: 8, attach_paths: attachPaths, history: _state.qaHistory.slice(0, -1) }, (ev) => {
+      const handle = window.cogseed.stream('kbqa.askStream', { question: q, space_id: _state.spaceId || null, k: 8, attach_paths: attachPaths, history: _state.qaHistory.filter((m) => m.kind !== 'mindmap').slice(0, -1) }, (ev) => {
         if (!ev) return;
         if (ev.type === 'delta' && ev.text) {
           text += ev.text;

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -29637,6 +29637,12 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .kb-eco-tab .kb-sdot { width: 6px; height: 6px; border-radius: 50%; }
 .kb-eco-tab.is-ok .kb-sdot { background: var(--kb-green); }
 .kb-eco-tab.is-soon .kb-sdot { background: var(--color-line-strong); }
+.kb-eco-tab .kb-eco-tab-soon {
+  font-size: 10px; line-height: 1; padding: 2px 5px; border-radius: 7px;
+  background: var(--kb-hover); color: var(--kb-text3); font-weight: 500;
+}
+.kb-eco-tab.active .kb-eco-tab-soon { background: var(--kb-accent-weak); color: var(--kb-accent); }
+.kb-eco--compact .kb-eco-tab-soon { display: none; }
 .kb-eco-compact {
   flex: none; width: 28px; height: 28px; border-radius: var(--radius-2); display: grid; place-items: center;
   color: var(--kb-text3); border: 0; background: transparent; cursor: pointer; font-size: var(--font-size-4);
@@ -29650,6 +29656,15 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .kb-eco-body .kb-eco-pane { display: flex; flex: 1; min-width: 0; min-height: 0; }
 .kb-eco-body .kb-workbench[hidden],
 .kb-eco-body .kb-eco-pane[hidden] { display: none; }
+
+/* 「待开发」占位面板（发现等预留模块） */
+.kb-eco-coming {
+  flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 8px; padding: 24px; text-align: center;
+}
+.kb-eco-coming-ico { font-size: 30px; line-height: 1; opacity: .8; }
+.kb-eco-coming-title { font-size: 15px; font-weight: 600; color: var(--kb-text); }
+.kb-eco-coming-sub { max-width: 460px; font-size: 12px; line-height: 1.8; color: var(--kb-text2); white-space: pre-line; }
 
 /* 三栏工作台（aside | 分隔条 | mid | 分隔条 | right） */
 .kb-wb {

--- a/test/main/features/kb_mindmap.test.ts
+++ b/test/main/features/kb_mindmap.test.ts
@@ -26,6 +26,7 @@ import {
   saveMindmap,
   listMindmaps,
   loadMindmap,
+  deleteMindmap,
   mindKey,
 } from '../../../src/main/features/kb_mindmap';
 import { collectReadyDocLines } from '../../../src/main/features/kb_summary';
@@ -81,6 +82,7 @@ describe('kb_mindmap', () => {
     collectMock.mockReturnValue([]);
     const res = await kbMindmap('u1', { dir: 'lib' }, { complete: completeOk('{}') });
     expect(res.source).toBe('degraded');
+    expect(res.reason).toBe('empty');
     expect(res.root.label).toBe('知识库');
     expect(res.root.children).toEqual([]);
   });
@@ -90,6 +92,7 @@ describe('kb_mindmap', () => {
     const complete = vi.fn(async () => ({ ok: false, text: '', error: 'provider down' }));
     const res = await kbMindmap('u1', { dir: 'lib' }, { complete });
     expect(res.source).toBe('degraded');
+    expect(res.reason).toBe('model-failed');
   });
 
   it('parses the tree out of model text with code fences', () => {
@@ -116,6 +119,52 @@ describe('kb_mindmap', () => {
     const forced = await kbMindmap('u1', { dir: 'lib', force: true }, { complete });
     expect(forced.source).toBe('generated');
     expect(complete).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent duplicate requests into one LLM call (single-flight)', async () => {
+    collectMock.mockReturnValue(['## lib/a.pdf\nx']);
+    type CompleteRes = { ok: boolean; text: string; error: string };
+    let release!: (v: CompleteRes) => void;
+    const gate = new Promise<CompleteRes>((r) => { release = r; });
+    const complete = vi.fn(() => gate);
+    // 未 await 即发起第二次：应复用同一在途 Promise，不重复调 LLM
+    const p1 = kbMindmap('u1', { dir: 'lib' }, { complete });
+    const p2 = kbMindmap('u1', { dir: 'lib' }, { complete });
+    expect(complete).toHaveBeenCalledTimes(1);
+    release({ ok: true, text: SAMPLE, error: '' });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.source).toBe('generated');
+    expect(r2.source).toBe('generated');
+    expect(r2.root.children.length).toBe(2);
+    expect(complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('degrades on LLM timeout and caches the late-arriving success for instant retry', async () => {
+    vi.useFakeTimers();
+    try {
+      collectMock.mockReturnValue(['## lib/a.pdf\nx']);
+      type CompleteRes = { ok: boolean; text: string; error: string };
+      let release!: (v: CompleteRes) => void;
+      const gate = new Promise<CompleteRes>((r) => { release = r; });
+      const complete = vi.fn(() => gate);
+      const firstP = kbMindmap('u1', { dir: 'lib' }, { complete });
+      await vi.advanceTimersByTimeAsync(121_000); // 超过 120s 上限
+      const first = await firstP;
+      expect(first.source).toBe('degraded');
+      expect(first.reason).toBe('timeout');
+      expect(first.root).toEqual({ label: '知识库', children: [] });
+      // 迟到的成功结果到达 → 兜底写入缓存；随即重试（同指纹）应秒出且不再调 LLM
+      release({ ok: true, text: SAMPLE, error: '' });
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      const second = await kbMindmap('u1', { dir: 'lib' }, { complete });
+      expect(second.source).toBe('cached');
+      expect(second.root.label).toBe('软件工程与AI');
+      expect(second.root.children.length).toBe(2);
+      expect(complete).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -170,5 +219,14 @@ describe('kb_mindmap store', () => {
     // 简短短语 + source 备注要求
     expect(sys.systemPrompt).toContain('简短短语');
     expect(sys.systemPrompt).toContain('source');
+  });
+
+  it('deletes a saved mind map by key (returns false for missing keys)', () => {
+    const key = mindKey('sp-del');
+    saveMindmap(key, { label: '待删', children: [] });
+    expect(loadMindmap(key)?.label).toBe('待删');
+    expect(deleteMindmap(key)).toBe(true);
+    expect(loadMindmap(key)).toBeNull();
+    expect(deleteMindmap('space:nope')).toBe(false);
   });
 });


### PR DESCRIPTION
## Why
1. 知识库脑图生成在模型高峰期频繁被 45s 超时误杀,降级为单节点「知识库」且无任何提示——用户反复生成都得到同一个光杆节点(kb-mindmaps.json 中 space 脑图仅 1 节点)。
2. 生成的脑图只追加到对话区 DOM,不写入会话历史,刷新/切换会话后消失。
3. 「发现」模块展示内置伪造的市场示例数据(订阅数/MCP/Skills 假列表),误导用户以为功能已上线。

## What
- `kb_mindmap`:超时上限 45s→120s(覆盖模型排队+推理高峰);降级单节点附带 `reason: empty|timeout|model-failed`
- 同指纹 single-flight:并发点击/后台预热只发起一次 LLM 调用
- 超时后底层迟到成功结果兜底缓存(重试同指纹秒出)
- 新增 `kb.mindmap.delete` IPC,删除会话时清理其脑图快照
- 问答会话历史支持 `kind:'mindmap'` 条目:生成成功自动存快照并按 key 还原;脑图消息不参与多轮 LLM 上下文;手动存档列表过滤历史快照 key
- kb-eco:「发现」标记为待开发(灰点+角标),页面改为占位说明,移除伪造市场数据

## How verified
- `kb_mindmap.test.ts` 14/14 通过(新增 single-flight、超时+迟到缓存、delete 用例)
- `tsc --noEmit` exit 0;eslint 改动文件 exit 0;渲染层 JS `node --check` OK
- 本地 dev 实例重启验证:发现页显示待开发占位;脑图会话历史可还原

## Checklist
- [x] cogseed-open-source-audit diff vs origin/develop:**PASS_WITH_WARNINGS**(2 HIGH 为无关基线项:sherpa-onnx gitignored 本地资源、sbom 已知待补,已窄豁免;本次改动 0 命中)
- [x] 发版扫描清单:敏感词/内网 IP/个人信息/密钥 0 命中;gitleaks 25 处均在历史测试文件且不在本 PR;trufflehog 0 verified
- [x] 提交邮箱均 noreply(cx677)
- [x] Conventional Commits + `-s` 签名

关联:COGSEED 知识库脑图质量问题