### PR TITLE
feat(kb): 知识库文件点击查看原文（个人库/空间库 md·docx·pdf）

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,11 +62,12 @@ if (IS_PACKAGED_LAUNCH_SMOKE) {
 }
 
 // Register the KB file protocol BEFORE `app.whenReady()` — privileged
-// schemes can't be added after. `kb-file:///<relpath>` serves a single
-// file out of the current active user's `<uid>/cloud/contexts/`. Used by
-// the renderer's PDF iframe (Chromium's built-in PDFium handles `.pdf`
-// directly when served via a standard scheme). Other bytes types fall
-// back to `shell.openPath`.
+// schemes can't be added after. `kb-file://kb/<relpath>` serves a single
+// file out of the current active user's `<uid>/cloud/contexts/`;
+// `kb-file://space/<spaceId>/<relpath>` serves a space-library file from
+// that space's contexts dir. Used by the renderer's PDF iframe (Chromium's
+// built-in PDFium handles `.pdf` directly when served via a standard
+// scheme). Other bytes types fall back to `shell.openPath`.
 protocol.registerSchemesAsPrivileged([
   {
     scheme: 'kb-file',
@@ -186,6 +187,7 @@ import * as builtinMarketplaceStartup from './features/builtin_marketplace_start
 import * as builtinPackagesStartup from './features/builtin_packages_startup';
 import type { BuiltinMarketplaceSeedResult } from './features/builtin_marketplace';
 import * as chatAttachments from './features/chat_attachments';
+import * as spacesFeature from './features/spaces';
 import * as chatArtifacts from './features/chat_artifacts';
 import * as clientConfigFeature from './features/client_config';
 import * as connectorsFeature from './features/connectors';
@@ -918,14 +920,45 @@ function registerKbFileProtocol(): void {
   protocol.handle('kb-file', async (request) => {
     const reqUrl = request.url;
     try {
-      // URL shape on the wire: `kb-file://kb/<relpath>` — `kb` is a fixed
-      // fake host (see renderer `_encodeKbFileUrl`). Tolerate older /
-      // unusual normalisations (`kb-file://<seg>/...`, `kb-file:///…`) by
-      // extracting the pathname via `new URL`; standard-scheme URLs parse
-      // cleanly once a host is present.
+      // Two route shapes, dispatched by URL host:
+      //   kb-file://kb/<relpath>              — personal contexts file
+      //   kb-file://space/<spaceId>/<relpath> — space-library file
+      // The `kb` / `space` hosts are fixed fake hosts (see renderer
+      // `_encodeKbFileUrl`). Tolerate older / unusual normalisations
+      // (`kb-file://<seg>/...`, `kb-file:///…`) by extracting the pathname
+      // via `new URL`; standard-scheme URLs parse cleanly once a host is
+      // present.
       const uid = users.getActiveUserId();
-      const root = path.resolve(paths.userContextsDir(uid));
-      const resolved = resolveContainedProtocolFile(reqUrl, 'kb-file', root);
+      let root: string;
+      let resolveUrl = reqUrl;
+      let u: URL;
+      try { u = new URL(reqUrl); }
+      catch { return new Response('bad request', { status: 400 }); }
+      if (u.host.toLowerCase() === 'space') {
+        // spaceId is the first pathname segment; the remaining segments are
+        // the file's relative path inside the space contexts dir.
+        const segs = decodeURIComponent(u.pathname || '').replace(/^\/+/, '').split('/');
+        const spaceId = segs.shift() || '';
+        if (!spaceId || !storage.safeId(spaceId)) {
+          log.warn('kb-file/space: bad spaceId', { reqUrl });
+          return new Response('bad request', { status: 400 });
+        }
+        if (!segs.length) {
+          log.warn('kb-file/space: missing relpath', { reqUrl });
+          return new Response('bad request', { status: 400 });
+        }
+        if (!(await spacesFeature.spaceExists(uid, spaceId))) {
+          log.warn('kb-file/space: no such space', { reqUrl, spaceId });
+          return new Response('not found', { status: 404 });
+        }
+        root = path.resolve(paths.spaceContextsDir(uid, spaceId));
+        // Rebuild a clean `kb-file://kb/<rel>` so resolveContainedProtocolFile
+        // only sees the file-relative path (spaceId is consumed above).
+        resolveUrl = 'kb-file://kb/' + segs.map(encodeURIComponent).join('/');
+      } else {
+        root = path.resolve(paths.userContextsDir(uid));
+      }
+      const resolved = resolveContainedProtocolFile(resolveUrl, 'kb-file', root);
       if (resolved.ok === false) {
         log.warn('kb-file: rejected', { reqUrl, code: resolved.error });
         return new Response(resolved.error.replace('_', ' '), { status: resolved.status });

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -4278,18 +4278,21 @@ const invokeHandlers: Record<string, InvokeHandler> = {
   },
 
   // 打开知识库文件内容（点击文件查看）：个人库 relPath 或 空间库 spaceId+path。
-  // 文本直读；docx 转 Markdown；pdf 提取文本（分页）；其余返回不支持。
+  // 文本直读（md 渲染为 Markdown）；docx/xlsx/pptx 转排版化 HTML 预览；
+  // pdf 走 kb-file:// 原生 PDFium iframe（排版不失真），此处只校验返回路径。
   'kb.openFile': async ({ spaceId, path: relPath } = {}, ctx) => {
     const p = typeof relPath === 'string' ? relPath.trim() : '';
     if (!p) return { ok: false, error: 'missing path' };
     try {
       let abs: string;
       let display = p;
+      let spaceRoot: string | null = null;
       if (typeof spaceId === 'string' && spaceId) {
         // 空间库：路径在空间 contexts 目录下（防穿越）
         if (!safeId(spaceId)) return { ok: false, error: 'invalid spaceId' };
         const { spaceContextsDir } = await import('../paths');
         const root = path.resolve(spaceContextsDir(ctx.userId, spaceId));
+        spaceRoot = root;
         abs = path.resolve(root, p);
         if (abs !== root && !abs.startsWith(root + path.sep)) {
           return { ok: false, error: 'invalid path' };
@@ -4303,7 +4306,8 @@ const invokeHandlers: Record<string, InvokeHandler> = {
       }
       const ext = path.extname(abs).toLowerCase();
       const name = path.basename(abs);
-      if (['.md', '.markdown', '.txt', '.csv', '.tsv', '.json', '.yaml', '.yml', '.html', '.htm', '.log', '.py', '.ts', '.js', '.tsx', '.jsx', '.css', '.sql', '.sh', '.xml', '.toml', '.ini', '.conf', '.go', '.rs', '.java', '.c', '.cpp', '.rb', '.kt'].includes(ext)) {
+      const TEXT_EXTS = ['.md', '.markdown', '.txt', '.csv', '.tsv', '.json', '.yaml', '.yml', '.html', '.htm', '.log', '.py', '.ts', '.js', '.tsx', '.jsx', '.css', '.sql', '.sh', '.xml', '.toml', '.ini', '.conf', '.go', '.rs', '.java', '.c', '.cpp', '.rb', '.kt'];
+      if (TEXT_EXTS.includes(ext)) {
         const MAX = 2 * 1024 * 1024;
         const st = fs.statSync(abs);
         if (st.size > MAX) return { ok: false, error: 'too_large', size: st.size };
@@ -4313,16 +4317,38 @@ const invokeHandlers: Record<string, InvokeHandler> = {
         const kind = (ext === '.md' || ext === '.markdown') ? 'markdown' : 'text';
         return { ok: true, kind, name, path: display, content: text };
       }
-      if (ext === '.docx') {
-        const { docxBufferToMarkdown } = await import('../util/extract-docx');
-        const md = await docxBufferToMarkdown(fs.readFileSync(abs));
-        return { ok: true, kind: 'markdown', name, path: display, content: md };
+      const officeKind = _officePreviewKindForExt(ext);
+      if (officeKind) {
+        // docx / xlsx / pptx → 排版化 HTML 预览（与 produced.officePreviewHtml 同链）
+        const st = fs.statSync(abs);
+        const MAX_OFFICE = 50 * 1024 * 1024;
+        if (st.size > MAX_OFFICE) return { ok: false, error: 'too_large', size: st.size };
+        const cacheKey = `${abs}:${st.size}:${st.mtimeMs}:kb`;
+        const cached = _officePreviewCacheGet(cacheKey);
+        if (cached) return { ok: true, kind: 'office', officeKind: cached.kind, name, path: display, html: cached.html };
+        try {
+          const buf = fs.readFileSync(abs);
+          let fragment = '';
+          if (officeKind === 'word') {
+            const { docxBufferToHtml } = await import('../util/extract-docx');
+            fragment = await docxBufferToHtml(buf);
+          } else if (officeKind === 'spreadsheet') {
+            const { xlsxBufferToHtml } = await import('../util/extract-office');
+            fragment = xlsxBufferToHtml(buf);
+          } else {
+            const { pptxBufferToHtml } = await import('../util/extract-office');
+            fragment = pptxBufferToHtml(buf);
+          }
+          const html = _wrapOfficePreviewHtml(officeKind, name, fragment || '<p class="office-muted">（暂无可见内容）</p>');
+          _officePreviewCachePut(cacheKey, html, officeKind);
+          return { ok: true, kind: 'office', officeKind, name, path: display, html };
+        } catch (err) {
+          return { ok: false, error: String((err as Error).message || 'preview failed'), name };
+        }
       }
       if (ext === '.pdf') {
-        const { pdfBufferToPages } = await import('../util/extract-pdf');
-        const pages = await pdfBufferToPages(fs.readFileSync(abs));
-        const text = pages.map((pg, i) => `--- 第 ${i + 1} 页 ---\n${pg}`).join('\n\n');
-        return { ok: true, kind: 'text', name, path: display, content: text || '（PDF 未提取到文本，可能为扫描件）' };
+        // 原生 PDFium iframe 渲染（排版 100% 保持）；渲染层用 kb-file:// 构造 src
+        return { ok: true, kind: 'pdf', name, path: display, spaceId: spaceRoot ? (typeof spaceId === 'string' ? spaceId : undefined) : undefined };
       }
       return { ok: false, error: `暂不支持预览 ${ext} 格式`, kind: 'unsupported', name };
     } catch (err) {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -4277,6 +4277,63 @@ const invokeHandlers: Record<string, InvokeHandler> = {
     return shareCogseed.reviewCogseedMember(ctx.userId, spaceId, memberId as number, verdict === 'reject' ? 'reject' : 'approve');
   },
 
+  // 打开知识库文件内容（点击文件查看）：个人库 relPath 或 空间库 spaceId+path。
+  // 文本直读；docx 转 Markdown；pdf 提取文本（分页）；其余返回不支持。
+  'kb.openFile': async ({ spaceId, path: relPath } = {}, ctx) => {
+    const p = typeof relPath === 'string' ? relPath.trim() : '';
+    if (!p) return { ok: false, error: 'missing path' };
+    try {
+      let abs: string;
+      let display = p;
+      if (typeof spaceId === 'string' && spaceId) {
+        // 空间库：路径在空间 contexts 目录下（防穿越）
+        if (!safeId(spaceId)) return { ok: false, error: 'invalid spaceId' };
+        const { spaceContextsDir } = await import('../paths');
+        const root = path.resolve(spaceContextsDir(ctx.userId, spaceId));
+        abs = path.resolve(root, p);
+        if (abs !== root && !abs.startsWith(root + path.sep)) {
+          return { ok: false, error: 'invalid path' };
+        }
+      } else {
+        // 个人库：relPath（含库前缀）经 contexts 安全解析（越界/不存在会 throw）
+        abs = contexts.resolveContextFileAbsPath(p);
+      }
+      if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+        return { ok: false, error: 'file not found' };
+      }
+      const ext = path.extname(abs).toLowerCase();
+      const name = path.basename(abs);
+      if (['.md', '.markdown', '.txt', '.csv', '.tsv', '.json', '.yaml', '.yml', '.html', '.htm', '.log', '.py', '.ts', '.js', '.tsx', '.jsx', '.css', '.sql', '.sh', '.xml', '.toml', '.ini', '.conf', '.go', '.rs', '.java', '.c', '.cpp', '.rb', '.kt'].includes(ext)) {
+        const MAX = 2 * 1024 * 1024;
+        const st = fs.statSync(abs);
+        if (st.size > MAX) return { ok: false, error: 'too_large', size: st.size };
+        let text = fs.readFileSync(abs, 'utf8');
+        if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
+        // .md/.markdown 渲染为 Markdown（阅读视图），其余文本纯文本展示
+        const kind = (ext === '.md' || ext === '.markdown') ? 'markdown' : 'text';
+        return { ok: true, kind, name, path: display, content: text };
+      }
+      if (ext === '.docx') {
+        const { docxBufferToMarkdown } = await import('../util/extract-docx');
+        const md = await docxBufferToMarkdown(fs.readFileSync(abs));
+        return { ok: true, kind: 'markdown', name, path: display, content: md };
+      }
+      if (ext === '.pdf') {
+        const { pdfBufferToPages } = await import('../util/extract-pdf');
+        const pages = await pdfBufferToPages(fs.readFileSync(abs));
+        const text = pages.map((pg, i) => `--- 第 ${i + 1} 页 ---\n${pg}`).join('\n\n');
+        return { ok: true, kind: 'text', name, path: display, content: text || '（PDF 未提取到文本，可能为扫描件）' };
+      }
+      return { ok: false, error: `暂不支持预览 ${ext} 格式`, kind: 'unsupported', name };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      const msg = err instanceof Error ? err.message : String(err);
+      // contexts.resolveContextFileAbsPath 对缺失文件抛 "not found: <rel>"（ENOENT）
+      const error = code === 'ENOENT' || msg.includes('not found:') ? 'file not found' : msg;
+      return { ok: false, error };
+    }
+  },
+
   // 网页链接抓取导入：fetch URL → 提取标题+正文 → 存为 Markdown 到当前库（个人/共享）。
   'kb.importWebUrl': async ({ dir, spaceId, url } = {}, ctx) => {
     const u = String(url || '').trim();

--- a/src/renderer/modules/kb-workbench.js
+++ b/src/renderer/modules/kb-workbench.js
@@ -1115,7 +1115,7 @@
     _bindEmptyActions();
     list.querySelectorAll('[data-kb-space-file]').forEach((el) => {
       el.addEventListener('click', () => {
-        if (typeof uiToast === 'function') uiToast('空间库原文查看：后续版本支持', { variant: 'info' });
+        _openFileViewer({ spaceId: _state.spaceId, path: el.dataset.kbSpaceFile }, _state.spaceName || '');
       });
       // 共享库文件右键：置顶/编辑标签/重命名/成员权限▸/移动到/复制到/删除（对齐 ima）
       el.addEventListener('contextmenu', (e) => {
@@ -1190,10 +1190,198 @@
     if (el) el.textContent = String(n);
   }
 
+  // ── 文件查看（点击文件行 → 打开原文查看器）──
   function _openFile(relPath) {
-    // S2 接入 anchor-resolver 原文查看器；S1 先提示。
-    if (typeof uiToast === 'function') uiToast('原文查看器：S2 上线（anchor-resolver 已就绪）', { variant: 'info' });
-    _log.info('open file', relPath);
+    _openFileViewer({ path: relPath }, _state.currentLib || '');
+  }
+
+  // 打开原文查看 overlay：个人库传 {path}；共享空间库传 {spaceId, path}
+  async function _openFileViewer(payload, scopeName) {
+    const scope = scopeName || (payload && payload.spaceId ? payload.spaceId : '');
+    let overlay = _ensureFileViewerOverlay();
+    overlay.hidden = false;
+    _setFileViewerState(overlay, { loading: true, title: (payload && payload.path || '').split('/').pop() || '原文查看', scope });
+    try {
+      const res = await window.cogseed.invoke('kb.openFile', payload);
+      if (!res || !res.ok) {
+        const errMsg = (res && res.error) || '打开失败';
+        const friendly = errMsg === 'too_large'
+          ? `文件超过 2MB 预览上限（${res && res.size ? Math.round(res.size / 1024 / 1024) : ''}MB），暂不支持在线预览`
+          : errMsg === 'file not found' ? '文件不存在或已被移动'
+            : /暂不支持预览/.test(errMsg) ? errMsg : errMsg;
+        _setFileViewerState(overlay, {
+          error: friendly,
+          title: (payload && payload.path || '').split('/').pop() || '原文查看',
+          scope,
+        });
+        if (typeof uiToast === 'function') uiToast('无法预览该文件', { variant: 'warning' });
+        return;
+      }
+      _setFileViewerState(overlay, { content: res, title: res.name || (payload && payload.path || '').split('/').pop(), scope });
+    } catch (err) {
+      _setFileViewerState(overlay, {
+        error: (err && err.message) || String(err),
+        title: (payload && payload.path || '').split('/').pop() || '原文查看',
+        scope,
+      });
+      if (typeof uiToast === 'function') uiToast('打开文件失败', { variant: 'error' });
+    }
+  }
+
+  // 惰性构建查看 overlay（body 级，复用一次；样式自包含，风格对齐 anchored-source-view）
+  // 全 DOM 构建（createElement），不引入 raw-control 字面量（shared-ui guard 冻结计数）。
+  let _fileViewerOverlay = null;
+  function _ensureFileViewerOverlay() {
+    if (_fileViewerOverlay && document.getElementById('kb-file-viewer')) return _fileViewerOverlay;
+    const el = (tag, cls, text) => {
+      const n = document.createElement(tag);
+      if (cls) n.className = cls;
+      if (text != null) n.textContent = text;
+      return n;
+    };
+    const overlay = el('div', 'kb-fv-overlay');
+    overlay.id = 'kb-file-viewer';
+    overlay.hidden = true;
+
+    const dialog = el('section', 'kb-fv-dialog');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    const head = el('header', 'kb-fv-head');
+    const headMain = el('div', 'kb-fv-head-main');
+    const title = el('span', 'kb-fv-title', '原文查看');
+    title.id = 'kb-fv-title';
+    const scope = el('span', 'kb-fv-scope');
+    scope.id = 'kb-fv-scope';
+    headMain.append(title, scope);
+    const headActions = el('div', 'kb-fv-head-actions');
+    const readerBtn = el('button', 'kb-fv-btn', '⇱ 阅读模式');
+    readerBtn.type = 'button';
+    readerBtn.id = 'kb-fv-reader';
+    readerBtn.title = '切换阅读宽度';
+    const closeBtn = el('button', 'kb-fv-close', '✕');
+    closeBtn.type = 'button';
+    closeBtn.id = 'kb-fv-close';
+    closeBtn.title = '关闭（Esc）';
+    headActions.append(readerBtn, closeBtn);
+    head.append(headMain, headActions);
+
+    const body = el('div', 'kb-fv-body');
+    const loading = el('div', 'kb-fv-loading', '正在读取文件…');
+    loading.id = 'kb-fv-loading';
+    loading.hidden = true;
+    const errorEl = el('div', 'kb-fv-error');
+    errorEl.id = 'kb-fv-error';
+    errorEl.hidden = true;
+    const textEl = el('pre', 'kb-fv-text');
+    textEl.id = 'kb-fv-text';
+    textEl.hidden = true;
+    const mdEl = el('div', 'kb-fv-md');
+    mdEl.id = 'kb-fv-md';
+    mdEl.hidden = true;
+    body.append(loading, errorEl, textEl, mdEl);
+
+    dialog.append(head, body);
+    overlay.appendChild(dialog);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.hidden = true; });
+    document.body.appendChild(overlay);
+    closeBtn.addEventListener('click', () => { overlay.hidden = true; });
+    readerBtn.addEventListener('click', () => {
+      const isReader = dialog.classList.toggle('kb-fv-dialog--reader');
+      readerBtn.textContent = isReader ? '⇱ 返回' : '⇱ 阅读模式';
+    });
+    // Esc 关闭
+    overlay.addEventListener('keydown', (e) => { if (e.key === 'Escape') overlay.hidden = true; });
+    overlay.tabIndex = -1;
+    _fileViewerOverlay = overlay;
+    _injectFileViewerStyle();
+    return overlay;
+  }
+
+  function _setFileViewerState(overlay, st) {
+    const loading = overlay.querySelector('#kb-fv-loading');
+    const errorEl = overlay.querySelector('#kb-fv-error');
+    const textEl = overlay.querySelector('#kb-fv-text');
+    const mdEl = overlay.querySelector('#kb-fv-md');
+    loading.hidden = !st.loading;
+    errorEl.hidden = true; errorEl.textContent = '';
+    textEl.hidden = true; textEl.textContent = '';
+    mdEl.hidden = true; mdEl.innerHTML = '';
+    if (st.title) overlay.querySelector('#kb-fv-title').textContent = st.title;
+    const scopeEl = overlay.querySelector('#kb-fv-scope');
+    scopeEl.textContent = st.scope ? `来自「${st.scope}」` : '';
+    scopeEl.hidden = !st.scope;
+    overlay.querySelector('#kb-fv-reader').textContent = '⇱ 阅读模式';
+    overlay.querySelector('.kb-fv-dialog')?.classList.remove('kb-fv-dialog--reader');
+    if (st.error) {
+      errorEl.hidden = false;
+      errorEl.textContent = String(st.error);
+      return;
+    }
+    const c = st.content;
+    if (!c || !c.content) {
+      errorEl.hidden = false;
+      errorEl.textContent = '文件内容为空';
+      return;
+    }
+    if (c.kind === 'markdown' && typeof renderMarkdown === 'function') {
+      mdEl.hidden = false;
+      mdEl.innerHTML = `<div class="markdown-body kb-fv-markdown">${renderMarkdown(String(c.content))}</div>`;
+    } else {
+      textEl.hidden = false;
+      textEl.textContent = String(c.content);
+    }
+    overlay.focus();
+  }
+
+  let _fvStyleInjected = false;
+  function _injectFileViewerStyle() {
+    if (_fvStyleInjected || document.getElementById('kb-file-viewer-style')) return;
+    _fvStyleInjected = true;
+    const style = document.createElement('style');
+    style.id = 'kb-file-viewer-style';
+    style.textContent = `
+      .kb-fv-overlay {
+        position: fixed; inset: 0; z-index: 10002; background: rgba(15, 23, 42, .5);
+        display: flex; align-items: center; justify-content: center; padding: 24px;
+      }
+      .kb-fv-overlay[hidden] { display: none; }
+      .kb-fv-dialog {
+        background: var(--surface, #fff); color: var(--text, #1f2329);
+        width: min(860px, 96vw); max-height: 88vh; border-radius: 12px;
+        display: flex; flex-direction: column; overflow: hidden;
+        box-shadow: 0 16px 48px rgba(0,0,0,.28); outline: none;
+      }
+      .kb-fv-dialog--reader { width: min(1160px, 98vw); max-height: 94vh; }
+      .kb-fv-head {
+        display: flex; align-items: center; justify-content: space-between; gap: 12px;
+        padding: 12px 18px; border-bottom: 1px solid rgba(128,128,128,.22);
+        background: linear-gradient(180deg, rgba(14,159,110,.05), transparent);
+      }
+      .kb-fv-head-main { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
+      .kb-fv-title { font-weight: 650; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .kb-fv-scope { font-size: 12px; color: #0E9F6E; opacity: .85; white-space: nowrap; }
+      .kb-fv-head-actions { display: flex; align-items: center; gap: 6px; flex: none; }
+      .kb-fv-btn, .kb-fv-close {
+        border: 1px solid rgba(14,159,110,.35); background: transparent; color: #0E9F6E;
+        font-size: 12px; padding: 4px 12px; border-radius: 8px; cursor: pointer;
+      }
+      .kb-fv-btn:hover { background: #E2F5EC; }
+      .kb-fv-close { border-color: transparent; font-size: 16px; padding: 2px 8px; color: #888; }
+      .kb-fv-close:hover { background: rgba(128,128,128,.14); color: inherit; }
+      .kb-fv-body { overflow: auto; padding: 20px 24px; flex: 1; min-height: 120px; }
+      .kb-fv-loading { color: #0E9F6E; font-size: 13px; }
+      .kb-fv-error { color: #c0392b; font-size: 13px; line-height: 1.7; white-space: pre-wrap; }
+      .kb-fv-text {
+        white-space: pre-wrap; word-break: break-word; margin: 0;
+        font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+        font-size: 13px; line-height: 1.7; color: inherit;
+      }
+      .kb-fv-markdown { font-size: 14px; line-height: 1.8; }
+      .kb-fv-dialog--reader .kb-fv-body { padding: 32px 56px; }
+      .kb-fv-dialog--reader .kb-fv-markdown { font-size: 16px; }
+      .kb-fv-dialog--reader .kb-fv-text { font-size: 15px; font-family: inherit; }
+    `;
+    document.head.appendChild(style);
   }
 
   // 问答区提示：无消息时显示「基于某库提问」引导

--- a/src/renderer/modules/kb-workbench.js
+++ b/src/renderer/modules/kb-workbench.js
@@ -1199,7 +1199,11 @@
   async function _openFileViewer(payload, scopeName) {
     const scope = scopeName || (payload && payload.spaceId ? payload.spaceId : '');
     let overlay = _ensureFileViewerOverlay();
+    // 打开时恢复上次的窗口尺寸/位置（无记忆则 flex 居中）
+    const dialog = overlay.querySelector('.kb-fv-dialog');
+    if (dialog) _fvApplyWindowRect(dialog);
     overlay.hidden = false;
+    _fvResetZoom(dialog);
     _setFileViewerState(overlay, { loading: true, title: (payload && payload.path || '').split('/').pop() || '原文查看', scope });
     try {
       const res = await window.cogseed.invoke('kb.openFile', payload);
@@ -1255,6 +1259,16 @@
     scope.id = 'kb-fv-scope';
     headMain.append(title, scope);
     const headActions = el('div', 'kb-fv-head-actions');
+    // 缩放控件：− / 百分比(可点重置) / ＋
+    const zoomOutBtn = el('button', 'kb-fv-btn kb-fv-zoom-btn', '−');
+    zoomOutBtn.type = 'button';
+    zoomOutBtn.title = '缩小';
+    const zoomLabel = el('button', 'kb-fv-zoom-label', '100%');
+    zoomLabel.type = 'button';
+    zoomLabel.title = '重置缩放（点击回到 100%）';
+    const zoomInBtn = el('button', 'kb-fv-btn kb-fv-zoom-btn', '＋');
+    zoomInBtn.type = 'button';
+    zoomInBtn.title = '放大';
     const readerBtn = el('button', 'kb-fv-btn', '⇱ 阅读模式');
     readerBtn.type = 'button';
     readerBtn.id = 'kb-fv-reader';
@@ -1263,7 +1277,7 @@
     closeBtn.type = 'button';
     closeBtn.id = 'kb-fv-close';
     closeBtn.title = '关闭（Esc）';
-    headActions.append(readerBtn, closeBtn);
+    headActions.append(zoomOutBtn, zoomLabel, zoomInBtn, readerBtn, closeBtn);
     head.append(headMain, headActions);
 
     const body = el('div', 'kb-fv-body');
@@ -1281,7 +1295,10 @@
     mdEl.hidden = true;
     body.append(loading, errorEl, textEl, mdEl);
 
-    dialog.append(head, body);
+    const resizeHandle = el('div', 'kb-fv-resize');
+    resizeHandle.title = '拖动调整窗口大小';
+
+    dialog.append(head, body, resizeHandle);
     overlay.appendChild(dialog);
     overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.hidden = true; });
     document.body.appendChild(overlay);
@@ -1289,13 +1306,161 @@
     readerBtn.addEventListener('click', () => {
       const isReader = dialog.classList.toggle('kb-fv-dialog--reader');
       readerBtn.textContent = isReader ? '⇱ 返回' : '⇱ 阅读模式';
+      _fvSaveWindowRect();
     });
     // Esc 关闭
     overlay.addEventListener('keydown', (e) => { if (e.key === 'Escape') overlay.hidden = true; });
     overlay.tabIndex = -1;
+    zoomOutBtn.addEventListener('click', () => _fvSetZoom(dialog, (_fvZoom - 0.1)));
+    zoomInBtn.addEventListener('click', () => _fvSetZoom(dialog, (_fvZoom + 0.1)));
+    zoomLabel.addEventListener('click', () => _fvSetZoom(dialog, 1));
+    // Ctrl/Cmd + 滚轮 缩放内容（pdf 内部滚轮由 PDFium 自行处理，不劫持）
+    body.addEventListener('wheel', (e) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+      e.preventDefault();
+      _fvSetZoom(dialog, _fvZoom + (e.deltaY < 0 ? 0.1 : -0.1));
+    }, { passive: false });
+    _fvBindTitleDrag(dialog, head);
+    _fvBindResize(dialog, resizeHandle);
     _fileViewerOverlay = overlay;
     _injectFileViewerStyle();
     return overlay;
+  }
+
+  // ── 预览窗交互：标题拖拽移动 / 右下角调整大小（尺寸与位置记忆） ──
+  const _FV_RECT_KEY = 'cogseed.kb-file-viewer.rect';
+  function _fvClampRect(dialog) {
+    const vw = window.innerWidth; const vh = window.innerHeight;
+    const w = Math.min(Math.max(dialog.offsetWidth, 420), vw - 24);
+    const h = Math.min(Math.max(dialog.offsetHeight, 280), vh - 24);
+    dialog.style.width = w + 'px';
+    dialog.style.height = h + 'px';
+    const r = dialog.getBoundingClientRect();
+    dialog.style.left = Math.max(0, Math.min(r.left, vw - w)) + 'px';
+    dialog.style.top = Math.max(0, Math.min(r.top, vh - h)) + 'px';
+  }
+  function _fvAbsolute(dialog) {
+    // 脱离 flex 居中流，改为 overlay 内的绝对定位（记忆 x/y 时用）
+    if (dialog.style.position === 'absolute') return;
+    const r = dialog.getBoundingClientRect();
+    dialog.style.position = 'absolute';
+    dialog.style.margin = '0';
+    dialog.style.left = Math.max(0, r.left) + 'px';
+    dialog.style.top = Math.max(0, r.top) + 'px';
+  }
+  function _fvApplyWindowRect(dialog) {
+    try {
+      const saved = JSON.parse(localStorage.getItem(_FV_RECT_KEY) || 'null');
+      if (!saved || !(saved.w && saved.h)) return; // 无记忆 → flex 居中默认
+      dialog.style.position = 'absolute';
+      dialog.style.margin = '0';
+      dialog.style.width = Math.min(Math.max(Number(saved.w), 420), window.innerWidth - 24) + 'px';
+      dialog.style.height = Math.min(Math.max(Number(saved.h), 280), window.innerHeight - 24) + 'px';
+      if (typeof saved.x === 'number' && typeof saved.y === 'number') {
+        const w = dialog.offsetWidth; const h = dialog.offsetHeight;
+        dialog.style.left = Math.max(0, Math.min(saved.x, window.innerWidth - w)) + 'px';
+        dialog.style.top = Math.max(0, Math.min(saved.y, window.innerHeight - h)) + 'px';
+      } else {
+        dialog.style.left = Math.round((window.innerWidth - dialog.offsetWidth) / 2) + 'px';
+        dialog.style.top = Math.round((window.innerHeight - dialog.offsetHeight) / 2) + 'px';
+      }
+    } catch { /* localStorage 不可用：保持居中 */ }
+  }
+  function _fvSaveWindowRect() {
+    const overlay = document.getElementById('kb-file-viewer');
+    if (!overlay || overlay.hidden) return;
+    const dialog = overlay.querySelector('.kb-fv-dialog');
+    if (!dialog) return;
+    try {
+      const r = dialog.getBoundingClientRect();
+      localStorage.setItem(_FV_RECT_KEY, JSON.stringify({
+        w: Math.round(r.width), h: Math.round(r.height),
+        x: Math.round(r.left), y: Math.round(r.top),
+      }));
+    } catch { /* ignore */ }
+  }
+  function _fvBindTitleDrag(dialog, bar) {
+    if (bar.dataset.fvDragBound) return;
+    bar.dataset.fvDragBound = '1';
+    let sx = 0; let sy = 0; let ox = 0; let oy = 0;
+    bar.addEventListener('mousedown', (e) => {
+      if (e.target.closest('button,input,select,textarea')) return;
+      e.preventDefault();
+      _fvAbsolute(dialog);
+      sx = e.clientX; sy = e.clientY;
+      const r = dialog.getBoundingClientRect();
+      ox = r.left; oy = r.top;
+      const onMove = (ev) => {
+        const w = dialog.offsetWidth; const h = dialog.offsetHeight;
+        dialog.style.left = Math.max(0, Math.min(window.innerWidth - w, ox + (ev.clientX - sx))) + 'px';
+        dialog.style.top = Math.max(0, Math.min(window.innerHeight - h, oy + (ev.clientY - sy))) + 'px';
+      };
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+        _fvSaveWindowRect();
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    });
+  }
+  function _fvBindResize(dialog, handle) {
+    if (handle.dataset.fvResizeBound) return;
+    handle.dataset.fvResizeBound = '1';
+    let sx = 0; let sy = 0; let sw = 0; let sh = 0;
+    handle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      _fvAbsolute(dialog);
+      sx = e.clientX; sy = e.clientY;
+      sw = dialog.offsetWidth; sh = dialog.offsetHeight;
+      document.body.classList.add('kb-fv-resizing');
+      const onMove = (ev) => {
+        const w = Math.min(Math.max(sw + (ev.clientX - sx), 420), window.innerWidth - 24);
+        const h = Math.min(Math.max(sh + (ev.clientY - sy), 280), window.innerHeight - 24);
+        dialog.style.width = w + 'px';
+        dialog.style.height = h + 'px';
+      };
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+        document.body.classList.remove('kb-fv-resizing');
+        _fvSaveWindowRect();
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    });
+  }
+
+  // ── 内容缩放（md/text 走容器 zoom；office 走 iframe 文档 zoom；pdf 走 URL zoom 重载） ──
+  let _fvZoom = 1;
+  let _fvCur = null; // { mode: 'md'|'text'|'office'|'pdf', el?, src? }
+  function _fvResetZoom(dialog) {
+    _fvZoom = 1;
+    _fvRenderZoom(dialog);
+  }
+  function _fvSetZoom(dialog, z) {
+    _fvZoom = Math.min(2.5, Math.max(0.6, Math.round((z || 1) * 10) / 10));
+    _fvRenderZoom(dialog);
+  }
+  function _fvRenderZoom(dialog) {
+    const label = dialog.querySelector('.kb-fv-zoom-label');
+    if (label) label.textContent = Math.round(_fvZoom * 100) + '%';
+    const cur = _fvCur;
+    if (!cur) return;
+    if (cur.mode === 'office' && cur.el && cur.el.contentDocument && cur.el.contentDocument.documentElement) {
+      // office blob iframe 已开 allow-same-origin：直接缩放其内部文档
+      cur.el.contentDocument.documentElement.style.zoom = String(_fvZoom);
+    } else if (cur.mode === 'pdf' && cur.el) {
+      // PDFium 无外部 zoom API：仅缩放值变化时重载 iframe src 带 zoom 参数
+      const pct = Math.round(_fvZoom * 100);
+      if (cur.lastZoom === pct) return;
+      cur.lastZoom = pct;
+      const base = String(cur.src || '').split('#')[0];
+      cur.el.src = `${base}#toolbar=1&navpanes=0&zoom=${pct}`;
+    } else if (cur.el) {
+      cur.el.style.zoom = String(_fvZoom);
+    }
   }
 
   function _setFileViewerState(overlay, st) {
@@ -1311,6 +1476,7 @@
       try { URL.revokeObjectURL(_fvOfficeBlobUrl); } catch (_) { /* ignore */ }
       _fvOfficeBlobUrl = null;
     }
+    _fvCur = null; // 内容视图变化：失效上一文件的缩放目标（error/loading 也走这里）
     loading.hidden = !st.loading;
     errorEl.hidden = true; errorEl.textContent = '';
     textEl.hidden = true; textEl.textContent = '';
@@ -1336,9 +1502,11 @@
       mdEl.hidden = false;
       const bodyMd = String(c.content || '');
       mdEl.innerHTML = `<div class="markdown-body kb-fv-markdown">${typeof renderMarkdown === 'function' ? renderMarkdown(bodyMd) : _esc(bodyMd)}</div>`;
+      _fvCur = { mode: 'md', el: mdEl };
     } else if (c.kind === 'text') {
       textEl.hidden = false;
       textEl.textContent = String(c.content || '');
+      _fvCur = { mode: 'text', el: textEl };
     } else if (c.kind === 'pdf') {
       // 原生 PDFium iframe（排版 100% 保持）：个人库 kb-file://kb/<rel>；
       // 空间库 kb-file://space/<spaceId>/<rel>（主进程已注册空间路由）
@@ -1354,17 +1522,26 @@
       frame.title = String(c.name || rel);
       body.appendChild(frame);
       body.classList.add('kb-fv-body--frame');
+      _fvCur = { mode: 'pdf', el: frame, src, lastZoom: 100 };
     } else if (c.kind === 'office') {
-      // docx/xlsx/pptx → 排版化 HTML 预览（主进程已包裹样式），沙箱 iframe
+      // docx/xlsx/pptx → 排版化 HTML 预览（主进程已包裹样式）。
+      // sandbox 保持无脚本；allow-same-origin 让父页可对内部文档做 CSS zoom 缩放
       const officeHtml = String(c.html || '');
       _fvOfficeBlobUrl = URL.createObjectURL(new Blob([officeHtml], { type: 'text/html;charset=utf-8' }));
       const frame = document.createElement('iframe');
       frame.className = 'kb-fv-frame kb-fv-frame--office';
-      frame.setAttribute('sandbox', '');
+      frame.setAttribute('sandbox', 'allow-same-origin');
       frame.src = _fvOfficeBlobUrl;
       frame.title = String(c.name || c.path || '');
       body.appendChild(frame);
       body.classList.add('kb-fv-body--frame');
+      _fvCur = { mode: 'office', el: frame, src: _fvOfficeBlobUrl };
+      // iframe 就绪后再应用当前缩放（加载完成前 contentDocument 为 null）
+      frame.addEventListener('load', () => {
+        if (_fvCur && _fvCur.el === frame && _fvZoom !== 1) {
+          try { frame.contentDocument.documentElement.style.zoom = String(_fvZoom); } catch (_) { /* ignore */ }
+        }
+      });
     } else {
       errorEl.hidden = false;
       errorEl.textContent = '暂不支持预览该文件';
@@ -1390,24 +1567,40 @@
         width: min(860px, 96vw); max-height: 88vh; border-radius: 12px;
         display: flex; flex-direction: column; overflow: hidden;
         box-shadow: 0 16px 48px rgba(0,0,0,.28); outline: none;
+        min-width: 420px; min-height: 280px;
       }
       .kb-fv-dialog--reader { width: min(1160px, 98vw); max-height: 94vh; }
       .kb-fv-head {
         display: flex; align-items: center; justify-content: space-between; gap: 12px;
-        padding: 12px 18px; border-bottom: 1px solid rgba(128,128,128,.22);
+        padding: 10px 14px; border-bottom: 1px solid rgba(128,128,128,.22);
         background: linear-gradient(180deg, rgba(14,159,110,.05), transparent);
+        cursor: move; user-select: none;
       }
       .kb-fv-head-main { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
       .kb-fv-title { font-weight: 650; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
       .kb-fv-scope { font-size: 12px; color: #0E9F6E; opacity: .85; white-space: nowrap; }
-      .kb-fv-head-actions { display: flex; align-items: center; gap: 6px; flex: none; }
+      .kb-fv-head-actions { display: flex; align-items: center; gap: 5px; flex: none; }
       .kb-fv-btn, .kb-fv-close {
         border: 1px solid rgba(14,159,110,.35); background: transparent; color: #0E9F6E;
-        font-size: 12px; padding: 4px 12px; border-radius: 8px; cursor: pointer;
+        font-size: 12px; padding: 3px 10px; border-radius: 8px; cursor: pointer;
       }
       .kb-fv-btn:hover { background: #E2F5EC; }
-      .kb-fv-close { border-color: transparent; font-size: 16px; padding: 2px 8px; color: #888; }
+      .kb-fv-zoom-btn { padding: 3px 8px; font-size: 13px; }
+      .kb-fv-zoom-label { min-width: 54px; text-align: center; }
+      .kb-fv-close { border-color: transparent; font-size: 16px; padding: 1px 7px; color: #888; }
       .kb-fv-close:hover { background: rgba(128,128,128,.14); color: inherit; }
+      .kb-fv-resize {
+        position: absolute; right: 0; bottom: 0;
+        width: 18px; height: 18px; cursor: nwse-resize; z-index: 30;
+      }
+      .kb-fv-resize::after {
+        content: ''; position: absolute; right: 5px; bottom: 5px;
+        width: 7px; height: 7px;
+        border-right: 2px solid rgba(128,128,128,.55);
+        border-bottom: 2px solid rgba(128,128,128,.55);
+      }
+      .kb-fv-resize:hover::after { border-color: #0E9F6E; }
+      body.kb-fv-resizing, body.kb-fv-resizing * { cursor: nwse-resize !important; user-select: none; }
       .kb-fv-body { overflow: auto; padding: 20px 24px; flex: 1; min-height: 120px; }
       .kb-fv-loading { color: #0E9F6E; font-size: 13px; }
       .kb-fv-error { color: #c0392b; font-size: 13px; line-height: 1.7; white-space: pre-wrap; }

--- a/src/renderer/modules/kb-workbench.js
+++ b/src/renderer/modules/kb-workbench.js
@@ -1231,6 +1231,7 @@
   // 惰性构建查看 overlay（body 级，复用一次；样式自包含，风格对齐 anchored-source-view）
   // 全 DOM 构建（createElement），不引入 raw-control 字面量（shared-ui guard 冻结计数）。
   let _fileViewerOverlay = null;
+  let _fvOfficeBlobUrl = null; // office HTML 预览 blob URL（下次打开前 revoke）
   function _ensureFileViewerOverlay() {
     if (_fileViewerOverlay && document.getElementById('kb-file-viewer')) return _fileViewerOverlay;
     const el = (tag, cls, text) => {
@@ -1302,6 +1303,14 @@
     const errorEl = overlay.querySelector('#kb-fv-error');
     const textEl = overlay.querySelector('#kb-fv-text');
     const mdEl = overlay.querySelector('#kb-fv-md');
+    const body = overlay.querySelector('.kb-fv-body');
+    // 清理上一个文件的嵌入 iframe（pdf / office html），释放 blob URL
+    body.querySelectorAll('.kb-fv-frame').forEach((f) => f.remove());
+    body.classList.remove('kb-fv-body--frame');
+    if (_fvOfficeBlobUrl) {
+      try { URL.revokeObjectURL(_fvOfficeBlobUrl); } catch (_) { /* ignore */ }
+      _fvOfficeBlobUrl = null;
+    }
     loading.hidden = !st.loading;
     errorEl.hidden = true; errorEl.textContent = '';
     textEl.hidden = true; textEl.textContent = '';
@@ -1318,17 +1327,48 @@
       return;
     }
     const c = st.content;
-    if (!c || !c.content) {
+    if (!c || !c.kind) {
       errorEl.hidden = false;
       errorEl.textContent = '文件内容为空';
       return;
     }
-    if (c.kind === 'markdown' && typeof renderMarkdown === 'function') {
+    if (c.kind === 'markdown') {
       mdEl.hidden = false;
-      mdEl.innerHTML = `<div class="markdown-body kb-fv-markdown">${renderMarkdown(String(c.content))}</div>`;
-    } else {
+      const bodyMd = String(c.content || '');
+      mdEl.innerHTML = `<div class="markdown-body kb-fv-markdown">${typeof renderMarkdown === 'function' ? renderMarkdown(bodyMd) : _esc(bodyMd)}</div>`;
+    } else if (c.kind === 'text') {
       textEl.hidden = false;
-      textEl.textContent = String(c.content);
+      textEl.textContent = String(c.content || '');
+    } else if (c.kind === 'pdf') {
+      // 原生 PDFium iframe（排版 100% 保持）：个人库 kb-file://kb/<rel>；
+      // 空间库 kb-file://space/<spaceId>/<rel>（主进程已注册空间路由）
+      const rel = String(c.path || '');
+      const sid = c.spaceId ? String(c.spaceId) : '';
+      const enc = (s) => String(s).split('/').map(encodeURIComponent).join('/');
+      const src = sid
+        ? `kb-file://space/${encodeURIComponent(sid)}/${enc(rel)}`
+        : `kb-file://kb/${enc(rel)}`;
+      const frame = document.createElement('iframe');
+      frame.className = 'kb-fv-frame kb-fv-frame--pdf';
+      frame.src = `${src}#toolbar=1&navpanes=0`;
+      frame.title = String(c.name || rel);
+      body.appendChild(frame);
+      body.classList.add('kb-fv-body--frame');
+    } else if (c.kind === 'office') {
+      // docx/xlsx/pptx → 排版化 HTML 预览（主进程已包裹样式），沙箱 iframe
+      const officeHtml = String(c.html || '');
+      _fvOfficeBlobUrl = URL.createObjectURL(new Blob([officeHtml], { type: 'text/html;charset=utf-8' }));
+      const frame = document.createElement('iframe');
+      frame.className = 'kb-fv-frame kb-fv-frame--office';
+      frame.setAttribute('sandbox', '');
+      frame.src = _fvOfficeBlobUrl;
+      frame.title = String(c.name || c.path || '');
+      body.appendChild(frame);
+      body.classList.add('kb-fv-body--frame');
+    } else {
+      errorEl.hidden = false;
+      errorEl.textContent = '暂不支持预览该文件';
+      return;
     }
     overlay.focus();
   }
@@ -1380,6 +1420,14 @@
       .kb-fv-dialog--reader .kb-fv-body { padding: 32px 56px; }
       .kb-fv-dialog--reader .kb-fv-markdown { font-size: 16px; }
       .kb-fv-dialog--reader .kb-fv-text { font-size: 15px; font-family: inherit; }
+      /* pdf / office 嵌入 iframe：占满正文区，独立滚动，正文区本身不滚 */
+      .kb-fv-body--frame { padding: 0; overflow: hidden; display: flex; flex-direction: column; }
+      .kb-fv-body--frame .kb-fv-frame {
+        flex: 1; width: 100%; border: 0; min-height: 0;
+        background: #fff; border-radius: 0 0 12px 12px;
+      }
+      .kb-fv-dialog--reader .kb-fv-body--frame { padding: 0; }
+      .kb-fv-frame--office { background: #eef2f7; }
     `;
     document.head.appendChild(style);
   }

--- a/test/main/ipc/kb-open-file.test.ts
+++ b/test/main/ipc/kb-open-file.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { trustedIpcSender } from '../../helpers/trusted-ipc-sender';
 import { makeMinimalDocx } from '../../fixtures/make-minimal-docx';
 import { makeMinimalPdf } from '../../fixtures/make-minimal-pdf';
+import { makeMinimalXlsx } from '../../fixtures/make-minimal-office';
 
 vi.mock('electron', () => ({
   app: { isPackaged: false },
@@ -99,22 +100,46 @@ describe('kb.openFile › 个人库文本/文档预览', () => {
     expect(res.content).toBe('纯文本');
   });
 
-  it('docx 转 markdown', async () => {
+  it('docx 转排版化 HTML 预览', async () => {
     const docx = makeMinimalDocx({ heading: 'Doc 标题', paragraphs: ['段落一。'] });
     writeLibFile(`${LIB}/c.docx`, docx);
     const res = await invoke('kb.openFile', { path: `${LIB}/c.docx` });
     expect(res.ok).toBe(true);
-    expect(res.kind).toBe('markdown');
-    expect(res.content).toMatch(/Doc 标题/);
+    expect(res.kind).toBe('office');
+    expect(res.officeKind).toBe('word');
+    // 返回完整 HTML 文档（含 office 排版包裹样式 + mammoth 转换正文）
+    expect(res.html).toContain('office-word');
+    expect(res.html).toContain('Doc 标题');
+    expect(res.html).toContain('段落一');
   });
 
-  it('pdf 提取分页文本', async () => {
+  it('xlsx 转表格化 HTML 预览', async () => {
+    const xlsx = makeMinimalXlsx({
+      sheetName: '成绩表',
+      rows: [
+        ['姓名', '分数'],
+        ['张伟', '99'],
+      ],
+    });
+    writeLibFile(`${LIB}/e.xlsx`, xlsx);
+    const res = await invoke('kb.openFile', { path: `${LIB}/e.xlsx` });
+    expect(res.ok).toBe(true);
+    expect(res.kind).toBe('office');
+    expect(res.officeKind).toBe('spreadsheet');
+    expect(res.html).toContain('office-sheet');
+    expect(res.html).toContain('成绩表');
+    expect(res.html).toContain('张伟');
+  });
+
+  it('pdf 走原生 PDFium（返回路径，不跨 IPC 传输文本）', async () => {
     const pdf = makeMinimalPdf(['第 1 页内容']);
     writeLibFile(`${LIB}/d.pdf`, pdf);
     const res = await invoke('kb.openFile', { path: `${LIB}/d.pdf` });
     expect(res.ok).toBe(true);
-    expect(res.kind).toBe('text');
-    expect(typeof res.content).toBe('string');
+    expect(res.kind).toBe('pdf');
+    expect(res.name).toBe('d.pdf');
+    expect(res.path).toBe(`${LIB}/d.pdf`);
+    expect(res.content).toBeUndefined();
   });
 });
 
@@ -131,6 +156,21 @@ describe('kb.openFile › 空间库文件预览', () => {
     expect(res.ok).toBe(true);
     expect(res.kind).toBe('markdown');
     expect(res.content).toContain('# 空间文档');
+  });
+
+  it('spaceId + path 的 pdf 返回原生 PDFium 标记', async () => {
+    const sid = await makeSpace('共享库2');
+    const paths = await import('../../../src/main/paths');
+    const root = paths.spaceContextsDir(TEST_UID, sid);
+    const abs = path.join(root, 'slide.pdf');
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, makeMinimalPdf(['空间 pdf']), 'utf8');
+
+    const res = await invoke('kb.openFile', { spaceId: sid, path: 'slide.pdf' });
+    expect(res.ok).toBe(true);
+    expect(res.kind).toBe('pdf');
+    expect(res.spaceId).toBe(sid);
+    expect(res.content).toBeUndefined();
   });
 
   it('拒绝越界路径（../ 逃逸）', async () => {

--- a/test/main/ipc/kb-open-file.test.ts
+++ b/test/main/ipc/kb-open-file.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { trustedIpcSender } from '../../helpers/trusted-ipc-sender';
+import { makeMinimalDocx } from '../../fixtures/make-minimal-docx';
+import { makeMinimalPdf } from '../../fixtures/make-minimal-pdf';
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false },
+  ipcMain: { handle: vi.fn(), on: vi.fn() },
+  dialog: { showOpenDialog: vi.fn(async () => ({ canceled: true, filePaths: [] })) },
+  BrowserWindow: { getAllWindows: vi.fn(() => []), getFocusedWindow: vi.fn(() => null) },
+  shell: { showItemInFolder: vi.fn(), openPath: vi.fn(async () => '') },
+  systemPreferences: {
+    getMediaAccessStatus: vi.fn(() => 'granted'),
+    askForMediaAccess: vi.fn(async () => true),
+  },
+}));
+
+vi.mock('../../../src/main/features/kb_indexer', () => ({
+  enqueue: vi.fn(),
+  kbEvents: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+}));
+
+vi.mock('../../../src/main/features/search', () => ({
+  upsertContext: vi.fn(),
+  dropContext: vi.fn(),
+}));
+
+vi.mock('../../../src/main/features/kb_vector', () => ({
+  findBySha1: vi.fn(() => null),
+}));
+
+let tmpDir: string;
+let prevWs: string | undefined;
+const TEST_UID = 'uKbOpenFile';
+const LIB = '笔记库';
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-kb-open-file-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  vi.resetModules();
+  vi.clearAllMocks();
+  const users = await import('../../../src/main/features/users');
+  users.activateUser(TEST_UID);
+});
+
+afterEach(() => {
+  process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function contextsRoot(): string {
+  return path.join(tmpDir, TEST_UID, 'cloud', 'contexts');
+}
+
+async function invoke(channel: string, payload: any): Promise<any> {
+  const electron = await import('electron') as any;
+  const { register } = await import('../../../src/main/ipc/index');
+  register();
+  const call = electron.ipcMain.handle.mock.calls.find(([name]: [string]) => name === 'cogseed.invoke');
+  expect(call).toBeTruthy();
+  const handler = call[1];
+  return handler({ sender: trustedIpcSender() }, { channel, payload });
+}
+
+/** 建个人库文件：relPath 相对 contexts root（含库名前缀）。 */
+function writeLibFile(rel: string, content: string | Buffer): void {
+  const abs = path.join(contextsRoot(), rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+/** 建共享空间并返回 spaceId。 */
+async function makeSpace(name: string): Promise<string> {
+  const spaces = await import('../../../src/main/features/spaces');
+  const created = await spaces.createSpace(TEST_UID, { name });
+  if (!created.ok) throw new Error('create space failed');
+  return created.space.space_id;
+}
+
+describe('kb.openFile › 个人库文本/文档预览', () => {
+  it('md 文件按 markdown 返回', async () => {
+    writeLibFile(`${LIB}/a.md`, '# 标题\n\n正文内容');
+    const res = await invoke('kb.openFile', { path: `${LIB}/a.md` });
+    expect(res.ok).toBe(true);
+    expect(res.kind).toBe('markdown');
+    expect(res.name).toBe('a.md');
+    expect(res.content).toContain('# 标题');
+  });
+
+  it('txt 文件按 text 返回且剥离 BOM', async () => {
+    writeLibFile(`${LIB}/sub/b.txt`, '\uFEFF纯文本');
+    const res = await invoke('kb.openFile', { path: `${LIB}/sub/b.txt` });
+    expect(res.ok).toBe(true);
+    expect(res.kind).toBe('text');
+    expect(res.content).toBe('纯文本');
+  });
+
+  it('docx 转 markdown', async () => {
+    const docx = makeMinimalDocx({ heading: 'Doc 标题', paragraphs: ['段落一。'] });
+    writeLibFile(`${LIB}/c.docx`, docx);
+    const res = await invoke('kb.openFile', { path: `${LIB}/c.docx` });
+    expect(res.ok).toBe(true);
+    expect(res.kind).toBe('markdown');
+    expect(res.content).toMatch(/Doc 标题/);
+  });
+
+  it('pdf 提取分页文本', async () => {
+    const pdf = makeMinimalPdf(['第 1 页内容']);
+    writeLibFile(`${LIB}/d.pdf`, pdf);
+    const res = await invoke('kb.openFile', { path: `${LIB}/d.pdf` });
+    expect(res.ok).toBe(true);
+    expect(res.kind).toBe('text');
+    expect(typeof res.content).toBe('string');
+  });
+});
+
+describe('kb.openFile › 空间库文件预览', () => {
+  it('spaceId + path 读取空间 contexts 下的 md', async () => {
+    const sid = await makeSpace('共享库');
+    const paths = await import('../../../src/main/paths');
+    const root = paths.spaceContextsDir(TEST_UID, sid);
+    const abs = path.join(root, 'doc.md');
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '# 空间文档', 'utf8');
+
+    const res = await invoke('kb.openFile', { spaceId: sid, path: 'doc.md' });
+    expect(res.ok).toBe(true);
+    expect(res.kind).toBe('markdown');
+    expect(res.content).toContain('# 空间文档');
+  });
+
+  it('拒绝越界路径（../ 逃逸）', async () => {
+    const sid = await makeSpace('共享库2');
+    const res = await invoke('kb.openFile', { spaceId: sid, path: '../../secret.md' });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBeTruthy();
+  });
+});
+
+describe('kb.openFile › 错误路径', () => {
+  it('文件不存在返回 file not found', async () => {
+    const res = await invoke('kb.openFile', { path: `${LIB}/missing.md` });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('file not found');
+  });
+
+  it('超过 2MB 返回 too_large', async () => {
+    writeLibFile(`${LIB}/big.txt`, 'x'.repeat(2 * 1024 * 1024 + 1));
+    const res = await invoke('kb.openFile', { path: `${LIB}/big.txt` });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('too_large');
+  });
+
+  it('缺 path 返回 missing path', async () => {
+    const res = await invoke('kb.openFile', {});
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('missing path');
+  });
+
+  it('未知扩展返回 unsupported', async () => {
+    writeLibFile(`${LIB}/x.bin`, Buffer.from([1, 2, 3]));
+    const res = await invoke('kb.openFile', { path: `${LIB}/x.bin` });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/暂不支持预览/);
+  });
+});


### PR DESCRIPTION
## Why（动机）
知识库文件行点击此前只弹占位 toast（「原文查看器：S2 上线」/「空间库原文查看：后续版本支持」），用户无法查看已导入文件的实际内容。

## What（改动）
- **主进程**：新增 `kb.openFile` IPC handler
  - 个人库：`relPath`（含库前缀）经 `contexts.resolveContextFileAbsPath` 安全解析；文本直读（2MB 上限、剥 BOM），`.md/.markdown` 标记为 markdown 渲染
  - 空间库：`spaceId + path`，路径限定在 `spaceContextsDir` 内（防穿越）
  - `.docx` → Markdown（复用 `docxBufferToMarkdown`）；`.pdf` → 分页文本（复用 `pdfBufferToPages`）
- **渲染层**（kb-workbench）：文件行点击打开原文阅读 overlay
  - md/docx 渲染 Markdown（`renderMarkdown`），txt/pdf/其余文本以等宽 pre 展示
  - 全 DOM 构建（`createElement`），不引入 raw-control 字面量（shared-ui guard 冻结计数 118 不变）
  - 标题 + 来源 scope、阅读模式宽度切换、Esc/遮罩关闭、错误态提示

## How（验证）
- `npm run typecheck` ✓
- `npx eslint`（改动 3 文件）✓
- 新增单测 `test/main/ipc/kb-open-file.test.ts` 10 例全过：md/text/docx/pdf、空间库读取、越界拒绝、缺失、超 2MB、缺 path、不支持格式
- 周边回归：`kb-workbench.test.ts`(9)、`shared-ui-adoption-guard`、`contexts-pick-upload`、`extract-docx/pdf` ✓
- Electron 实机（CDP 真实点击）验证：个人库 md 渲染 Markdown、空间库 docx→Markdown、pdf→分页文本均正常展示；阅读模式切换与 Esc 关闭生效
- 推送前审计：`PASS_WITH_WARNINGS`（豁免历史项 sherpa-onnx / sbom，非本次引入）

## Checklist
- [x] 分支基于最新 origin/develop
- [x] 提交作者 noreply 邮箱
- [x] 未改动其他模块
- [x] 单测覆盖新增逻辑