### PR TITLE
ci: run verify only on cicd branch again (undo #152 widening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: CI
 
-# Pull requests to develop and cicd run the macOS and Windows verification jobs.
-# Pushes to cicd repeat the full release gate before tagging a release.
+# CI (verify + verify-windows) runs only on the cicd branch — the release gate.
+# Day-to-day development merges into develop via review only (no CI);
+# the full macOS and Windows verification runs once when a PR targets cicd,
+# and again on push to cicd, right before tagging a release.
 on:
   pull_request:
     branches:
-      - develop
       - cicd
   push:
     branches:


### PR DESCRIPTION
## 动机（Why）

#152（2026-09-02 合并）把 CI 触发从"仅 cicd"改回了 develop+cicd，导致**每个 PR → develop 都跑完整的 macOS verify + Windows verify-windows（15–20 分钟）**。内部流程手册（草案 v0.4 §1.1/§2）约定 CI 是发布门禁：日常 develop 靠评审、不跑 CI；发布前 PR 合入 cicd 时跑完整验证。

## 改动（What）

- ci.yml：`pull_request` 触发条件删掉 `develop`，恢复为**仅 cicd**（PR → cicd / push cicd / 手动 dispatch 仍会跑 macOS + Windows 验证）
- 保留 #152 新增的 `verify-windows` job —— Windows 打包/平台验证仍作为 cicd 发布门禁的一部分
- 保留 email 门禁的 `github.base_ref == 'cicd'` 条件（cicd 路径兜底不变）

## 验证（How）

- 纯 workflow 配置改动（1 文件 4 行变更）
- 本 PR 目标 develop：按新配置 develop PR 不再触发 CI，email-gate 仍会跑
- 发布路径不受影响：PR → cicd / push cicd 时 verify + verify-windows 照常执行

## 关联

- 撤销 #152 对触发条件的拓宽（Windows 功能合流本身保留）
- 恢复 #52 的发布门禁模型
- 手册 v0.4 与仓库现状重新对齐

## 检查清单

- [x] 提交作者为个人 noreply 邮箱
- [ ] 评审组 ≥1 人 Approve