### PR TITLE
chore(builtin): 内置包版本统一 0.4.1 → 0.4.2

### DIFF
--- a/resources/builtin-packages/eduseed-course-client/manifest.json
+++ b/resources/builtin-packages/eduseed-course-client/manifest.json
@@ -10,7 +10,7 @@
     "zh": "EduSeed 课程学习入口。学生端：查看挑战、预检交付物、提交项目、查看评分与教师反馈、课后复盘；教师端：创建挑战、发布作业、跟踪班级进度、完成终审。全部数据同步 EduSeed 平台，评分经 AI 初评、教师终审。",
     "en": "The EduSeed course portal. Students: browse challenges, precheck deliverables, submit projects, view scores and teacher feedback, and reflect after each challenge. Teachers: create challenges, publish assignments, track class progress, and finalize reviews. All data syncs with the EduSeed platform, with AI first-pass grading and teacher final review."
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "compatible_cogseed": ">=1.0.0",
   "audience_roles": [
     "student",

--- a/resources/builtin-packages/eduseed-course-client/package.json
+++ b/resources/builtin-packages/eduseed-course-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eduseed-course-client",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "EduSeed 课程客户端（CogSeed 内置 Course Plugin）——课程无关薄客户端；课程内容与业务数据在 EduSeed 平台，随 CogSeed 发版升级。"
 }

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-aar/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-aar/scripts/runtime.js
@@ -17282,7 +17282,7 @@ var COMMANDS = [
   { command: "agent-inbox", role: "both", desc: "P3394 \u6536\u4EF6\u7BB1" },
   { command: "agent-contacts", role: "both", desc: "P3394 \u901A\u8BAF\u5F55" }
 ];
-var CURRENT_PLUGIN_VERSION = true ? "0.4.1" : "0.0.0";
+var CURRENT_PLUGIN_VERSION = true ? "0.4.2" : "0.0.0";
 var LICENSE_EXEMPT = /* @__PURE__ */ new Set(["help", "license-check", "health", "plugin-version", "check-deliverables", "prepare-submission"]);
 function compareVersions(a, b) {
   const pa = String(a).trim().replace(/^v/, "").split(".").map((n) => Number.parseInt(n, 10) || 0);

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-review/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-review/scripts/runtime.js
@@ -17282,7 +17282,7 @@ var COMMANDS = [
   { command: "agent-inbox", role: "both", desc: "P3394 \u6536\u4EF6\u7BB1" },
   { command: "agent-contacts", role: "both", desc: "P3394 \u901A\u8BAF\u5F55" }
 ];
-var CURRENT_PLUGIN_VERSION = true ? "0.4.1" : "0.0.0";
+var CURRENT_PLUGIN_VERSION = true ? "0.4.2" : "0.0.0";
 var LICENSE_EXEMPT = /* @__PURE__ */ new Set(["help", "license-check", "health", "plugin-version", "check-deliverables", "prepare-submission"]);
 function compareVersions(a, b) {
   const pa = String(a).trim().replace(/^v/, "").split(".").map((n) => Number.parseInt(n, 10) || 0);

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-submit/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-submit/scripts/runtime.js
@@ -17293,7 +17293,7 @@ var COMMANDS = [
   { command: "agent-inbox", role: "both", desc: "P3394 \u6536\u4EF6\u7BB1" },
   { command: "agent-contacts", role: "both", desc: "P3394 \u901A\u8BAF\u5F55" }
 ];
-var CURRENT_PLUGIN_VERSION = true ? "0.4.1" : "0.0.0";
+var CURRENT_PLUGIN_VERSION = true ? "0.4.2" : "0.0.0";
 var LICENSE_EXEMPT = /* @__PURE__ */ new Set(["help", "license-check", "health", "plugin-version", "check-deliverables", "prepare-submission"]);
 function compareVersions(a, b) {
   const pa = String(a).trim().replace(/^v/, "").split(".").map((n) => Number.parseInt(n, 10) || 0);

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-teacher-publish/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-teacher-publish/scripts/runtime.js
@@ -17282,7 +17282,7 @@ var COMMANDS = [
   { command: "agent-inbox", role: "both", desc: "P3394 \u6536\u4EF6\u7BB1" },
   { command: "agent-contacts", role: "both", desc: "P3394 \u901A\u8BAF\u5F55" }
 ];
-var CURRENT_PLUGIN_VERSION = true ? "0.4.1" : "0.0.0";
+var CURRENT_PLUGIN_VERSION = true ? "0.4.2" : "0.0.0";
 var LICENSE_EXEMPT = /* @__PURE__ */ new Set(["help", "license-check", "health", "plugin-version", "check-deliverables", "prepare-submission"]);
 function compareVersions(a, b) {
   const pa = String(a).trim().replace(/^v/, "").split(".").map((n) => Number.parseInt(n, 10) || 0);


### PR DESCRIPTION
_builtin.json 索引已在 #179 升到 0.4.2（触发老用户重装播种），但 manifest/package/4×runtime 仍自报 0.4.1，版本口径三处漂移。统一向上对齐为 0.4.2（保留升级触发号）：manifest.json、package.json、4×runtime.js CURRENT_PLUGIN_VERSION 一并同步。

源仓库 aix-course-elite20 已同步提交（d301b76）。