### PR TITLE
fix(builtin): 教师待审计数纳入 checked 状态——与平台回写口径对齐

### DIFF
--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-aar/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-aar/scripts/runtime.js
@@ -15048,7 +15048,9 @@ async function getDashboard(client) {
     ]);
     const submissions = Array.isArray(subsResp.submissions) ? subsResp.submissions : [];
     const completed = submissions.filter((s) => s.status === "accepted" || s.task_state === "COMPLETED").length;
-    const pendingReview = submissions.filter((s) => s.status === "submitted" || (s.status ?? "").includes("review")).length;
+    const pendingReview = submissions.filter(
+      (s) => s.status === "submitted" || s.status === "checked" || (s.status ?? "").includes("review")
+    ).length;
     return {
       ok: true,
       stats: {
@@ -15821,7 +15823,7 @@ async function submitProject(client, args, challengeRequiredDeliverables) {
         localIssues,
         error: {
           code: "INPUT_MISSING",
-          // 领域错误码：模板分类
+          // 领域错误码：Richard 模板 taxonomy
           message: `\u7F3A\u5C11\u4EA4\u4ED8\u7269: ${check2.missing.join("\u3001")}\u3002\u8BF7\u8865\u5145\u540E\u91CD\u65B0\u63D0\u4EA4\u3002`,
           ...check2.missing.length === 1 ? { field: check2.missing[0] } : {}
         }

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-review/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-review/scripts/runtime.js
@@ -15048,7 +15048,9 @@ async function getDashboard(client) {
     ]);
     const submissions = Array.isArray(subsResp.submissions) ? subsResp.submissions : [];
     const completed = submissions.filter((s) => s.status === "accepted" || s.task_state === "COMPLETED").length;
-    const pendingReview = submissions.filter((s) => s.status === "submitted" || (s.status ?? "").includes("review")).length;
+    const pendingReview = submissions.filter(
+      (s) => s.status === "submitted" || s.status === "checked" || (s.status ?? "").includes("review")
+    ).length;
     return {
       ok: true,
       stats: {
@@ -15821,7 +15823,7 @@ async function submitProject(client, args, challengeRequiredDeliverables) {
         localIssues,
         error: {
           code: "INPUT_MISSING",
-          // 领域错误码：模板分类
+          // 领域错误码：Richard 模板 taxonomy
           message: `\u7F3A\u5C11\u4EA4\u4ED8\u7269: ${check2.missing.join("\u3001")}\u3002\u8BF7\u8865\u5145\u540E\u91CD\u65B0\u63D0\u4EA4\u3002`,
           ...check2.missing.length === 1 ? { field: check2.missing[0] } : {}
         }

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-submit/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-student-submit/scripts/runtime.js
@@ -15048,7 +15048,9 @@ async function getDashboard(client) {
     ]);
     const submissions = Array.isArray(subsResp.submissions) ? subsResp.submissions : [];
     const completed = submissions.filter((s) => s.status === "accepted" || s.task_state === "COMPLETED").length;
-    const pendingReview = submissions.filter((s) => s.status === "submitted" || (s.status ?? "").includes("review")).length;
+    const pendingReview = submissions.filter(
+      (s) => s.status === "submitted" || s.status === "checked" || (s.status ?? "").includes("review")
+    ).length;
     return {
       ok: true,
       stats: {
@@ -15821,7 +15823,7 @@ async function submitProject(client, args, challengeRequiredDeliverables) {
         localIssues,
         error: {
           code: "INPUT_MISSING",
-          // 领域错误码：模板分类
+          // 领域错误码：Richard 模板 taxonomy
           message: `\u7F3A\u5C11\u4EA4\u4ED8\u7269: ${check2.missing.join("\u3001")}\u3002\u8BF7\u8865\u5145\u540E\u91CD\u65B0\u63D0\u4EA4\u3002`,
           ...check2.missing.length === 1 ? { field: check2.missing[0] } : {}
         }

--- a/resources/builtin-packages/eduseed-course-client/skills/eduseed-teacher-publish/scripts/runtime.js
+++ b/resources/builtin-packages/eduseed-course-client/skills/eduseed-teacher-publish/scripts/runtime.js
@@ -15048,7 +15048,9 @@ async function getDashboard(client) {
     ]);
     const submissions = Array.isArray(subsResp.submissions) ? subsResp.submissions : [];
     const completed = submissions.filter((s) => s.status === "accepted" || s.task_state === "COMPLETED").length;
-    const pendingReview = submissions.filter((s) => s.status === "submitted" || (s.status ?? "").includes("review")).length;
+    const pendingReview = submissions.filter(
+      (s) => s.status === "submitted" || s.status === "checked" || (s.status ?? "").includes("review")
+    ).length;
     return {
       ok: true,
       stats: {
@@ -15821,7 +15823,7 @@ async function submitProject(client, args, challengeRequiredDeliverables) {
         localIssues,
         error: {
           code: "INPUT_MISSING",
-          // 领域错误码：模板分类
+          // 领域错误码：Richard 模板 taxonomy
           message: `\u7F3A\u5C11\u4EA4\u4ED8\u7269: ${check2.missing.join("\u3001")}\u3002\u8BF7\u8865\u5145\u540E\u91CD\u65B0\u63D0\u4EA4\u3002`,
           ...check2.missing.length === 1 ? { field: check2.missing[0] } : {}
         }


### PR DESCRIPTION
## 背景

平台侧修复了 AI 初评回写静默失败的问题（提交表无「总分」列导致飞书 FieldNameNotFound）。修复后，提交行在 AI 初评完成后进入新状态 **checked**（评审状态 pending_teacher_review）。

## 改动

本 PR 同步 runtime 统一版（源: eduseed-runtime `3c05ad0`，aix-course-elite20 `05a998d`），教师仪表盘待审计数纳入 `checked` 状态，净 diff = 4 个 runtime.js（与 PR #187 同方式）。

## 验证

- 平台侧单元测试 219 全过（新增 5 例 review-backfill 回归）
- 生产飞书表实写验证：5 条存量卡住行已回写为 checked/pending_teacher_review，字段组被飞书接受