### PR TITLE
fix(builtin-course-client): 删除硬编码默认平台地址 49.233.169.16

### DIFF
--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-aar/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-aar/scripts/runtime.js
@@ -15168,7 +15168,7 @@ function loadConfig(env = process.env) {
       `\u7F3A\u5C11\u5FC5\u9700\u73AF\u5883\u53D8\u91CF: ${missing.join(", ")}\u3002\u914D\u7F6E\u65B9\u6CD5\uFF1ACogseed MCP Hub \u7684 env \u6CE8\u5165\uFF0C\u6216\u672C\u5730\u5F00\u53D1\u8BBE EDUSEED_MOCK=1\u3002`
     );
   }
-  const serverUrl = (env.EDUSEED_SERVER_URL ?? "http://49.233.169.16").replace(/\/+$/, "");
+  const serverUrl = (env.EDUSEED_SERVER_URL ?? "").replace(/\/+$/, "");
   try {
     const u = new URL(serverUrl);
     const isLocal = ["localhost", "127.0.0.1", "::1"].includes(u.hostname);

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-review/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-review/scripts/runtime.js
@@ -15168,7 +15168,7 @@ function loadConfig(env = process.env) {
       `\u7F3A\u5C11\u5FC5\u9700\u73AF\u5883\u53D8\u91CF: ${missing.join(", ")}\u3002\u914D\u7F6E\u65B9\u6CD5\uFF1ACogseed MCP Hub \u7684 env \u6CE8\u5165\uFF0C\u6216\u672C\u5730\u5F00\u53D1\u8BBE EDUSEED_MOCK=1\u3002`
     );
   }
-  const serverUrl = (env.EDUSEED_SERVER_URL ?? "http://49.233.169.16").replace(/\/+$/, "");
+  const serverUrl = (env.EDUSEED_SERVER_URL ?? "").replace(/\/+$/, "");
   try {
     const u = new URL(serverUrl);
     const isLocal = ["localhost", "127.0.0.1", "::1"].includes(u.hostname);

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-submit/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-submit/scripts/runtime.js
@@ -15168,7 +15168,7 @@ function loadConfig(env = process.env) {
       `\u7F3A\u5C11\u5FC5\u9700\u73AF\u5883\u53D8\u91CF: ${missing.join(", ")}\u3002\u914D\u7F6E\u65B9\u6CD5\uFF1ACogseed MCP Hub \u7684 env \u6CE8\u5165\uFF0C\u6216\u672C\u5730\u5F00\u53D1\u8BBE EDUSEED_MOCK=1\u3002`
     );
   }
-  const serverUrl = (env.EDUSEED_SERVER_URL ?? "http://49.233.169.16").replace(/\/+$/, "");
+  const serverUrl = (env.EDUSEED_SERVER_URL ?? "").replace(/\/+$/, "");
   try {
     const u = new URL(serverUrl);
     const isLocal = ["localhost", "127.0.0.1", "::1"].includes(u.hostname);

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-teacher-publish/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-teacher-publish/scripts/runtime.js
@@ -15168,7 +15168,7 @@ function loadConfig(env = process.env) {
       `\u7F3A\u5C11\u5FC5\u9700\u73AF\u5883\u53D8\u91CF: ${missing.join(", ")}\u3002\u914D\u7F6E\u65B9\u6CD5\uFF1ACogseed MCP Hub \u7684 env \u6CE8\u5165\uFF0C\u6216\u672C\u5730\u5F00\u53D1\u8BBE EDUSEED_MOCK=1\u3002`
     );
   }
-  const serverUrl = (env.EDUSEED_SERVER_URL ?? "http://49.233.169.16").replace(/\/+$/, "");
+  const serverUrl = (env.EDUSEED_SERVER_URL ?? "").replace(/\/+$/, "");
   try {
     const u = new URL(serverUrl);
     const isLocal = ["localhost", "127.0.0.1", "::1"].includes(u.hostname);


### PR DESCRIPTION
## 背景
内置插件 runtime.js 的默认平台地址硬编码为已废弃的 `http://49.233.169.16`（平台已迁至 101.36.66.129）。任何未配置地址的安装会静默连接废弃 IP。

## 改动
- 4 份 runtime.js：删除默认地址（`EDUSEED_SERVER_URL` 本就必填，默认值是死代码）；未配置时得到明确报错；
- API Key v2 自带平台地址，正常激活流程不受影响；
- 内置资源门校验通过，清单哈希已重算。

## 关联
- 插件仓库 aix-course-elite20 与 nseap-mcp 的旧地址引用已同步清理。