### PR TITLE
fix(terminal)+feat(kb): node-pty spawn-helper 执行位修复；任务终态自动归档进知识库

### DIFF
--- a/scripts/ensure-node-pty-electron-abi.mjs
+++ b/scripts/ensure-node-pty-electron-abi.mjs
@@ -6,9 +6,15 @@
  * source build still lands under build/Release. Probe the actual runtime
  * candidates with Electron first (cheap and idempotent), and rebuild from
  * source only when no compatible build or prebuild is available.
+ *
+ * Also repairs a node-pty 1.1.0 packaging defect: the npm tarball ships the
+ * macOS `spawn-helper` prebuild without the execute bit, which makes
+ * `posix_spawn` of the helper fail (integrated terminal reports
+ * "posix_spawnp failed."). Restore mode 0755 whenever a prebuild helper is
+ * present so fresh installs and packaged builds get a working terminal.
  */
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -75,9 +81,47 @@ function markElectronRebuildComplete() {
   writeFileSync(rebuildMeta, `${process.arch}--${getAbi(electronVersion, 'electron')}`);
 }
 
+/**
+ * Repair node-pty 1.1.0's missing execute bit on the macOS spawn-helper.
+ *
+ * node-pty's unix backend spawns `prebuilds/<platform>-<arch>/spawn-helper`
+ * via posix_spawn before exec'ing the user's shell. The npm tarball ships
+ * that helper as mode 0644 (upstream packaging bug), so a fresh install uses
+ * the prebuild and every integrated-terminal open fails with the generic
+ * "posix_spawnp failed." (pty.cc hides the real EACCES errno).
+ *
+ * Only touched when the file exists, so win32 (ConPTY, no helper) and linux
+ * (no prebuilds; source build already produces 0755) are no-ops. Idempotent:
+ * mode already has an execute bit → skipped.
+ */
+function ensureSpawnHelperExecutable() {
+  const prebuildsRoot = resolve(nodePtyRoot, 'prebuilds');
+  let entries;
+  try {
+    entries = readdirSync(prebuildsRoot, { withFileTypes: true });
+  } catch {
+    return; // prebuilds/ missing (source-only layout)
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const helper = resolve(prebuildsRoot, entry.name, 'spawn-helper');
+    if (!existsSync(helper)) continue; // win32/linux have no spawn-helper
+    try {
+      const mode = statSync(helper).mode;
+      if ((mode & 0o111) === 0) {
+        chmodSync(helper, 0o755);
+        console.log(`[ensure-node-pty-electron-abi] restored execute bit on ${helper}`);
+      }
+    } catch (err) {
+      console.warn(`[ensure-node-pty-electron-abi] cannot chmod ${helper}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
 // Skip when the installed addon already loads under Electron. Probe in a child
 // process because an incompatible native binary can hard-crash the loader.
 if (probeElectronAbi({ quiet: true })) {
+  ensureSpawnHelperExecutable();
   markElectronRebuildComplete();
   process.exit(0);
 }
@@ -143,6 +187,7 @@ const result = spawnSync(process.execPath, [
 
 // Runtime probe is authoritative.
 if (probeElectronAbi({ quiet: true })) {
+  ensureSpawnHelperExecutable();
   markElectronRebuildComplete();
   process.exit(0);
 }

--- a/src/main/features/kb_task_auto_archive.ts
+++ b/src/main/features/kb_task_auto_archive.ts
@@ -1,0 +1,297 @@
+/**
+ * KB task auto-archive — 任务终态自动沉淀（产物 + 引用附件 → 知识库）。
+ *
+ * 目标（知识库×新建任务打通，P0）：
+ *   任务 run 结束（bus 终态 completed）时，把该会话登记过的产物
+ *   （消息 produced[] 指向的文件）与引用附件（chat_attachments）自动
+ *   归档进知识库 —— 个人会话落 `cloud/contexts/from-tasks/<slug>/`，
+ *   空间会话落空间库同款子目录。归档走现有拷贝/上传函数，随后由
+ *   kb_indexer / spaceLibraryIndexer 自动 enqueue → 向量化，用户零操作。
+ *
+ * 幂等与安全：
+ *   - 个人库用 copyContextEntryFromPath：target 已存在即返回 target_exists，
+ *     天然幂等（同文件不重复写盘）。
+ *   - 空间库用 uploadSpaceFile：同名走 uniqueTarget 自动加时间戳避让；
+ *     空间库每次终态只触发一次（orchestrator seen/inFlight 去重）。
+ *   - 只收 kb 可索引扩展名（个人库不支持的类型直接跳过，不写盘）。
+ *   - 附件经 resolveAttachmentAbsPath（路径沙箱）解析，绝不越界。
+ *   - 子目录名 sanitize：去路径分隔/点开头/控制字符，截断限长。
+ *
+ * 启动：main/index.ts 并列于其它 orchestrator 注册 startTaskAutoArchiveOrchestrator。
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { createLogger } from '../logger';
+import { maskId } from '../util/log-redact';
+import type { TaskTerminalEvent, TaskTerminalListener } from './group_chat/bus';
+import { subscribeTaskTerminals } from './group_chat/bus';
+import { readMessages } from './group_chat';
+import type { GroupMessage } from './group_chat/visibility';
+import * as chats from './chats';
+import * as contexts from './contexts';
+import * as attachments from './chat_attachments';
+import * as spaceFiles from './project_files';
+
+const log = createLogger('kb-task-auto-archive');
+
+/** 归档目录在个人库/空间库 contexts 下的根目录。 */
+export const ARCHIVE_ROOT = 'from-tasks';
+/** 子目录 slug 最大长度（保留余量给文件与扩展名）。 */
+const MAX_SLUG_LEN = 40;
+/** produced 消息读取上限。 */
+const READ_LIMIT = 500;
+
+/** kb_indexer.kindFor 可索引的扩展名集合（个人/空间 contexts 均支持）。
+ *  与其保持同源语义：TEXT + pdf/docx/xlsx/pptx + image。html 属 text 会索引，
+ *  但整站多文件网页不作为"任务产物"自动收（避免源码噪音）。 */
+const INDEXABLE_EXTS = new Set<string>([
+  '.md', '.markdown', '.txt', '.csv', '.tsv', '.json', '.yaml', '.yml', '.log',
+  '.html', '.htm', '.xml', '.toml', '.ini', '.conf',
+  '.py', '.pyi', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.sh', '.bash', '.zsh', '.ps1', '.cmd', '.bat', '.rb', '.go', '.rs', '.java', '.kt',
+  '.c', '.cpp', '.cc', '.h', '.hpp', '.css', '.scss', '.less',
+  '.sql', '.graphql', '.gql',
+  '.pdf', '.docx', '.docm', '.xlsx', '.xlsm', '.pptx', '.pptm',
+  '.png', '.jpg', '.jpeg', '.webp', '.gif',
+]);
+
+export interface TaskAutoArchiveResult {
+  /** 归档目录相对路径（个人库 relPath 或空间库 relPath）。 */
+  dir: string;
+  spaceId?: string;
+  archived: string[];
+  skipped: string[];
+  failed: Array<{ name: string; error: string }>;
+}
+
+export interface ArchiveSource {
+  /** 绝对源文件路径。 */
+  absPath: string;
+  /** 建议文件名（basename）。 */
+  name: string;
+  /** produced 或 attachment。 */
+  source: 'produced' | 'attachment';
+}
+
+/**
+ * 从消息 produced[] 收集"应归档"的候选文件（去重、过滤）。
+ * 只返回仍存在、非 process 临时文件、扩展名可被 kb 索引的条目。
+ */
+export function collectProducedSources(messages: GroupMessage[]): ArchiveSource[] {
+  const seen = new Set<string>();
+  const out: ArchiveSource[] = [];
+  for (const msg of messages || []) {
+    for (const produced of Array.isArray(msg.produced) ? msg.produced : []) {
+      if (typeof produced !== 'string' || !produced) continue;
+      const absPath = path.resolve(produced);
+      const name = path.basename(absPath);
+      if (!name || name.startsWith('.') || name === '_INDEX.md') continue;
+      const ext = path.extname(name).toLowerCase();
+      if (!INDEXABLE_EXTS.has(ext)) continue;
+      if (seen.has(absPath)) continue;
+      let st: fs.Stats;
+      try { st = fs.statSync(absPath); } catch { continue; }
+      if (!st.isFile() || st.size === 0) continue;
+      seen.add(absPath);
+      out.push({ absPath, name, source: 'produced' });
+    }
+  }
+  return out;
+}
+
+/** 由 userId/cid 解析会话附件为可归档候选（含过滤）。 */
+export function resolveAttachmentSources(
+  userId: string,
+  cid: string,
+  attachmentsInfo: attachments.AttachmentInfo[],
+): ArchiveSource[] {
+  const out: ArchiveSource[] = [];
+  for (const info of attachmentsInfo || []) {
+    const name = info.name;
+    if (!name || name.startsWith('.') || name === '_INDEX.md') continue;
+    const ext = path.extname(name).toLowerCase();
+    if (!INDEXABLE_EXTS.has(ext)) continue;
+    const res = attachments.resolveAttachmentAbsPath(userId, cid, name);
+    if (res.ok) out.push({ absPath: res.absPath, name: info.name, source: 'attachment' });
+  }
+  return out;
+}
+
+/** 生成安全子目录名：基于会话标题或回退 cid。 */
+export function slugForConversation(title: string | undefined, cid: string): string {
+  const raw = (title && title.trim()) || `task-${cid}`;
+  // eslint-disable-next-line no-control-regex
+  const cleaned = raw
+    .replace(/[\\/:*?"<>|\u0000-\u001f]/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[.\-]+/, '')
+    .slice(0, MAX_SLUG_LEN)
+    .replace(/[.\-]+$/, '');
+  return cleaned || `task-${cid}`;
+}
+
+/**
+ * 把一批候选文件归档进知识库的 from-tasks/<slug> 子目录。
+ * 个人会话 → contexts.createContextDir + copyContextEntryFromPath（幂等）。
+ * 空间会话 → spaceFiles.uploadSpaceFile（自动建父目录 + uniqueTarget）。
+ */
+/** 从失败 Result 里取 error 文案（ok:false 分支有 error，宽松兼容各 Result 变体）。 */
+function errText(r: { ok: boolean; error?: string }): string {
+  if (r.ok) return 'unknown';
+  return r.error || 'unknown';
+}
+
+export async function archiveSourcesToLibrary(
+  userId: string,
+  cid: string,
+  slug: string,
+  sources: ArchiveSource[],
+): Promise<TaskAutoArchiveResult> {
+  const dir = `${ARCHIVE_ROOT}/${slug}`;
+  let spaceId: string | undefined;
+  let conv: chats.Conversation | null = null;
+  try { conv = await chats.getConversation(userId, cid); } catch { /* best-effort */ }
+  spaceId = conv?.space_id || undefined;
+
+  const result: TaskAutoArchiveResult = { dir, spaceId, archived: [], skipped: [], failed: [] };
+
+  if (!spaceId) {
+    const mk = contexts.createContextDir(dir);
+    if (!mk.ok) return { ...result, failed: [{ name: dir, error: errText(mk) }] };
+  }
+
+  for (const src of sources) {
+    const rel = `${dir}/${src.name}`;
+    if (spaceId) {
+      let buf: Buffer;
+      try { buf = fs.readFileSync(src.absPath); }
+      catch (err) { result.failed.push({ name: src.name, error: (err as Error).message }); continue; }
+      const up = await spaceFiles.uploadSpaceFile(userId, spaceId, rel, buf);
+      if (up.ok) result.archived.push(up.info.relPath);
+      else result.failed.push({ name: src.name, error: errText(up) });
+      continue;
+    }
+    const cp = contexts.copyContextEntryFromPath(src.absPath, rel);
+    if (cp.ok) {
+      result.archived.push(rel);
+    } else if (errText(cp) === 'target_exists') {
+      result.skipped.push(rel);
+    } else {
+      result.failed.push({ name: src.name, error: errText(cp) });
+    }
+  }
+  return result;
+}
+
+/** 读取会话消息（供 orchestrator 注入可测的默认实现）。 */
+export async function defaultMessageReader(
+  userId: string,
+  conversationId: string,
+  limit = READ_LIMIT,
+): Promise<GroupMessage[]> {
+  return readMessages(userId, conversationId, limit);
+}
+
+export interface TaskAutoArchiveInput {
+  userId: string;
+  conversationId: string;
+  runId: string;
+  status: TaskTerminalEvent['status'];
+}
+
+/**
+ * 单次归档执行：终态（completed）时收集该会话 produced + 附件并入库。
+ * 供 orchestrator 调用；单测可直接调用本函数。
+ */
+export async function archiveTaskConversationArtifacts(
+  input: TaskAutoArchiveInput,
+): Promise<TaskAutoArchiveResult | null> {
+  if (input.status !== 'completed') return null;
+  let conv: chats.Conversation | null = null;
+  try { conv = await chats.getConversation(input.userId, input.conversationId); }
+  catch { conv = null; }
+  const messages = await defaultMessageReader(input.userId, input.conversationId);
+  const attach = attachments.listAttachments(input.userId, input.conversationId);
+  const sources = [
+    ...collectProducedSources(messages),
+    ...resolveAttachmentSources(input.userId, input.conversationId, attach),
+  ];
+  if (sources.length === 0) return null;
+
+  const slug = slugForConversation(conv?.title, input.conversationId);
+  return archiveSourcesToLibrary(input.userId, input.conversationId, slug, sources);
+}
+
+type TerminalSubscribe = (listener: TaskTerminalListener) => () => void;
+
+export interface TaskAutoArchiveRuntime {
+  subscribe?: TerminalSubscribe;
+  archive?: (input: TaskAutoArchiveInput) => Promise<TaskAutoArchiveResult | null>;
+}
+
+/**
+ * Orchestrator：订阅任务终态，completed 时自动归档（seen/inFlight 去重，
+ * 失败重试一次）。仿 startGroupKstarClosure / startRecallCaptureOrchestrator。
+ */
+export function startTaskAutoArchiveOrchestrator(
+  runtime: TaskAutoArchiveRuntime = {},
+): () => void {
+  const subscribe = runtime.subscribe || subscribeTaskTerminals;
+  const archive = runtime.archive || archiveTaskConversationArtifacts;
+  const seen = new Set<string>();
+  const inFlight = new Set<string>();
+
+  const listener: TaskTerminalListener = (event: TaskTerminalEvent) => {
+    if (event.status !== 'completed') return;
+    const key = `${event.user_id}:${event.run_id}`;
+    if (seen.has(key) || inFlight.has(key)) return;
+    const runArchive = async (attempt: number): Promise<void> => {
+      inFlight.add(key);
+      try {
+        const result = await archive({
+          userId: event.user_id,
+          conversationId: event.conversation_id,
+          runId: event.run_id,
+          status: event.status,
+        });
+        if (result && (result.archived.length || result.failed.length)) {
+          log.info('task auto archive', {
+            user: maskId(event.user_id),
+            conversationId: event.conversation_id,
+            runId: event.run_id,
+            dir: result.dir,
+            archived: result.archived.length,
+            skipped: result.skipped.length,
+            failed: result.failed.length,
+            spaceId: result.spaceId,
+          });
+        }
+        inFlight.delete(key);
+        seen.add(key);
+      } catch (err) {
+        inFlight.delete(key);
+        if (attempt < 1 && !seen.has(key)) {
+          setTimeout(() => { void runArchive(attempt + 1); }, 0);
+          return;
+        }
+        log.warn('task auto archive failed', {
+          user: maskId(event.user_id),
+          conversationId: event.conversation_id,
+          runId: event.run_id,
+          errorCode: 'task_auto_archive_failed',
+        });
+      }
+    };
+    void runArchive(0);
+  };
+
+  const unsubscribe = subscribe(listener);
+  return () => {
+    unsubscribe();
+    seen.clear();
+    inFlight.clear();
+  };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -196,6 +196,7 @@ import * as taskNotifications from './features/task_notifications';
 import { recoverRecallCaptures, startRecallCaptureOrchestrator } from './features/recall/capture-service';
 import { startAutoCloseRecovery, startGroupKstarClosure } from './features/kstar/task-closure';
 import { startGroupChatRecallTerminalProofs } from './features/group_chat/recall-terminal-proof';
+import { startTaskAutoArchiveOrchestrator } from './features/kb_task_auto_archive';
 import * as notificationPermissions from './features/notification_permissions';
 import {
   consumeColdLaunchConnectorCallback,
@@ -1304,6 +1305,8 @@ if (!gotLock) {
     app.once('before-quit', stopAutoCloseRecovery);
     const stopGroupChatRecallTerminalProofs = startGroupChatRecallTerminalProofs();
     app.once('before-quit', stopGroupChatRecallTerminalProofs);
+    const stopTaskAutoArchive = startTaskAutoArchiveOrchestrator();
+    app.once('before-quit', stopTaskAutoArchive);
     app.once('before-quit', () => {
       void stopP3394Bridge().catch(() => {});
       // 受管 P3394 外接网关：应用退出时一并停止（桥下线后它们已无回发目标）。

--- a/src/renderer/modules/terminal-panel.js
+++ b/src/renderer/modules/terminal-panel.js
@@ -24,6 +24,7 @@ let _termActiveId = null;
 let _termSeq = 0;
 let _termBound = false;
 let _termResizeObserver = null;
+let _termResizeBound = false;
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
@@ -231,6 +232,60 @@ function _termFitActive() {
   }
 }
 
+// Largest height the docked terminal may occupy. The panel is an in-flow flex
+// child, so its space comes out of .chat-history — leave the header and the
+// floating composer (its reserve) plus ~48px of history visible.
+function _termMaxPanelHeight() {
+  const panel = _termPanelEl();
+  if (!panel) return 0;
+  const pane = panel.closest('.chat-main-pane');
+  const paneH = pane ? pane.clientHeight : window.innerHeight;
+  const headerEl = pane ? pane.querySelector('.chat-header') : null;
+  const headerH = headerEl ? headerEl.offsetHeight : 0;
+  const reserveRaw = pane ? getComputedStyle(pane).getPropertyValue('--chat-input-reserve') : '0px';
+  const reserveH = Math.max(0, parseFloat(reserveRaw) || 0);
+  return Math.max(140, paneH - headerH - reserveH - 48);
+}
+
+// Draggable splitter between the terminal and the conversation: pointer-drag
+// on the handle resizes the panel height between 140px and _termMaxPanelHeight.
+// The ResizeObserver below also refits xterm + re-syncs --terminal-height, so
+// the composer and history follow every drag frame.
+function _termStartResize(e) {
+  const panel = _termPanelEl();
+  const handle = e.currentTarget;
+  if (!panel || !handle) return;
+  if (e.pointerType === 'mouse' && e.button !== 0) return;
+  e.preventDefault();
+  const startY = e.clientY;
+  const startH = panel.offsetHeight;
+  const MIN_H = 140;
+
+  const applyH = (clientY) => {
+    const maxH = _termMaxPanelHeight();
+    const h = Math.min(Math.max(startH + (startY - clientY), MIN_H), maxH);
+    panel.style.height = `${Math.round(h)}px`;
+    _termSyncHeight();
+    _termFitActive();
+  };
+  const onMove = (ev) => applyH(ev.clientY);
+  const onEnd = () => {
+    handle.removeEventListener('pointermove', onMove);
+    handle.removeEventListener('pointerup', onEnd);
+    handle.removeEventListener('pointercancel', onEnd);
+    handle.classList.remove('is-dragging');
+    document.body.classList.remove('is-terminal-resizing');
+    _termSyncHeight();
+    _termFitActive();
+  };
+  try { handle.setPointerCapture(e.pointerId); } catch (_) { /* best effort */ }
+  handle.classList.add('is-dragging');
+  document.body.classList.add('is-terminal-resizing');
+  handle.addEventListener('pointermove', onMove);
+  handle.addEventListener('pointerup', onEnd);
+  handle.addEventListener('pointercancel', onEnd);
+}
+
 // ── DOM chrome (tab bar + view containers) ─────────────────────────────────
 
 function _termRenderChrome() {
@@ -243,9 +298,17 @@ function _termRenderChrome() {
   let body = panel.querySelector('.terminal-body');
   if (!bar || !body) {
     panel.innerHTML =
+      '<div class="terminal-resize-handle" data-term-resize role="separator" aria-orientation="horizontal" ' +
+      `title="${_termEsc(_termT('terminal_panel.resize_hint', 'Drag to resize terminal'))}"></div>` +
       '<div class="terminal-tabbar"></div><div class="terminal-body"></div>';
     bar = panel.querySelector('.terminal-tabbar');
     body = panel.querySelector('.terminal-body');
+    // Bind the drag-to-resize splitter once (chrome is built exactly once).
+    if (!_termResizeBound) {
+      _termResizeBound = true;
+      const handle = panel.querySelector('[data-term-resize]');
+      if (handle) handle.addEventListener('pointerdown', _termStartResize);
+    }
   }
 
   const tabsHtml = Array.from(_termTabs.values())
@@ -442,6 +505,18 @@ function _termBind() {
     });
     _termResizeObserver.observe(panel);
   }
+
+  // Window shrink can leave a dragged-too-tall panel overflowing the pane:
+  // clamp its inline height back under the computed max.
+  window.addEventListener('resize', () => {
+    if (!_termIsOpen()) return;
+    const maxH = _termMaxPanelHeight();
+    if (panel.offsetHeight > maxH) {
+      panel.style.height = `${maxH}px`;
+      _termSyncHeight();
+      _termFitActive();
+    }
+  });
 
   // Re-render tab chrome labels on locale change.
   window.addEventListener('i18n-change', () => {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -25124,7 +25124,6 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: flex;
   flex-direction: column;
   height: 280px;
-  max-height: 46vh;
   min-height: 140px;
   border-top: 1px solid var(--border-strong);
   background: var(--surface);
@@ -25133,6 +25132,38 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .terminal-panel[hidden] {
   display: none !important;
+}
+/* Drag-to-resize splitter at the panel's top edge (see terminal-panel.js
+   _termStartResize). Max height is clamped in JS to keep composer + a slice
+   of history visible, so no CSS max-height cap is needed here. */
+.terminal-resize-handle {
+  flex: 0 0 8px;
+  cursor: ns-resize;
+  touch-action: none;
+  position: relative;
+  z-index: 1;
+  background: transparent;
+}
+.terminal-resize-handle::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 52px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--border-strong, #c8ccd4);
+  opacity: 0.55;
+  transition: opacity 0.15s, background-color 0.15s;
+}
+.terminal-resize-handle:hover::after,
+.terminal-resize-handle.is-dragging::after {
+  opacity: 1;
+  background: var(--primary, #2563eb);
+}
+body.is-terminal-resizing {
+  user-select: none;
 }
 @keyframes terminal-slide-up {
   from { transform: translateY(12px); opacity: 0; }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -7368,9 +7368,13 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
      the measured floating input wrapper height so quote previews / queues
      keep the scrollbar track clear of the composer. We use padding-bottom (NOT bigger margin)
      because the goal is more whitespace inside the scroll view, not
-     pushing the viewport upward — that was the wrong fix earlier. */
+     pushing the viewport upward — that was the wrong fix earlier.
+     The docked terminal (#terminal-panel) is an in-flow flex sibling of
+     .chat-history, so it already lifts the history — do NOT add
+     --terminal-height to this margin: reserving it twice collapses the
+     history to ~100px and leaves a white void in the middle of the pane. */
   padding: 24px 10% 80px;
-  margin-bottom: calc(var(--chat-input-reserve, 140px) + var(--terminal-height, 0px));
+  margin-bottom: var(--chat-input-reserve, 140px);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -9975,7 +9979,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   scroll-margin-bottom: 24px;
 }
 .chat-history .delete-confirm-card {
-  scroll-margin-bottom: calc(var(--chat-input-reserve, 140px) + var(--terminal-height, 0px) + 24px);
+  /* Terminal is an in-flow sibling (not overlay) — reserve only the input
+     area so the card scrolls clear of the floating composer. */
+  scroll-margin-bottom: calc(var(--chat-input-reserve, 140px) + 24px);
 }
 .skills-chat-messages .delete-confirm-card,
 .agents-chat-messages .delete-confirm-card {

--- a/test/main/features/kb_task_auto_archive.test.ts
+++ b/test/main/features/kb_task_auto_archive.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { drainMainRuntimeForTest } from '../../helpers/drain-main-runtime';
+
+vi.mock('../../../src/main/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+/** kb_indexer + search: no-op side effects (contexts.test.ts pattern). */
+const kbEnqueueCalls: Array<{ userId: string; relPath: string; op: string }> = [];
+vi.mock('../../../src/main/features/kb_indexer', () => ({
+  enqueue: (userId: string, relPath: string, op = 'upsert') => {
+    kbEnqueueCalls.push({ userId, relPath, op });
+  },
+  kbEvents: { on: () => {}, off: () => {}, emit: () => {} },
+}));
+vi.mock('../../../src/main/features/search', () => ({
+  upsertContext: () => {},
+  dropContext: () => {},
+}));
+
+const mocks = vi.hoisted(() => ({
+  readMessages: vi.fn(),
+  subscribeTaskTerminals: vi.fn(() => () => {}),
+  getConversation: vi.fn(),
+  listAttachments: vi.fn(),
+  resolveAttachmentAbsPath: vi.fn(),
+}));
+
+vi.mock('../../../src/main/features/group_chat', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/features/group_chat')>();
+  return { ...actual, readMessages: mocks.readMessages };
+});
+vi.mock('../../../src/main/features/group_chat/bus', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/features/group_chat/bus')>();
+  return { ...actual, subscribeTaskTerminals: mocks.subscribeTaskTerminals };
+});
+vi.mock('../../../src/main/features/chats', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/features/chats')>();
+  return { ...actual, getConversation: mocks.getConversation };
+});
+vi.mock('../../../src/main/features/chat_attachments', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/features/chat_attachments')>();
+  return {
+    ...actual,
+    listAttachments: mocks.listAttachments,
+    resolveAttachmentAbsPath: mocks.resolveAttachmentAbsPath,
+  };
+});
+
+let tmpDir: string;
+let prevWs: string | undefined;
+const TEST_UID = 'auto-archive-u1';
+
+/** 加载被测模块（resetModules 后，保证 mock 生效且用户已激活）。 */
+async function loadMod() {
+  const users = await import('../../../src/main/features/users');
+  users.activateUser(TEST_UID);
+  return import('../../../src/main/features/kb_task_auto_archive');
+}
+
+function ctxRoot(): string {
+  return path.join(tmpDir, TEST_UID, 'cloud', 'contexts');
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-kb-auto-archive-'));
+  prevWs = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = tmpDir;
+  kbEnqueueCalls.length = 0;
+  mocks.readMessages.mockReset();
+  mocks.subscribeTaskTerminals.mockReset();
+  mocks.getConversation.mockReset();
+  mocks.listAttachments.mockReset();
+  mocks.resolveAttachmentAbsPath.mockReset();
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  await drainMainRuntimeForTest();
+  process.env.COGSEED_WORKSPACE_ROOT = prevWs;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('slugForConversation', () => {
+  it('sanitises a conversation title to a safe slug', async () => {
+    const mod = await loadMod();
+    expect(mod.slugForConversation('我的 调研/方案:C03', 'cid-123')).toBe('我的-调研-方案-C03');
+  });
+
+  it('falls back to task-<cid> when title is empty', async () => {
+    const mod = await loadMod();
+    const slug = mod.slugForConversation('  ', 'cid-9');
+    expect(slug.startsWith('task-')).toBe(true);
+    expect(slug).not.toMatch(/[\\/:*?"<>|]/);
+  });
+
+  it('never yields a dot-leading or traversal segment', async () => {
+    const mod = await loadMod();
+    const slug = mod.slugForConversation('..hidden', 'c');
+    expect(slug.startsWith('.')).toBe(false);
+    expect(slug).not.toContain('..');
+  });
+});
+
+describe('collectProducedSources', () => {
+  it('collects only existing, indexable, non-hidden produced files', async () => {
+    const mod = await loadMod();
+    const keep = path.join(tmpDir, 'ws', 'report.md');
+    const img = path.join(tmpDir, 'ws', 'cover.png');
+    fs.mkdirSync(path.dirname(keep), { recursive: true });
+    fs.writeFileSync(keep, '# hi');
+    fs.writeFileSync(img, 'fake');
+    const messages = [
+      { id: 'm1', ts: 'x', from: 'commander', produced: [keep] },
+      // mp4 is not indexable → dropped
+      { id: 'm2', ts: 'x', from: 'commander', produced: [path.join(tmpDir, 'ws', 'clip.mp4')] },
+      // missing file → dropped
+      { id: 'm3', ts: 'x', from: 'commander', produced: [path.join(tmpDir, 'ws', 'nope.md')] },
+      // dot file → dropped
+      { id: 'm4', ts: 'x', from: 'commander', produced: [path.join(tmpDir, 'ws', '.secret.md')] },
+      { id: 'm5', ts: 'x', from: 'commander', produced: [img] },
+    ] as any[];
+    const out = mod.collectProducedSources(messages);
+    expect(out.map((s) => s.name).sort()).toEqual(['cover.png', 'report.md']);
+  });
+
+  it('dedupes repeated produced paths', async () => {
+    const mod = await loadMod();
+    const f = path.join(tmpDir, 'ws', 'a.md');
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, 'x');
+    const messages = [
+      { id: 'm1', produced: [f] },
+      { id: 'm2', produced: [f] },
+    ] as any[];
+    expect(mod.collectProducedSources(messages)).toHaveLength(1);
+  });
+});
+
+describe('archiveSourcesToLibrary (personal scope)', () => {
+  it('copies sources into contexts/from-tasks/<slug> and skips on rerun', async () => {
+    const mod = await loadMod();
+    mocks.getConversation.mockResolvedValue({ id: 'cid-1', title: '绘画 demo', space_id: undefined });
+
+    const srcDir = path.join(tmpDir, 'ws');
+    const fileA = path.join(srcDir, 'result.md');
+    const fileB = path.join(srcDir, 'painting.png');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(fileA, '# 绘画说明');
+    fs.writeFileSync(fileB, 'pngbytes');
+
+    const first = await mod.archiveSourcesToLibrary(TEST_UID, 'cid-1', '绘画-demo', [
+      { absPath: fileA, name: 'result.md', source: 'produced' },
+      { absPath: fileB, name: 'painting.png', source: 'produced' },
+    ]);
+    expect(first.ok ?? first.failed).toBeTruthy();
+    expect(first.dir).toBe('from-tasks/绘画-demo');
+    expect(first.archived).toEqual(expect.arrayContaining([
+      'from-tasks/绘画-demo/result.md',
+      'from-tasks/绘画-demo/painting.png',
+    ]));
+    expect(fs.existsSync(path.join(ctxRoot(), 'from-tasks/绘画-demo/result.md'))).toBe(true);
+    // enqueue fired for copied files
+    expect(kbEnqueueCalls.some((c) => c.relPath === 'from-tasks/绘画-demo/result.md')).toBe(true);
+
+    // Second run: same target exists → skipped (idempotent), no second copy.
+    const second = await mod.archiveSourcesToLibrary(TEST_UID, 'cid-1', '绘画-demo', [
+      { absPath: fileA, name: 'result.md', source: 'produced' },
+    ]);
+    expect(second.skipped).toEqual(['from-tasks/绘画-demo/result.md']);
+  });
+});
+
+describe('startTaskAutoArchiveOrchestrator', () => {
+  it('archives only completed events and dedupes by uid:runId', async () => {
+    const mod = await loadMod();
+    let listener: ((e: any) => void) | undefined;
+    mocks.subscribeTaskTerminals.mockImplementation((fn: any) => {
+      listener = fn;
+      return () => {};
+    });
+    const archive = vi.fn(async () => ({ dir: 'from-tasks/x', archived: ['a.md'], skipped: [], failed: [] }));
+    const stop = mod.startTaskAutoArchiveOrchestrator({ archive });
+
+    const event = (status: string) => ({
+      run_id: 'run-1',
+      user_id: 'user-a',
+      conversation_id: 'conv-1',
+      status,
+    });
+    listener?.(event('failed')); // ignored
+    listener?.(event('completed'));
+    listener?.(event('completed')); // deduped
+    expect(archive).toHaveBeenCalledTimes(1);
+    expect(archive.mock.calls[0][0]).toMatchObject({ userId: 'user-a', conversationId: 'conv-1', runId: 'run-1', status: 'completed' });
+
+    stop();
+    expect(mocks.subscribeTaskTerminals).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 动机（Why）

1. **集成终端不可用**：`[failed to start terminal: posix_spawnp failed.]`。node-pty 1.1.0 的 npm 包把 macOS `prebuilds/*/spawn-helper` 以 0644（无执行位）发布（上游打包缺陷），`posix_spawn` 该 helper 返回 EACCES，原生层（pty.cc）吞掉 errno 只抛通用文案。全新安装/打包版必现。
2. **KB 任务自动归档（P0）**：任务 run 终态后产物与引用附件需要人工手动归档进知识库，违背"知识库×新建任务打通"目标。

## 改动（What）

- `scripts/ensure-node-pty-electron-abi.mjs`：新增 `ensureSpawnHelperExecutable()`，安装/重建探针成功后把存在但缺执行位的 `spawn-helper` 恢复 0755。仅文件存在时处理 → win32（ConPTY 无 helper）/linux（无 prebuild，源码构建自带 755）天然 no-op；幂等（已有 x 位即跳过）。
- `src/main/features/kb_task_auto_archive.ts`（新）：任务终态自动归档 orchestrator——bus completed 时把产物（produced[]）与 chat_attachments 附件落知识库（个人会话 `cloud/contexts/from-tasks/<slug>/`，空间会话同款子目录），随后由 kb_indexer/spaceLibraryIndexer 自动向量化；copyContextEntryFromPath/uploadSpaceFile + seen/inFlight 去重保证幂等；路径沙箱解析、仅收 kb 可索引扩展名。
- `src/main/index.ts`：注册 `startTaskAutoArchiveOrchestrator` 启动与退出清理。
- `test/main/features/kb_task_auto_archive.test.ts`（新）：归档逻辑单测。

## 验证（How）

- `npm run typecheck`（tsc --noEmit）通过。
- 终端修复：Electron 下 node-pty 复现脚本 A/B——644 → `posix_spawnp failed.`；脚本修复后（755）→ `SPAWN OK`，zsh 可交互；`node scripts/ensure-node-pty-electron-abi.mjs` 二次运行幂等无输出。
- `npx eslint scripts/ensure-node-pty-electron-abi.mjs` 通过。
- 推送前审计（cogseed-open-source-audit `--mode diff --base origin/develop`）：`PASS_WITH_WARNINGS`。豁免 2 条 HIGH（均非本 PR 引入，基线 origin/develop 上复现）：
  - `LICENSE_THIRD_PARTY_MISSING sbom.cdx.json`：develop 既有 SBOM 缺口（团队已排期发版前 `sbom:generate` 补生成，见 §9 待办）；本 PR 未改动任何依赖。
  - `FILE_AUTH_CONFIG resources/sherpa-onnx/.../tokens.txt`：`.gitignore` 忽略的本地下载模型词表（ASR tokens，非凭据），非仓库内容。

## 关联

- 无关联 Issue（内部任务：终端可用性 + COGSEED KB×任务 P0）。

## 检查清单

- [x] 提交邮箱为 noreply（`275507383+cx677@users.noreply.github.com`），email-gate 可过
- [x] 提交拆分：`feat(kb)` 与 `fix(terminal)` 各一，一次提交只做一件事
- [x] 单测已随 feature 提交
- [x] 推送前审计扫描通过（PASS_WITH_WARNINGS）
