### PR TITLE
feat(kb): 知识库问答增强（跨库引导/元问题/概览路由/流式）+ 文件预览查看器 + PDF 引用页码定位

### DIFF
--- a/src/main/features/kb_qa.ts
+++ b/src/main/features/kb_qa.ts
@@ -10,21 +10,33 @@
  * Read-only pipeline: never writes to chats / conversation bus, mirrors the
  * aside pattern (`streamChatWithModel` injected via deps, so this module is
  * unit-testable without a live provider).
+ *
+ * Retrieval shaping (2026-09-05，针对“引用不真/看着不变”问题):
+ *  - 范围跟随所在目录：`dir` 透传给 askMaterials，不再永远整库检索；
+ *  - 放宽候选集后再做“每文件 ≤2 条”多样化裁减，抑制巨型文档霸榜；
+ *  - 引用 chips 只保留回答文本里真实出现的 `path#chunk N` 锚点；模型
+ *    漏标/明确“未找到”时不挂引用；
+ *  - 按文件名提问（如「AST.pdf 讲了什么」）：若该文件在当前范围存在则置顶
+ *    命中；若只存在于其它个人库目录，则返回 `suggestion` 引导用户切库重问。
  */
 
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import { createLogger } from '../logger';
 import { maskId } from '../util/log-redact';
+import * as kbVector from './kb_vector';
 import { askMaterials, formatEvidence } from '../model/core-agent/ask-materials';
 import type { MaterialHit } from '../model/core-agent/material-search';
 
 const log = createLogger('kb-qa');
 
 export interface KbAskInput {
-  /** 空 = 全局（用户个人资料库）；非空 = 空间库。 */
+  /** 非空 = 空间库；空 = 个人资料库。 */
   spaceId?: string | null;
+  /** 空 = 个人资料库整库；非空 = 个人库该目录（含子目录）。 */
+  dir?: string | null;
   question: string;
+  /** 返回给渲染层的引用条数上限（默认 8）。 */
   k?: number;
   /** 本次提问挂载的附件（本地文件绝对路径），内容作为补充上下文。 */
   attachPaths?: string[];
@@ -52,6 +64,15 @@ export interface KbEvidenceRef {
   score: number;
 }
 
+/** 跨库引导：当前个人库目录没找到，但另一个个人库目录有对应内容。 */
+export interface KbCrossLibSuggestion {
+  /** 目标个人库目录（rel_path 首段）。 */
+  dir: string;
+  path: string;
+  chunkIdx: number;
+  snippet: string;
+}
+
 export interface KbAskEvent {
   type: 'delta' | 'final' | 'error';
   text?: string;
@@ -59,11 +80,46 @@ export interface KbAskEvent {
   evidence?: KbEvidenceRef[];
   noMaterial?: boolean;
   reason?: 'no_material' | 'low_confidence';
+  /** 明确“未找到/无相关”结论：渲染层据此把回答按浅灰提示块展示。 */
+  notFound?: boolean;
+  /** 未找到时若其它个人库目录有对应内容，渲染层展示“前往该库提问”引导。 */
+  suggestion?: KbCrossLibSuggestion | null;
 }
 
-const KB_SYSTEM_PROMPT = `你是知识库问答助手。只依据提供的 ask_materials 证据回答；
-每一条结论都必须标注引用 \`path#chunk N\`；资料中没有的内容明确说「资料中未找到」，
-不要编造，不要切换联网搜索，除非用户明确要求。`;
+const KB_SYSTEM_PROMPT = `你是知识库问答助手。只依据提供的 ask_materials 证据回答；每条结论都标注引用 \`path#chunk N\`；资料里没有的内容明确归入「资料未说明」，不编造、不联网。
+
+回答结构请遵循：
+1. 开头先用一句话直接给出结论或一句话概括（如问“X 是什么”，第一句就给定义与定位，不要埋在大段中间）。
+2. 再按信息类型分节组织（如「是什么 / 任务要求 / 评分规则 / 复盘要求」）；同类型多条用列表逐条列出，每条一行为宜，避免长句堆砌、整段照抄原文。
+3. 对关键概念与指标做必要的解读：它要求什么、与问题或其它概念的关系，用自己的话简短说明，不只做摘录搬运。
+4. 全文先结论后细节；确实未找到的信息单列「资料未说明：…」如实说明，不脑补未给出的维度或定义。`;
+
+/** 元问题（询问助手能力/身份）：不走资料检索，直接给能力说明。 */
+const META_QUESTION_RE = /你会(做|干|啥)|你能(做|干|啥)|你会什么|你能什么|你有什么(功能|用|能力)|你是谁|介绍一下你(自己)?|你的(能力|功能|职责|作用)(是|都)/i;
+
+const KB_META_ANSWER = `我是「知识库问答助手」，只基于你当前选定的知识库资料回答，不做联网搜索或凭空编造。我能帮你：
+
+• 讲解某个文件讲了什么（例如「初中词汇-8词-真实试跑.md 讲了什么」）；
+• 按资料归纳要点，区分「是什么 / 任务要求 / 评分规则 / 复盘要求」；
+• 先给一句话结论再做解读，并标注「资料来源」供你点开溯源；资料里没有的会如实列为「资料未说明」。
+你可以直接问具体内容；若内容在其它个人库目录，我会提示你切换过去提问。`;
+
+/** 全库概览类问题（“这个知识库讲了什么/总结一下”）：走 AI 解析(kb.summary)，不走单点检索。 */
+const LIBRARY_OVERVIEW_RE = /(这个|该|当前|整个)?(知识库|资料库|这个库|该库|当前库)(里|中)?(的)?(主要)?(讲(的)?什么|讲了什么|说什么|什么内容|有什么|包含什么|是什么|干什么的|主题|有哪些|内容|介绍|总结)|(总结|概括|介绍)一下?.*(知识库|资料库)|(知识库|资料库|这个库|该库).*(讲什么|讲的什么|说了什么|总结|介绍)/i;
+
+const DEFAULT_K = 8;
+/** material-search 单次候选集上限（其内部还会 clamp 到 30）。 */
+const MAX_CANDIDATE_K = 30;
+/** 最终引用里同一个文件最多保留的条数（防巨型文档霸榜、让引用分散到多个来源）。 */
+const DIVERSIFY_PER_FILE = 2;
+/** 文件名置顶命中使用的参考分（高于默认阈值即可，不参与真实语义比较）。 */
+const PIN_SCORE = 0.02;
+/** 文件名置顶最多取前几个 chunk。 */
+const PIN_CHUNK_CAP = 2;
+
+/** 可被当作“文件名提问”识别的扩展名。 */
+const FILE_EXT = '(?:pdf|md|markdown|docx?|xlsx?|pptx?|doc|xls|ppt|txt|csv|html?|htm|json|png|jpe?g|gif|svg)';
+const FILE_NAME_RE = new RegExp(`([^\\s，。？！?！、,;:：;'"“”‘’（）()\\[\\]【】<>]+?\\.${FILE_EXT})\\b`, 'i');
 
 function toEvidenceRefs(hits: MaterialHit[]): KbEvidenceRef[] {
   return hits.map((h) => ({
@@ -76,6 +132,139 @@ function toEvidenceRefs(hits: MaterialHit[]): KbEvidenceRef[] {
   }));
 }
 
+/** 单文件条数封顶的多样化：保持检索排序，每个 (scope,path) 至多取 cap 条。 */
+export function diversifyHits(hits: MaterialHit[], cap: number, limit?: number): MaterialHit[] {
+  const counts = new Map<string, number>();
+  const out: MaterialHit[] = [];
+  for (const h of hits) {
+    if (limit != null && out.length >= limit) break;
+    const key = `${h.scope}\u0000${h.path}`;
+    const c = counts.get(key) || 0;
+    if (c >= cap) continue;
+    counts.set(key, c + 1);
+    out.push(h);
+  }
+  return out;
+}
+
+/** 回答文本是否真正引用了该证据锚点。优先全路径精确匹配；再容忍只用文件名 + `#chunk N`。 */
+export function isAnchorCited(answer: string, r: { path: string; chunkIdx: number }): boolean {
+  const exact = `${r.path}#chunk ${r.chunkIdx}`;
+  if (answer.includes(exact)) return true;
+  const base = r.path.slice(r.path.lastIndexOf('/') + 1);
+  return base !== r.path && answer.includes(`${base}#chunk ${r.chunkIdx}`);
+}
+
+/** 回答是否为明确的“未找到相关内容”声明。此时不挂引用 chips（没有支撑证据可展示）。 */
+export function isNotFoundAnswer(answer: string): boolean {
+  return /资料未说明|资料[中内]?未找到|未找到(任何|与|关于)?(相关)?(的)?(内容|资料|文档|文件|定义)|没有(找到|检索到)?(任何)?(与|关于)?.*(相关内容|相关资料)|未检索到|未查找到|未提供.*(定义|说明|内容)/.test(
+    String(answer || ''),
+  );
+}
+
+/** 从问题文本里识别“按文件名提问”的目标文件名（如 AST.pdf / 初中词汇.md）。 */
+export function detectTargetFilename(question: string): string | null {
+  const m = String(question || '').match(FILE_NAME_RE);
+  if (!m) return null;
+  let raw = m[1].trim();
+  raw = raw.replace(/^[`'"“”‘’([【\u300a]+|[`'"“”‘’)\]]*\u300b?[）)\]】]+$/g, '');
+  const base = raw.slice(raw.lastIndexOf('/') + 1).trim();
+  return base || null;
+}
+
+/** rel_path 是否在 dir 范围内（dir 为空 = 整库）。 */
+function isWithinScope(relPath: string, dir: string | null): boolean {
+  if (!dir) return true;
+  return relPath === dir || relPath.startsWith(`${dir}/`);
+}
+
+/** 顶层目录（rel_path 第一段）；根级文件返回 null。 */
+function topDirOf(relPath: string): string | null {
+  const idx = relPath.indexOf('/');
+  return idx > 0 ? relPath.slice(0, idx) : null;
+}
+
+function snippetOf(text: string): string {
+  const s = (text || '').trim();
+  return s.length <= 600 ? s : `${s.slice(0, 600)}…`;
+}
+
+/** 当前范围内、与文件名同名的 ready 文件（按 basename 不敏感匹配）。 */
+export function findReadyByBasename(uid: string, base: string, dir: string | null): string[] {
+  const want = base.toLowerCase();
+  return kbVector
+    .listFiles(uid)
+    .filter((f) => f.status === 'ready' && isWithinScope(f.rel_path, dir))
+    .filter((f) => f.rel_path.slice(f.rel_path.lastIndexOf('/') + 1).toLowerCase() === want)
+    .map((f) => f.rel_path);
+}
+
+/** 给目标文件前 N 个 chunk 做置顶候选（保证“按文件名提问”能命中该文件）。 */
+export function pinnedHitsForFile(uid: string, relPath: string): MaterialHit[] {
+  const chunks = kbVector.readFileChunks(uid, relPath) || [];
+  return chunks.slice(0, PIN_CHUNK_CAP).map((c) => ({
+    source: 'library' as const,
+    scope: 'global' as const,
+    path: relPath,
+    chunkIdx: c.chunk_idx,
+    title: c.title,
+    snippet: snippetOf(c.content),
+    score: PIN_SCORE,
+  }));
+}
+
+/** 跨库定位：文件名整库查找优先，其次整库语义检索；仅个人库目录场景使用。 */
+async function resolveCrossLibSuggestion(
+  userId: string,
+  input: { question: string; dir: string | null; spaceId?: string | null },
+): Promise<KbCrossLibSuggestion | null> {
+  const dir = input.dir;
+  if (!dir || input.spaceId) return null; // 整库提问没有“其它目录”；空间库本期不做
+  const question = String(input.question || '').trim();
+
+  // tier-1：按文件名在整库找，命中的顶层目录不同于当前目录 → 引导
+  const fname = detectTargetFilename(question);
+  if (fname) {
+    const want = fname.toLowerCase();
+    const others = kbVector
+      .listFiles(userId)
+      .filter((f) => f.status === 'ready' && f.rel_path.slice(f.rel_path.lastIndexOf('/') + 1).toLowerCase() === want)
+      .filter((f) => !isWithinScope(f.rel_path, dir));
+    if (others.length) {
+      const hit = others[0];
+      const top = topDirOf(hit.rel_path);
+      if (top) {
+        const chunks = kbVector.readFileChunks(userId, hit.rel_path) || [];
+        const first = chunks[0];
+        return {
+          dir: top,
+          path: hit.rel_path,
+          chunkIdx: first?.chunk_idx ?? 0,
+          snippet: first ? snippetOf(first.content) : '',
+        };
+      }
+    }
+  }
+
+  // tier-2：整库语义检索，取 top 命中做引导
+  try {
+    const res = await askMaterials({ userId, query: question, scope: 'global', k: 6 });
+    if (res.hasEvidence && res.hits.length) {
+      const best = res.hits[0];
+      if (best.scope === 'global') {
+        const top = topDirOf(best.path);
+        if (top && top !== dir) return { dir: top, path: best.path, chunkIdx: best.chunkIdx, snippet: best.snippet };
+      }
+    }
+  } catch (err) {
+    log.warn('cross-lib suggestion topic search failed', {
+      user_id: maskId(userId),
+      error: (err as Error).message,
+    });
+  }
+  return null;
+}
+
 export async function* kbAskStream(
   userId: string,
   input: KbAskInput,
@@ -86,6 +275,63 @@ export async function* kbAskStream(
     yield { type: 'error', text: 'empty question' };
     return;
   }
+  // 元问题（问助手会什么/你是谁等）：不走资料检索，直接给能力说明。
+  // 这类问题问的是助手自身，资料库里本就不该有“助手能力”条目。
+  if (META_QUESTION_RE.test(question)) {
+    yield { type: 'final', text: KB_META_ANSWER, evidence: [] };
+    return;
+  }
+  const dirScope =
+    typeof input.dir === 'string' && input.dir.trim()
+      ? input.dir.trim().replace(/^\/+|\/+$/g, '') || null
+      : null;
+
+  // 全库概览类问题：复用「AI 解析」能力（一句话总结 + 逐文档要点），
+  // 避免单点检索对“整个库讲什么”必然空手而归。
+  if (LIBRARY_OVERVIEW_RE.test(question)) {
+    try {
+      const kbSummaryMod = await import('./kb_summary');
+      const overview = await kbSummaryMod.kbSummarize(userId, {
+        dir: dirScope,
+        spaceId: input.spaceId || null,
+      }, {
+        complete: async (opts) => {
+          let txt = '';
+          let err = '';
+          for await (const e of deps.stream({
+            userId: opts.userId,
+            message: opts.message,
+            systemPrompt: opts.systemPrompt,
+            sessionId: opts.sessionId,
+          })) {
+            if (e.type === 'delta' && e.text) txt += e.text;
+            else if (e.type === 'error') { err = e.text || 'kb summary failed'; break; }
+          }
+          return { ok: !err && !!txt.trim(), text: txt, error: err };
+        },
+      });
+      const docs = Array.isArray(overview.docs) ? overview.docs : [];
+      let text = overview.oneLiner
+        ? `一句话概括：${overview.oneLiner}`
+        : '未能生成一句话总结。';
+      if (docs.length) {
+        const scope = dirScope ? `「${dirScope}」` : '个人知识库';
+        text += `\n\n${scope}当前共解析 ${docs.length} 份文档，例如：`;
+        text += `\n${docs.slice(0, 8).map((d, i) => `${i + 1}. ${d.name}${d.text ? `：${d.text}` : ''}`).join('\n')}`;
+      } else {
+        text += '\n\n（当前还没有可索引文档，导入资料后可再次总结。）';
+      }
+      yield { type: 'final', text, evidence: [] };
+      return;
+    } catch (err) {
+      log.warn('library-overview summary failed; falling back to normal retrieval', {
+        user_id: maskId(userId),
+        error: (err as Error).message,
+      });
+    }
+  }
+  const finalK = typeof input.k === 'number' && input.k > 0 ? Math.floor(input.k) : DEFAULT_K;
+  const dir = dirScope;
 
   let res;
   try {
@@ -94,7 +340,9 @@ export async function* kbAskStream(
       query: question,
       scope: input.spaceId ? 'space' : 'global',
       spaceId: input.spaceId || undefined,
-      k: typeof input.k === 'number' && input.k > 0 ? input.k : undefined,
+      dir: dir || undefined,
+      // 放宽候选集供“每文件封顶”多样化裁减；material-search 会 clamp 到 30。
+      k: Math.min(MAX_CANDIDATE_K, Math.max(finalK * 3, finalK)),
     });
   } catch (err) {
     log.warn('ask_materials failed', { user_id: maskId(userId), error: (err as Error).message });
@@ -102,17 +350,63 @@ export async function* kbAskStream(
     return;
   }
 
-  const evidence = toEvidenceRefs(res.hits);
+  // 按文件名提问且该文件在当前范围存在：置顶命中，避免检索不到文件本身。
+  const hadEvidenceBeforePin = res.hasEvidence;  const fname = detectTargetFilename(question);
+  const pinned: MaterialHit[] = fname
+    ? findReadyByBasename(userId, fname, dir).slice(0, DIVERSIFY_PER_FILE).flatMap((p) => pinnedHitsForFile(userId, p))
+    : [];
+  if (pinned.length && !hadEvidenceBeforePin) {
+    res = {
+      ...res,
+      hasEvidence: true,
+      reason: undefined,
+      hits: pinned,
+      summary: [...res.summary, `filename hit pinned: ${fname}`],
+    };
+  }
+  // 合并去重：pinned 优先；同 (path, chunkIdx) 只保留一次。
+  const merged: MaterialHit[] = [];
+  const seenKeys = new Set<string>();
+  for (const h of [...pinned, ...(res.hits || [])]) {
+    const key = `${h.scope}\u0000${h.path}\u0000${h.chunkIdx}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    merged.push(h);
+  }
 
   if (!res.hasEvidence) {
+    const weakEvidence = diversifyHits(res.hits, DIVERSIFY_PER_FILE, finalK);
+    log.info('kbqa retrieval observed', {
+      user_id: maskId(userId),
+      space: input.spaceId || null,
+      dir,
+      query: question.slice(0, 120),
+      has_evidence: false,
+      reason: res.reason || null,
+      hits: weakEvidence.map((h) => `${h.path}#chunk ${h.chunkIdx}@${h.score.toFixed(4)}`),
+    });
+    const suggestion = await resolveCrossLibSuggestion(userId, { question, dir, spaceId: input.spaceId });
     const text = res.reason === 'no_material'
-      ? '资料中未找到与问题相关的内容。可以补充资料后再问，或换个问法。'
+      ? '资料中未找到与问题相关的内容。我是只基于当前资料库回答的问答助手：可以把问题问得更具体（例如「某文件讲了什么」），或补充资料后再问。'
       : '找到的相关资料很弱，无法给出可靠回答。建议换个问法或补充资料。';
-    yield { type: 'final', text, noMaterial: true, reason: res.reason, evidence };
+    // 无资料/弱资料时回答本身是“未找到/存疑”声明，不挂“引用”chips。
+    yield { type: 'final', text, noMaterial: true, reason: res.reason, evidence: [], notFound: true, suggestion };
     return;
   }
 
-  const systemPrompt = `${KB_SYSTEM_PROMPT}\n\n${formatEvidence(res)}${await formatAttachments(userId, input.attachPaths)}${formatHistory(input.history)}`;
+  const chosen = diversifyHits(merged, DIVERSIFY_PER_FILE, finalK);
+  log.info('kbqa retrieval observed', {
+    user_id: maskId(userId),
+    space: input.spaceId || null,
+    dir,
+    query: question.slice(0, 120),
+    has_evidence: true,
+    candidates: merged.length,
+    hits: chosen.map((h) => `${h.path}#chunk ${h.chunkIdx}@${h.score.toFixed(4)}`),
+  });
+
+  const evidence = toEvidenceRefs(chosen);
+  const systemPrompt = `${KB_SYSTEM_PROMPT}\n\n${formatEvidence({ ...res, hits: chosen })}${await formatAttachments(userId, input.attachPaths)}${formatHistory(input.history)}`;
   let answer = '';
   try {
     for await (const event of deps.stream({
@@ -140,10 +434,42 @@ export async function* kbAskStream(
     return;
   }
 
+  // 引用口径：只把回答文本里真实出现的锚点当作“引用”；回答明确“未找到”时不挂
+  // chips（可附跨库 suggestion）；只有模型确实作答却没标任何锚点时才回退本次证据。
+  const cited = evidence.filter((r) => isAnchorCited(answer, r));
+  if (cited.length) {
+    yield { type: 'final', text: answer, evidence: cited };
+    return;
+  }
+  if (isNotFoundAnswer(answer)) {
+    const suggestion = await resolveCrossLibSuggestion(userId, { question, dir, spaceId: input.spaceId });
+    log.info('kb answer reports nothing found; suppressing citation chips', {
+      user_id: maskId(userId),
+      dir,
+      query: question.slice(0, 80),
+      suggestion_dir: suggestion?.dir || null,
+    });
+    yield { type: 'final', text: answer, evidence: [], notFound: true, suggestion };
+    return;
+  }
+  log.warn('kb answer carries no path#chunk anchors; falling back to retrieval evidence', {
+    user_id: maskId(userId),
+    dir,
+    query: question.slice(0, 80),
+  });
   yield { type: 'final', text: answer, evidence };
 }
 
-export const _internals = { toEvidenceRefs };
+export const _internals = {
+  toEvidenceRefs,
+  diversifyHits,
+  isAnchorCited,
+  isNotFoundAnswer,
+  detectTargetFilename,
+  findReadyByBasename,
+  pinnedHitsForFile,
+  topDirOf,
+};
 
 /** 多轮对话历史拼进 systemPrompt（只保留最近 6 轮，防上下文溢出）。 */
 function formatHistory(history?: Array<{ role: 'user' | 'assistant'; content: string }>): string {

--- a/src/main/features/kb_summary.ts
+++ b/src/main/features/kb_summary.ts
@@ -9,6 +9,12 @@
  * an error page (the renderer keeps the library usable).
  *
  * Read-only: never writes to chats / artifacts; one non-streaming LLM call.
+ *
+ * Single-shot & stateless: callers must run it against an ephemeral model session
+ * (see ipc 'kb.summary'), so a failed parse that the user retries never accumulates
+ * history that later triggers a ~30s context compaction on the next attempt. The
+ * LLM call is also hard-aborted when the timeout fires, so a stalled provider can't
+ * keep holding the model turn lock and silently delay later turns.
  */
 
 import { createHash } from 'node:crypto';
@@ -44,24 +50,37 @@ export interface KbSummaryDeps {
     message: string;
     systemPrompt: string;
     sessionId: string;
+    /** 超时中止信号：接线方应透传给 chatWithModel.abortSignal。 */
+    signal?: AbortSignal;
   }) => Promise<{ ok: boolean; text: string; error: string }>;
 }
 
-const CHUNKS_PER_FILE = 3;
-const CHUNK_CHAR_CAP = 400;
-const DOC_CHAR_CAP = 1200;
-const FILES_CAP = 12;
+const CHUNKS_PER_FILE = 2; // 每文件取前 N 个 chunk
+const CHUNK_CHAR_CAP = 300; // 每 chunk 截断字符
+const DOC_CHAR_CAP = 900; // 每文件拼进 prompt 的总字符上限
+const FILES_CAP = 10; // 单库最多纳入的文件数
 const CACHE_MAX = 50;
-/** LLM 单次解析超时（网络不可达/模型卡住时降级，避免 UI 无限等待） */
-const SUMMARY_LLM_TIMEOUT_MS = 45 * 1000;
+/** LLM 单次解析超时。先 abort 上游请求（释放模型 turn 锁、停止浪费生成）再降级，
+ *  避免 UI 无限"正在解析…"。120s 与 kb_mindmap 对齐，覆盖慢端点首字数十秒的真实完成时间。 */
+const SUMMARY_LLM_TIMEOUT_MS = 120 * 1000;
 
-/** 给 Promise 加超时：超时 reject（调用方 catch 后降级）。 */
-function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+/** 超时 + 中止：到点先 abort（真正停掉服务端生成、释放单飞模型锁），再以超时错误
+ *  reject。比"只 reject 不取消"干净——被掐断的请求不会继续占着模型锁拖慢后续调用。 */
+function withTimeout<T>(p: Promise<T>, ctrl: AbortController, ms: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const t = setTimeout(() => reject(new Error(`LLM timeout after ${ms}ms`)), ms);
+    const t = setTimeout(() => {
+      ctrl.abort();
+      reject(new Error(`LLM timeout after ${ms}ms`));
+    }, ms);
     p.then(
-      (v) => { clearTimeout(t); resolve(v); },
-      (e) => { clearTimeout(t); reject(e); },
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(t);
+        reject(e);
+      },
     );
   });
 }
@@ -198,15 +217,19 @@ async function kbSummarizeInner(
 
   const docLines = collectReadyDocLines(userId, { dir, spaceId });
 
+  const ctrl = new AbortController();
   try {
-    // LLM 调用加超时兜底：网络不可达/模型卡住时 45s 后降级，避免 UI 无限"正在解析…"
+    // 会话按单发无状态运行（接线方以 ephemeralSession 调用，见 ipc 'kb.summary'）：
+    // 不累积历史，避免失败重试后触发 ~30s 的上下文压缩。超时先 abort 再降级。
     const res = await withTimeout(
       deps.complete({
         userId,
         message: `请整理以下知识库文档要点：\n\n${docLines.join('\n\n')}`,
         systemPrompt: SUMMARY_SYSTEM_PROMPT,
         sessionId: `aside-kbsummary-${userId}`,
+        signal: ctrl.signal,
       }),
+      ctrl,
       SUMMARY_LLM_TIMEOUT_MS,
     );
     if (!res.ok) throw new Error(res.error || 'model failed');

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -4059,6 +4059,11 @@ const invokeHandlers: Record<string, InvokeHandler> = {
           message: opts.message,
           systemPrompt: opts.systemPrompt,
           sessionId: opts.sessionId,
+          // 单发无状态整理：不写/不复用持久 aside 会话——固定会话会累积历史，
+          // 失败重试后下一次要先跑 ~30s 上下文压缩再请求（见 kb_summary 头注）。
+          ephemeralSession: true,
+          // kb_summary 超时到点会先 abort：透传信号真正中止上游请求、释放模型 turn 锁。
+          ...(opts.signal ? { abortSignal: opts.signal } : {}),
           skillList: [],
           disableTools: true,
         });
@@ -4083,6 +4088,9 @@ const invokeHandlers: Record<string, InvokeHandler> = {
           message: opts.message,
           systemPrompt: opts.systemPrompt,
           sessionId: opts.sessionId,
+          // 单发无状态整理：不写/不复用持久 aside 会话——固定会话会累积历史，
+          // 失败重试后下一次要先跑 ~30s 上下文压缩再请求（kb.summary/kb.mindmap 同款）。
+          ephemeralSession: true,
           skillList: [],
           disableTools: true,
         });
@@ -5739,12 +5747,14 @@ const streamHandlers: Record<string, StreamHandler> = {
 
   // KB grounded Q&A (知识库模块 S2)：ask_materials 证据边界内流式回答。
   // 只读管线：不进主对话/群聊 bus，不写 chats；无资料时明说（no_material）。
-  'kbqa.askStream': async function* ({ space_id, question, k, attach_paths, history, model }, ctx, signal) {
+  'kbqa.askStream': async function* ({ space_id, dir, question, k, attach_paths, history, model }, ctx, signal) {
     const q = String(question ?? '').trim();
     if (!q) {
       yield { type: 'error', text: 'empty question' };
       return;
     }
+    // 渲染层传入当前所在个人库目录：空 = 整库检索；非空 = 只在该目录内检索。
+    const dirScoped = typeof dir === 'string' && dir.trim() ? dir.trim().replace(/^\/+|\/+$/g, '') || null : null;
     // 用户在问答框模型配置里选的模型（provider+model）；未传则走默认优先级组
     const mo = (model && typeof model === 'object' &&
       typeof (model as { provider?: unknown }).provider === 'string' &&
@@ -5756,6 +5766,7 @@ const streamHandlers: Record<string, StreamHandler> = {
     try {
       const events = kbQa.kbAskStream(ctx.userId, {
         spaceId: space_id ? String(space_id) : null,
+        dir: dirScoped,
         question: q,
         k: typeof k === 'number' ? k : undefined,
         attachPaths: Array.isArray(attach_paths) ? attach_paths.filter((p: unknown) => typeof p === 'string') : undefined,
@@ -5766,6 +5777,11 @@ const streamHandlers: Record<string, StreamHandler> = {
           message: opts.message,
           systemPrompt: opts.systemPrompt,
           sessionId: opts.sessionId,
+          // 单问无状态：kb-qa 的证据边界随目录/空间变化，持久 aside 会话会把
+          // 之前其它范围的检索内容"记忆"进来，导致回答引用越界内容（如本次
+          // 引用上轮别处检索到的 AST.pdf#chunk 61）。多轮上下文已由渲染层通过
+          // history 文本参数显式提供，不需要模型侧会话记忆。
+          ephemeralSession: true,
           // 只回答问题：不给工具、不进技能（disableTools 才是真正强制项）。
           skillList: [],
           disableTools: true,

--- a/src/main/model/core-agent/anchor-resolver.ts
+++ b/src/main/model/core-agent/anchor-resolver.ts
@@ -123,6 +123,13 @@ function pageForText(text: string, charStart: number): number | undefined {
   return page;
 }
 
+/** PDF chunk title（形如 p.7 / p.7-8 / Page 3）→ 起始页码。索引时已记录，最可靠。 */
+function pdfPageFromChunkTitle(title: string | null | undefined): number | undefined {
+  if (!title) return undefined;
+  const m = String(title).match(/(?:^|\D)(\d{1,4})(?:\D|$)/);
+  return m ? Number(m[1]) : undefined;
+}
+
 /**
  * Resolve a citation anchor to a character range in the source document.
  * Returns `resolved: false` (with a reason) instead of throwing when the
@@ -135,6 +142,8 @@ export async function resolveAnchor(target: AnchorTarget): Promise<AnchorLocatio
   // ── Resolve abs path + read the chunk text ─────────────────────────────
   let absPath: string;
   let chunkText: string | null = null;
+  // pdf chunk title（形如 p.7 / p.7-8）：chunk 级页码的最可靠来源
+  let chunkTitle: string | null = null;
 
   if (source === 'attachment') {
     if (!target.cid) return { resolved: false, reason: 'bad_input' };
@@ -147,11 +156,15 @@ export async function resolveAnchor(target: AnchorTarget): Promise<AnchorLocatio
     if (!target.spaceId) return { resolved: false, reason: 'bad_input' };
     absPath = path.join(spaceContextsDir(userId, target.spaceId), displayPath);
     const chunks = spaceLibrary.readFileChunks(userId, target.spaceId, displayPath);
-    chunkText = chunks.find((c) => c.chunk_idx === target.chunkIdx)?.content?.trim() ?? null;
+    const meta = chunks.find((c) => c.chunk_idx === target.chunkIdx);
+    chunkText = meta?.content?.trim() ?? null;
+    chunkTitle = meta?.title ?? null;
   } else {
     absPath = path.join(userContextsDir(userId), displayPath);
     const chunks = kb.readFileChunks(userId, displayPath);
-    chunkText = chunks.find((c) => c.chunk_idx === target.chunkIdx)?.content?.trim() ?? null;
+    const meta = chunks.find((c) => c.chunk_idx === target.chunkIdx);
+    chunkText = meta?.content?.trim() ?? null;
+    chunkTitle = meta?.title ?? null;
   }
 
   // ── Scope check: source must be inside its allowed root ────────────────
@@ -171,22 +184,35 @@ export async function resolveAnchor(target: AnchorTarget): Promise<AnchorLocatio
   // readRange: plain text reads the file directly; rich docs require an
   // existing file-indexer cache (NeedStatError → no_cache) and carry the
   // PDF page map.
-  let text: string;
+  let text: string | null = null;
   try {
     const read = await fileIndexer.readRange(userId, absPath, {});
     text = read.content;
   } catch (err) {
     const name = (err as Error).name || '';
-    if (name.includes('NeedStat')) {
+    if (name.includes('NeedStat') && source === 'library') {
+      // KB 向量索引与 file-indexer 缓存并不同步：富文档（pdf/docx/html 等）若
+      // 只经 kb 索引、从未走文件索引器，此处会 no_cache。此时用向量库按 chunk
+      // 顺序拼接整篇文本做降级定位——文本即 kb 索引时的提取结果，足以定位被
+      // 引用的段落；拼接为空（该文件确实无索引文本）才保持 no_cache。
+      const rows = scope === 'space'
+        ? spaceLibrary.readFileChunks(userId, target.spaceId!, displayPath)
+        : kb.readFileChunks(userId, displayPath);
+      const joined = (rows || []).map((c) => c.content || '').join('\n').trim();
+      if (!joined) return { resolved: false, reason: 'no_cache', absPath, displayPath };
+      text = joined;
+    } else if (name.includes('NeedStat')) {
       return { resolved: false, reason: 'no_cache', absPath, displayPath };
+    } else {
+      log.warn('anchor_resolver: extract failed', {
+        user_id: maskId(userId),
+        abs_path: displayPath,
+        error: (err as Error).message,
+      });
+      return { resolved: false, reason: 'no_text', absPath, displayPath };
     }
-    log.warn('anchor_resolver: extract failed', {
-      user_id: maskId(userId),
-      abs_path: displayPath,
-      error: (err as Error).message,
-    });
-    return { resolved: false, reason: 'no_text', absPath, displayPath };
   }
+  if (!text) return { resolved: false, reason: 'no_text', absPath, displayPath };
 
   const needle = target.quote?.trim() || chunkText;
   if (!needle) return { resolved: false, reason: 'not_found', absPath, displayPath };
@@ -196,7 +222,10 @@ export async function resolveAnchor(target: AnchorTarget): Promise<AnchorLocatio
     return { resolved: false, reason: 'not_found', absPath, displayPath, totalChars: text.length };
   }
 
-  const page = pageForText(text, located.start);
+  // 页优先取 file-indexer 文本里的 `--- page N ---`；拿不到再用向量库 pdf chunk
+  // title（p.N / p.N-M）兜底——不依赖 file-indexer 缓存是否已生成。
+  const isPdf = /\.pdf$/i.test(displayPath);
+  const page = pageForText(text, located.start) ?? (isPdf ? pdfPageFromChunkTitle(chunkTitle) : undefined);
   return {
     resolved: true,
     absPath,

--- a/src/renderer/modules/anchored-source-view.js
+++ b/src/renderer/modules/anchored-source-view.js
@@ -99,6 +99,13 @@
   }
 
   async function openAnchorViewer(anchor) {
+    // 整篇原文优先：library 源且 KB 工作台已提供整篇查看器桥 → 打开整篇并高亮/翻页
+    if (anchor && anchor.source !== 'attachment' && typeof window.__openKbSourceDocument === 'function') {
+      try {
+        const ok = await window.__openKbSourceDocument(anchor);
+        if (ok) return;
+      } catch (_) { /* 打开失败回落片段查看器 */ }
+    }
     const overlay = _ensureOverlay();
     overlay.hidden = false;
     _setMeta('定位中…');

--- a/src/renderer/modules/kb-workbench.js
+++ b/src/renderer/modules/kb-workbench.js
@@ -1195,9 +1195,11 @@
     _openFileViewer({ path: relPath }, _state.currentLib || '');
   }
 
-  // 打开原文查看 overlay：个人库传 {path}；共享空间库传 {spaceId, path}
-  async function _openFileViewer(payload, scopeName) {
+  // 打开原文查看 overlay：个人库传 {path}；共享空间库传 {spaceId, path}。
+  // opts?: { page?, quote? } —— 来自引用的定位信息：pdf 跳到 page、文本类按 quote 高亮。
+  async function _openFileViewer(payload, scopeName, opts) {
     const scope = scopeName || (payload && payload.spaceId ? payload.spaceId : '');
+    const hl = (opts && typeof opts === 'object') ? opts : null;
     let overlay = _ensureFileViewerOverlay();
     // 打开时恢复上次的窗口尺寸/位置（无记忆则 flex 居中）
     const dialog = overlay.querySelector('.kb-fv-dialog');
@@ -1221,7 +1223,7 @@
         if (typeof uiToast === 'function') uiToast('无法预览该文件', { variant: 'warning' });
         return;
       }
-      _setFileViewerState(overlay, { content: res, title: res.name || (payload && payload.path || '').split('/').pop(), scope });
+      _setFileViewerState(overlay, { content: res, title: res.name || (payload && payload.path || '').split('/').pop(), scope }, hl);
     } catch (err) {
       _setFileViewerState(overlay, {
         error: (err && err.message) || String(err),
@@ -1457,13 +1459,145 @@
       if (cur.lastZoom === pct) return;
       cur.lastZoom = pct;
       const base = String(cur.src || '').split('#')[0];
-      cur.el.src = `${base}#toolbar=1&navpanes=0&zoom=${pct}`;
+      const pagePart = cur.page ? `&page=${cur.page}` : '';
+      cur.el.src = `${base}#toolbar=1&navpanes=0${pagePart}&zoom=${pct}`;
     } else if (cur.el) {
       cur.el.style.zoom = String(_fvZoom);
     }
   }
 
-  function _setFileViewerState(overlay, st) {
+  // ── 整篇查看器高亮：在渲染文档里定位引用文本并包 <mark>（兼容 md 渲染差异）──
+  function _fvTextNodeList(root) {
+    const doc = (root && root.ownerDocument) || root;
+    if (!doc || !doc.createTreeWalker) return [];
+    const walker = doc.createTreeWalker(root, 4 /* SHOW_TEXT */);
+    const out = [];
+    let n;
+    while ((n = walker.nextNode())) out.push(n);
+    return out;
+  }
+  function _fvNormSpace(s) {
+    return String(s == null ? '' : s).replace(/\s+/g, ' ').trim();
+  }
+  function _fvWrapRaw(node, start, len) {
+    if (!node || !node.nodeValue) return null;
+    const end = Math.min(node.nodeValue.length, start + Math.max(len, 1));
+    if (start >= end) return null;
+    const doc = node.ownerDocument;
+    const range = doc.createRange();
+    range.setStart(node, start);
+    range.setEnd(node, end);
+    const mark = doc.createElement('mark');
+    mark.className = 'kb-fv-mark';
+    try { range.surroundContents(mark); } catch (_) { return null; }
+    return mark;
+  }
+  // 归一化后的索引 → 原始文本近似偏移（空白折叠为单个空格）
+  function _fvApproxRawStart(raw, normIdx) {
+    let p = 0;
+    let inWS = false;
+    for (let i = 0; i < raw.length; i++) {
+      const ws = /\s/.test(raw[i]);
+      if (ws) {
+        if (!inWS) { if (p === normIdx) return i; p++; inWS = true; }
+      } else {
+        inWS = false;
+        if (p === normIdx) return i;
+        p++;
+      }
+    }
+    return Math.max(0, raw.length - 1);
+  }
+  // 去掉行首 md 标记（标题/引用/无序与有序列表编号），便于与渲染后 DOM 比对
+  function _fvStripMdMarks(s) {
+    return String(s || '').split('\n').map((ln) => ln
+      .replace(/^\s*(?:#{1,6}[ \t]+|>[\t ]?|[-*+•][ \t]+|\d+[.、)][ \t]+|```+[^\n]*|~~~+)/, ''))
+      .join(' ');
+  }
+  // 高亮前最终清洗：行首标记 + 行内强调符 + 空白归一（与高亮实际使用一致）
+  function _fvCleanQuote(q) {
+    return _fvNormSpace(_fvStripMdMarks(q).replace(/\*\*|__|`/g, ''));
+  }
+  function _fvSignificantTokens(s) {
+    const seen = new Set();
+    const out = [];
+    String(s || '').split(/[^\p{L}\p{N}]+/u).forEach((t) => {
+      const c = (t || '').replace(/[^\p{L}\p{N}_-]/gu, '');
+      if (c && c.length >= 3 && !seen.has(c)) { seen.add(c); out.push(c); }
+    });
+    return out;
+  }
+  function _fvHighlightContainer(container, quote) {
+    if (!container || !quote) return false;
+    // 渲染后正文不含 ** ` 与列表序号/标题标记，先清洗再比对
+    const cleaned = _fvCleanQuote(quote);
+    if (!cleaned) return false;
+    const needles = [];
+    const push = (s) => {
+      const c = _fvNormSpace(s);
+      if (c && c.length >= 3 && !needles.includes(c)) needles.push(c);
+    };
+    push(cleaned.slice(0, 140));
+    if (cleaned.length > 140) push(cleaned.slice(0, 80));
+    const headSentence = (cleaned.match(/^[^\n。！？!?；;，,]{0,60}/) || [''])[0];
+    push(headSentence);
+    const root = container.nodeType === 9 ? container.body : container;
+    const nodes = _fvTextNodeList(root);
+    for (const needle of needles) {
+      const needleNorm = _fvNormSpace(needle);
+      for (const node of nodes) {
+        const raw = node.nodeValue || '';
+        if (!raw.trim()) continue;
+        const rawNorm = _fvNormSpace(raw);
+        const idx = rawNorm.indexOf(needleNorm);
+        let rawStart = -1;
+        if (idx >= 0) {
+          rawStart = _fvApproxRawStart(raw, idx);
+        } else {
+          const word = (needleNorm.match(/[\p{L}\p{N}][\p{L}\p{N}._-]{2,}/u) || [])[0];
+          if (!word) continue;
+          const w = raw.indexOf(word);
+          if (w < 0) continue;
+          rawStart = w;
+        }
+        if (rawStart < 0) continue;
+        const mark = _fvWrapRaw(node, rawStart, Math.min(needleNorm.length * 2 + 8, 200));
+        if (mark) {
+          try { mark.scrollIntoView({ block: 'center' }); } catch (_) { /* ignore */ }
+          return true;
+        }
+      }
+    }
+    // 单节点匹配失败（列表/加粗把一句话拆到多个节点）→ 块级兜底：高亮整段
+    const blocks = root.querySelectorAll ? Array.from(root.querySelectorAll('p,li,blockquote,h1,h2,h3,h4,h5,h6,pre,td,dd,dt,summary')) : [];
+    if (blocks.length) {
+      const tokens = _fvSignificantTokens(cleaned);
+      let best = null;
+      let bestScore = 0;
+      for (const b of blocks) {
+        const bn = _fvNormSpace(b.textContent || '');
+        if (!bn) continue;
+        let score = 0;
+        for (const t of tokens) if (bn.includes(t)) score++;
+        if (score > bestScore) { bestScore = score; best = b; }
+      }
+      if (best && bestScore >= 1) {
+        best.classList.add('kb-fv-block-mark');
+        try { best.scrollIntoView({ block: 'center' }); } catch (_) { /* ignore */ }
+        return true;
+      }
+    }
+    return false;
+  }
+  function _fvHighlightFrame(frame, quote) {
+    try {
+      const doc = frame.contentDocument;
+      if (doc && doc.body && quote) return _fvHighlightContainer(doc.body, quote);
+    } catch (_) { /* 跨域/未就绪 */ }
+    return false;
+  }
+
+  function _setFileViewerState(overlay, st, hl) {
     const loading = overlay.querySelector('#kb-fv-loading');
     const errorEl = overlay.querySelector('#kb-fv-error');
     const textEl = overlay.querySelector('#kb-fv-text');
@@ -1503,10 +1637,20 @@
       const bodyMd = String(c.content || '');
       mdEl.innerHTML = `<div class="markdown-body kb-fv-markdown">${typeof renderMarkdown === 'function' ? renderMarkdown(bodyMd) : _esc(bodyMd)}</div>`;
       _fvCur = { mode: 'md', el: mdEl };
+      if (hl && hl.quote) setTimeout(() => {
+        if (!_fvHighlightContainer(mdEl, hl.quote)) {
+          console.warn('[kb] highlight-miss', { kind: 'markdown', path: String(c.path || ''), quote: String(hl.quote).slice(0, 40) });
+        }
+      }, 60);
     } else if (c.kind === 'text') {
       textEl.hidden = false;
       textEl.textContent = String(c.content || '');
       _fvCur = { mode: 'text', el: textEl };
+      if (hl && hl.quote) setTimeout(() => {
+        if (!_fvHighlightContainer(textEl, hl.quote)) {
+          console.warn('[kb] highlight-miss', { kind: 'text', path: String(c.path || ''), quote: String(hl.quote).slice(0, 40) });
+        }
+      }, 60);
     } else if (c.kind === 'pdf') {
       // 原生 PDFium iframe（排版 100% 保持）：个人库 kb-file://kb/<rel>；
       // 空间库 kb-file://space/<spaceId>/<rel>（主进程已注册空间路由）
@@ -1516,13 +1660,14 @@
       const src = sid
         ? `kb-file://space/${encodeURIComponent(sid)}/${enc(rel)}`
         : `kb-file://kb/${enc(rel)}`;
+      const pagePart = hl && typeof hl.page === 'number' && hl.page > 0 ? `&page=${Math.floor(hl.page)}` : '';
       const frame = document.createElement('iframe');
       frame.className = 'kb-fv-frame kb-fv-frame--pdf';
-      frame.src = `${src}#toolbar=1&navpanes=0`;
+      frame.src = `${src}#toolbar=1&navpanes=0${pagePart}`;
       frame.title = String(c.name || rel);
       body.appendChild(frame);
       body.classList.add('kb-fv-body--frame');
-      _fvCur = { mode: 'pdf', el: frame, src, lastZoom: 100 };
+      _fvCur = { mode: 'pdf', el: frame, src, page: (hl && hl.page) || null, lastZoom: 100 };
     } else if (c.kind === 'office') {
       // docx/xlsx/pptx → 排版化 HTML 预览（主进程已包裹样式）。
       // sandbox 保持无脚本；allow-same-origin 让父页可对内部文档做 CSS zoom 缩放
@@ -1536,8 +1681,13 @@
       body.appendChild(frame);
       body.classList.add('kb-fv-body--frame');
       _fvCur = { mode: 'office', el: frame, src: _fvOfficeBlobUrl };
-      // iframe 就绪后再应用当前缩放（加载完成前 contentDocument 为 null）
+      // iframe 就绪后：应用缩放 + 尽力高亮引用段落（失败可见）
       frame.addEventListener('load', () => {
+        if (hl && hl.quote) setTimeout(() => {
+          if (!_fvHighlightFrame(frame, hl.quote)) {
+            console.warn('[kb] highlight-miss', { kind: 'office', path: String(c.path || ''), quote: String(hl.quote).slice(0, 40) });
+          }
+        }, 80);
         if (_fvCur && _fvCur.el === frame && _fvZoom !== 1) {
           try { frame.contentDocument.documentElement.style.zoom = String(_fvZoom); } catch (_) { /* ignore */ }
         }
@@ -1621,6 +1771,11 @@
       }
       .kb-fv-dialog--reader .kb-fv-body--frame { padding: 0; }
       .kb-fv-frame--office { background: #eef2f7; }
+      .kb-fv-mark { background: #ffe58a; color: inherit; padding: 0 1px; border-radius: 2px; scroll-margin-top: 64px; }
+      .kb-fv-block-mark {
+        background: rgba(255, 229, 138, .4); box-shadow: inset 3px 0 0 rgba(240, 173, 0, .75);
+        border-radius: 2px; scroll-margin-top: 64px;
+      }
     `;
     document.head.appendChild(style);
   }
@@ -1941,6 +2096,20 @@
       .catch(() => { /* 快照失败不阻塞展示；手动存档通道不受影响 */ });
   }
 
+  // 从“回答文本 → 脑图”记录快照到该回答消息（entry.mm），历史恢复时据此
+  // 把按钮标为「重新生成脑图」并在答案区内恢复预览，不再额外生成独立气泡。
+  function _recordAnswerMindmap(root, entry) {
+    if (!root || !root.label || !entry || !window.cogseed || typeof window.cogseed.invoke !== 'function') return;
+    const key = _mmSnapshotKey();
+    window.cogseed.invoke('kb.mindmap.save', { key, root })
+      .then((r) => {
+        if (!r || !r.ok) return;
+        entry.mm = { key, label: root.label, ts: Date.now() };
+        _qaSaveCurrentSession();
+      })
+      .catch(() => { /* 快照失败不阻塞展示 */ });
+  }
+
   // 从会话历史还原一条脑图消息：先占位，再按 key 异步读档渲染
   function _appendMindmapMessage(box, m) {
     const ai = document.createElement('div');
@@ -1958,6 +2127,30 @@
       return;
     }
     window.cogseed.invoke('kb.mindmap.load', { key: m.key })
+      .then((r) => {
+        if (!canvas) return;
+        if (!r || !r.ok || !r.root) {
+          canvas.innerHTML = '<div class="kb-mm-fail">脑图存档已失效（可能已被删除）</div>';
+          return;
+        }
+        const root = r.root;
+        _state.mmCollapsed.clear();
+        canvas.innerHTML = _mmTreeSvg(root, _state.mmCollapsed, _mmRenderOpts());
+        canvas._mmRoot = root;
+        _bindMindCanvas(canvas);
+      })
+      .catch(() => { if (canvas) canvas.innerHTML = '<div class="kb-mm-fail">脑图载入失败</div>'; });
+  }
+
+  // 历史恢复时，在答案的「重新生成脑图」按钮下方异步载入该答案已存的脑图快照
+  function _qaSnapshotInto(row, key) {
+    if (!row || !key || !window.cogseed || typeof window.cogseed.invoke !== 'function') return;
+    const holder = document.createElement('div');
+    holder.className = 'kb-mm-msg';
+    holder.innerHTML = '<div class="kb-wb-mm-canvas"><div class="kb-mm-loading">正在载入脑图…</div></div>';
+    row.appendChild(holder);
+    const canvas = holder.querySelector('.kb-wb-mm-canvas');
+    window.cogseed.invoke('kb.mindmap.load', { key })
       .then((r) => {
         if (!canvas) return;
         if (!r || !r.ok || !r.root) {
@@ -2027,18 +2220,20 @@
     box.scrollTop = box.scrollHeight;
   }
 
-  // 对话回答 → 脑图：基于本条回答文本生成（复用 kb.mindmap 的 text 参数）
-  function _genMindmapFromText(text, btn) {
+  // 对话回答 → 脑图：基于本条回答文本生成（复用 kb.mindmap 的 text 参数）。
+  // entry 是该回答在 qaHistory 里的消息对象：生成成功后把快照记到 entry.mm，
+  // 使该回答的按钮变为「重新生成脑图」（可覆盖式再生成）。
+  function _genMindmapFromText(text, btn, entry) {
     if (!text || !text.trim()) {
       if (typeof uiToast === 'function') uiToast('回答内容为空，无法生成脑图', { variant: 'warning' });
       return;
     }
     if (!window.cogseed || typeof window.cogseed.invoke !== 'function') return;
     const anchor = btn && btn.parentElement ? btn.parentElement : null;
-    // 防止重复生成：按钮下方已有预览则不再叠加
-    if (anchor && anchor.querySelector('.kb-wb-mm-canvas')) {
-      if (typeof uiToast === 'function') uiToast('已生成，点击脑图可打开预览', { variant: 'info' });
-      return;
+    // 覆盖式再生成：先移除该回答下已有的脑图预览，避免叠加
+    if (anchor) {
+      const old = anchor.querySelector('.kb-mm-msg');
+      if (old) old.remove();
     }
     btn.disabled = true;
     const holder = document.createElement('div');
@@ -2056,7 +2251,7 @@
           const retryBtn = canvas.querySelector('.kb-mm-retry-btn');
           if (retryBtn) retryBtn.addEventListener('click', () => {
             holder.remove();
-            _genMindmapFromText(text, btn);
+            _genMindmapFromText(text, btn, entry);
           });
           return;
         }
@@ -2067,7 +2262,11 @@
         canvas.innerHTML = _mmTreeSvg(res.root, _state.mmCollapsed, _mmRenderOpts());
         canvas._mmRoot = res.root;
         _bindMindCanvas(canvas);
-        if (res.source === 'generated') _mmRecordToHistory(res.root);
+        if (res.source === 'generated') {
+          btn.textContent = '🧠 重新生成脑图';
+          if (entry && typeof entry === 'object') _recordAnswerMindmap(res.root, entry);
+          else _mmRecordToHistory(res.root);
+        }
       })
       .catch(() => {
         btn.disabled = false;
@@ -2757,24 +2956,21 @@
   function _mmOpenSource(source, idx) {
     const name = String(source || '');
     if (!name) return;
-    if (typeof window.__openAnchorViewer === 'function') {
-      const candidates = [];
-      for (const f of (_state.spaceFiles || [])) if (f && f.path) candidates.push(String(f.path));
-      const walk = (n) => {
-        if (n && n.path) candidates.push(String(n.path));
-        for (const c of (n && n.children) || []) walk(c);
-      };
-      walk({ children: _state.tree });
-      const hit = candidates.find((p) => p.toLowerCase().endsWith(name.toLowerCase()));
-      if (hit) {
-        window.__openAnchorViewer({
-          source: _state.spaceId ? 'space' : 'library',
-          scope: _state.spaceId || 'global',
-          path: hit,
-          chunkIdx: 0,
-        });
-        return;
+    const candidates = [];
+    for (const f of (_state.spaceFiles || [])) if (f && f.path) candidates.push(String(f.path));
+    const walk = (n) => {
+      if (n && n.path) candidates.push(String(n.path));
+      for (const c of (n && n.children) || []) walk(c);
+    };
+    walk({ children: _state.tree });
+    const hit = candidates.find((p) => p.toLowerCase().endsWith(name.toLowerCase()));
+    if (hit) {
+      if (_state.spaceId) {
+        _openFileViewerForAnchor({ source: 'space', scope: 'space', spaceId: _state.spaceId, path: hit, chunkIdx: 0 });
+      } else {
+        _openFileViewerForAnchor({ source: 'library', scope: 'global', path: hit, chunkIdx: 0 });
       }
+      return;
     }
     if (typeof uiToast === 'function') uiToast(`未在知识库中找到来源文档：${name}`, { variant: 'warning' });
   }
@@ -3123,23 +3319,65 @@
     const s = _state.qaSessions.find((x) => x.id === id);
     if (!s) return;
     _state.qaSessionId = id;
-    _state.qaHistory = (s.msgs || []).map((m) => (
+    const migrated = (s.msgs || []).map((m) => (
       m && m.kind === 'mindmap'
         ? { role: m.role, content: m.content, kind: 'mindmap', key: m.key, label: m.label, ts: m.ts }
-        : { role: m.role, content: m.content }
+        : {
+            role: m.role,
+            content: m.content,
+            ...(Array.isArray(m.evidence) && m.evidence.length ? { evidence: m.evidence } : {}),
+            ...(m.mm && m.mm.key ? { mm: m.mm } : {}),
+          }
     ));
+    _state.qaHistory = migrated;
     _clearQa();
     const box = document.getElementById('kb-qa-messages');
     if (!box) return;
+    // 上一个 AI 回答（供老会话的独立脑图气泡就近挂回所属回答）
+    let prevAi = null;
+    const refreshAiMm = (ai) => {
+      const btn = ai.row.querySelector('.kb-qa-mm-btn');
+      if (btn) { btn.innerHTML = '🧠 重新生成脑图'; btn.title = '重新生成该回答的脑图'; }
+      if (ai.msg.mm && ai.msg.mm.key) _qaSnapshotInto(ai.row, ai.msg.mm.key);
+    };
+    let legacyAttached = false;
+    const nextMsgs = [];
     for (const m of _state.qaHistory) {
       if (m.kind === 'mindmap') {
+        // 老会话兼容：该脑图就近挂到它前面那条“还没有脑图”的回答，按钮变「重新生成脑图」
+        if (prevAi && prevAi.msg && !(prevAi.msg.mm && prevAi.msg.mm.key)) {
+          prevAi.msg.mm = { key: m.key, label: m.label || '', ts: m.ts };
+          refreshAiMm(prevAi);
+          legacyAttached = true;
+          continue; // 已并入该回答，不再作为独立气泡/历史条目
+        }
+        nextMsgs.push(m);
         _appendMindmapMessage(box, m);
         continue;
       }
+      nextMsgs.push(m);
       const el = document.createElement('div');
       el.className = m.role === 'user' ? 'kb-qa-msg is-user' : 'kb-qa-msg is-ai';
-      el.innerHTML = `<div class="kb-qa-msg-body">${_esc(m.content)}</div>`;
+      const body = document.createElement('div');
+      body.className = 'kb-qa-msg-body';
+      if (m.role === 'user') body.textContent = m.content || '';
+      else body.innerHTML = _decorateAnswerHtml(m.content || '');
+      el.appendChild(body);
+      prevAi = null;
+      // 历史恢复：AI 回答重建引用 chips 与「生成脑图/重新生成脑图」按钮
+      if (m.role === 'assistant') {
+        if (Array.isArray(m.evidence) && m.evidence.length) el.appendChild(_qaRefsElement(m.evidence));
+        const mmRow = _qaMmButtonRow(m.content || '', m);
+        el.appendChild(mmRow);
+        if (m.mm && m.mm.key) _qaSnapshotInto(mmRow, m.mm.key);
+        prevAi = { row: mmRow, msg: m };
+      }
       box.appendChild(el);
+    }
+    if (legacyAttached) {
+      // 老会话结构顺带迁移为“回答内联脑图”，持久化后下次直接按 mm 读取
+      _state.qaHistory = nextMsgs;
+      _qaSaveCurrentSession();
     }
     _maybeShowQaHint();
   }
@@ -3182,12 +3420,12 @@
         const gone = _state.qaSessions.find((x) => x.id === id);
         _state.qaSessions = _state.qaSessions.filter((x) => x.id !== id);
         if (_state.qaSessionId === id) { _state.qaSessionId = null; _state.qaHistory = []; _clearQa(); }
-        // 删除会话时同步清理其脑图快照存档（key 含 '#' 的条目）
+        // 删除会话时同步清理其脑图快照存档（kind='mindmap' 独立消息 + 答案内联 mm）
         if (gone && window.cogseed && typeof window.cogseed.invoke === 'function') {
           (gone.msgs || []).forEach((m) => {
-            if (m && m.kind === 'mindmap' && m.key) {
-              window.cogseed.invoke('kb.mindmap.delete', { key: m.key }).catch(() => { /* ignore */ });
-            }
+            if (!m) return;
+            const key = (m.kind === 'mindmap' && m.key) || (m.mm && m.mm.key);
+            if (key) window.cogseed.invoke('kb.mindmap.delete', { key }).catch(() => { /* ignore */ });
           });
         }
         _qaPersist();
@@ -3199,6 +3437,116 @@
     const d = new Date(Number(ts) || 0);
     if (isNaN(d.getTime())) return '';
     return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  }
+
+  function _copyText(text, okMsg) {
+    const done = () => {
+      if (typeof uiToast === 'function') uiToast(okMsg || '已复制', { variant: 'success', timeoutMs: 1500 });
+    };
+    const fallback = () => {
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        ta.remove();
+        done();
+      } catch { /* 复制失败静默 */ }
+    };
+    if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+      navigator.clipboard.writeText(text).then(done).catch(fallback);
+    } else fallback();
+  }
+
+  // 引用区 = 底部「资料来源」折叠区：路径等宽小字，行内不打断正文，机器/溯源用途
+  function _qaRefsElement(evidence) {
+    const box = document.createElement('div');
+    box.className = 'kb-qa-src';
+    const n = evidence.length;
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'kb-qa-src-toggle';
+    const list = document.createElement('div');
+    list.className = 'kb-qa-src-list';
+    list.hidden = true;
+    const setLabel = (open) => {
+      toggle.textContent = `资料来源 · ${n}${open ? ' ▴' : ' ▾'}`;
+      toggle.setAttribute('aria-expanded', String(open));
+    };
+    setLabel(false);
+    for (const r of evidence) {
+      const row = document.createElement('div');
+      row.className = 'kb-qa-src-row';
+      const pathBtn = document.createElement('button');
+      pathBtn.type = 'button';
+      pathBtn.className = 'kb-qa-src-path';
+      pathBtn.textContent = `${r.path}#chunk ${r.chunkIdx}`;
+      pathBtn.title = '跳转到原文';
+      pathBtn.addEventListener('click', () => _openAnchor(r));
+      const copy = document.createElement('button');
+      copy.type = 'button';
+      copy.className = 'kb-qa-src-copy';
+      copy.textContent = '⧉';
+      copy.title = '复制引用路径';
+      copy.setAttribute('aria-label', '复制引用路径');
+      copy.addEventListener('click', (e) => {
+        e.stopPropagation();
+        _copyText(`${r.path}#chunk ${r.chunkIdx}`, '已复制引用路径');
+      });
+      row.appendChild(pathBtn);
+      row.appendChild(copy);
+      list.appendChild(row);
+    }
+    toggle.addEventListener('click', () => {
+      list.hidden = !list.hidden;
+      setLabel(!list.hidden);
+    });
+    box.appendChild(toggle);
+    box.appendChild(list);
+    return box;
+  }
+
+  function _qaMmButtonRow(answerText, entry) {
+    const row = document.createElement('div');
+    row.className = 'kb-qa-mm-action';
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'kb-qa-mm-btn';
+    const hasMm = !!(entry && entry.mm && entry.mm.key);
+    btn.innerHTML = hasMm ? '🧠 重新生成脑图' : '🧠 生成脑图';
+    btn.title = hasMm ? '重新生成该回答的脑图' : '基于本条回答内容生成脑图';
+    btn.addEventListener('click', () => _genMindmapFromText(answerText, btn, entry));
+    row.appendChild(btn);
+    return row;
+  }
+
+  // AI 回答正文 → “人读友好”HTML：
+  //  - 剔除行内 `path#chunk N` 溯源锚点（统一收敛到底部「资料来源」区，正文不再打断）
+  //  - 渲染 **加粗** 与 `行内代码`
+  //  - 空行分段；`-`/编号列表结构化
+  function _decorateAnswerHtml(text) {
+    let t = String(text || '');
+    t = t
+      .replace(/`[^`\n]+?#chunk\s*\d+`/g, '') // 反引号包裹的完整锚点
+      .replace(/[^\s，。；：、！？?（）()【】"'“”‘’]+?#chunk\s*\d+/g, ''); // 裸锚点
+    let html = _esc(t);
+    html = html.replace(/(^|[^`])`([^`\n]+)`/g, '$1<code>$2</code>'); // 行内代码
+    html = html.replace(/\*\*([^*\n]+)\*\*/g, '<b>$1</b>'); // **加粗**
+    const blocks = html.split(/\n{2,}/);
+    return blocks.map((block) => {
+      const lines = block.split('\n');
+      const out = [];
+      for (const ln of lines) {
+        let m;
+        if ((m = ln.match(/^\s*[-*•]\s+(.*)$/))) out.push(`<div class="kb-a-li">${m[1] || ''}</div>`);
+        else if ((m = ln.match(/^\s*(\d+)[.、]\s+(.*)$/))) out.push(`<div class="kb-a-li is-num">${m[1]}. ${m[2] || ''}</div>`);
+        else if (ln.trim()) out.push(`<div class="kb-a-line">${ln}</div>`);
+      }
+      return out.length ? `<div class="kb-a-block">${out.join('')}</div>` : '';
+    }).join('');
   }
 
   function _ask(question) {
@@ -3278,6 +3626,8 @@
       const handle = window.cogseed.stream('kbqa.askStream', {
         question: q,
         space_id: _state.spaceId || null,
+        // 问答检索范围跟随当前所在个人库目录（与 AI 解析/脑图一致）；整库视图时为 null。
+        dir: _state.spaceId ? null : (_state.currentLib || null),
         k: 8,
         attach_paths: attachPaths,
         history: _state.qaHistory.filter((m) => m.kind !== 'mindmap').slice(0, -1),
@@ -3289,58 +3639,52 @@
         if (!ev) return;
         if (ev.type === 'delta' && ev.text) {
           text += ev.text;
-          streamBody.textContent = text;
+          streamBody.innerHTML = _decorateAnswerHtml(text);
           box.scrollTop = box.scrollHeight;
         } else if (ev.type === 'final') {
           ai.classList.remove('is-typing');
           text = ev.text || text;
-          streamBody.textContent = text;
-          // 多轮上下文：回答入 history + 持久化当前会话
-          _state.qaHistory.push({ role: 'assistant', content: text });
-          _qaSaveCurrentSession(q);
+          streamBody.innerHTML = _decorateAnswerHtml(text);
+          // 明确“未找到/无相关”结论 → 浅灰提示块，与有效信息做视觉隔离
+          if (ev.notFound) streamBody.classList.add('is-notfound');
+          // 多轮上下文：回答入 history + 持久化当前会话（AI 回答额外存引用锚点，
+          // 供“打开历史会话”时恢复引用 chips 与脑图按钮）
+          const asstMsg = { role: 'assistant', content: text };
+          _state.qaHistory.push(asstMsg);
           const evidence = Array.isArray(ev.evidence) ? ev.evidence : [];
           if (evidence.length) {
-            // 引用折叠（方案1）：默认只显示「引用(N)」按钮，点击展开全部锚点
-            const refs = document.createElement('div');
-            refs.className = 'kb-qa-refs';
-            const toggle = document.createElement('button');
-            toggle.type = 'button';
-            toggle.className = 'kb-qa-refs-toggle';
-            toggle.textContent = `引用(${evidence.length}) ▾`;
-            toggle.setAttribute('aria-expanded', 'false');
-            const list = document.createElement('div');
-            list.className = 'kb-qa-refs-list';
-            list.hidden = true;
-            for (const r of evidence) {
-              const chip = document.createElement('button');
-              chip.type = 'button';
-              chip.className = 'kb-qa-chip';
-              chip.textContent = `${r.path}#chunk ${r.chunkIdx} ↗`;
-              chip.title = '跳转到原文';
-              chip.addEventListener('click', () => _openAnchor(r));
-              list.appendChild(chip);
-            }
-            toggle.addEventListener('click', () => {
-              list.hidden = !list.hidden;
-              toggle.textContent = list.hidden ? `引用(${evidence.length}) ▾` : `引用(${evidence.length}) ▴`;
-              toggle.setAttribute('aria-expanded', String(!list.hidden));
-            });
-            refs.appendChild(toggle);
-            refs.appendChild(list);
-            streamBody.appendChild(refs);
+            // 精简持久化字段，控制 localStorage 体积（引用 chips/原文跳转只需这几项）
+            asstMsg.evidence = evidence.slice(0, 12).map((r) => ({
+              source: r.source || 'library',
+              scope: r.scope || 'global',
+              path: r.path,
+              chunkIdx: r.chunkIdx,
+            }));
+            streamBody.appendChild(_qaRefsElement(asstMsg.evidence));
           }
+          _qaSaveCurrentSession(q);
           // 每条 AI 回答末尾附「生成脑图」按钮：基于本条回答文本生成（不是整库）
-          const mmRow = document.createElement('div');
-          mmRow.className = 'kb-qa-mm-action';
-          const mmBtn = document.createElement('button');
-          mmBtn.type = 'button';
-          mmBtn.className = 'kb-qa-mm-btn';
-          mmBtn.innerHTML = '🧠 生成脑图';
-          mmBtn.title = '基于本条回答内容生成脑图';
-          const answerText = text;
-          mmBtn.addEventListener('click', () => _genMindmapFromText(answerText, mmBtn));
-          mmRow.appendChild(mmBtn);
-          streamBody.appendChild(mmRow);
+          streamBody.appendChild(_qaMmButtonRow(text, asstMsg));
+          // 未找到时跨库引导：内容在其它个人库目录 → 提供“前往该库提问”按钮
+          const sug = ev.suggestion;
+          if (sug && typeof sug.dir === 'string' && sug.dir && sug.path) {
+            const card = document.createElement('div');
+            card.className = 'kb-qa-suggest';
+            const txt = document.createElement('span');
+            txt.className = 'kb-qa-suggest-txt';
+            txt.innerHTML = `📁 当前库未找到，可能在「<b>${_esc(sug.dir)}</b>」：<code>${_esc(sug.path)}</code>`;
+            const goBtn = document.createElement('button');
+            goBtn.type = 'button';
+            goBtn.className = 'kb-qa-suggest-btn';
+            goBtn.textContent = '前往该库提问';
+            goBtn.addEventListener('click', () => {
+              if (_state.currentLib !== sug.dir) _selectLib(sug.dir);
+              _ask(q);
+            });
+            card.appendChild(txt);
+            card.appendChild(goBtn);
+            streamBody.appendChild(card);
+          }
           box.scrollTop = box.scrollHeight;
         } else if (ev.type === 'error') {
           ai.classList.remove('is-typing');
@@ -3354,7 +3698,51 @@
     }
   }
 
+  // 引用 → 整篇原文（与“在文件夹/列表中打开”同一查看器）：
+  // 先尝试 anchor.resolve 拿 page/quote 用于跳页/高亮；失败也照常打开整篇。
+  async function _openFileViewerForAnchor(anchor) {
+    if (!anchor || typeof anchor.path !== 'string' || !anchor.path) return false;
+    const isSpace = anchor.source === 'space' || anchor.scope === 'space';
+    const spaceId = isSpace ? String(anchor.spaceId || '') : '';
+    if (isSpace && !spaceId) {
+      if (typeof uiToast === 'function') uiToast('缺少空间信息，无法打开原文', { variant: 'warning' });
+      return false;
+    }
+    let hl = null;
+    try {
+      if (window.cogseed && typeof window.cogseed.invoke === 'function') {
+        const loc = await window.cogseed.invoke('cogseed.anchor.resolve', {
+          source: isSpace ? 'space' : 'library',
+          scope: isSpace ? 'space' : 'global',
+          path: anchor.path,
+          chunkIdx: typeof anchor.chunkIdx === 'number' ? anchor.chunkIdx : 0,
+          ...(isSpace ? { spaceId } : {}),
+          ...(typeof anchor.quote === 'string' && anchor.quote.trim() ? { quote: anchor.quote } : {}),
+        });
+        if (loc && loc.resolved) {
+          hl = {};
+          if (typeof loc.page === 'number' && loc.page > 0) hl.page = loc.page;
+          const quote = String(loc.text || '').slice(0, 220).trim();
+          if (quote) hl.quote = quote;
+        }
+      }
+    } catch (_) { /* 定位失败不阻断打开整篇 */ }
+    const payload = isSpace ? { spaceId, path: anchor.path } : { path: anchor.path };
+    try {
+      await _openFileViewer(payload, isSpace ? spaceId : '', hl);
+      return true;
+    } catch (_) {
+      if (typeof uiToast === 'function') uiToast('打开原文失败', { variant: 'error' });
+      return false;
+    }
+  }
+
   function _openAnchor(ref) {
+    // library（个人库/空间库）引用 → 打开整篇原文并高亮/翻页；attachment 等回落片段查看器
+    if (ref && ref.source !== 'attachment' && (ref.scope === 'global' || ref.scope === 'space')) {
+      _openFileViewerForAnchor(ref);
+      return;
+    }
     if (typeof window.__openAnchorViewer === 'function') {
       window.__openAnchorViewer({
         source: ref.source || 'library',
@@ -5260,4 +5648,23 @@
   }
 
   window.renderKbWorkbench = renderKbWorkbench;
+
+  // 高亮纯函数（供渲染层回归测试锁定清洗/分词逻辑）
+  window.__kbFvUtils = {
+    stripMdMarks: _fvStripMdMarks,
+    cleanQuote: _fvCleanQuote,
+    normSpace: _fvNormSpace,
+    significantTokens: _fvSignificantTokens,
+  };
+
+  // 整篇原文打开桥（供 KB 面板外的引用点击复用，如 chat-citation）：
+  // 返回 true = 已交给整篇查看器；false = 请回落片段查看器。
+  window.__openKbSourceDocument = function openKbSourceDocument(anchor) {
+    if (!anchor || anchor.source === 'attachment') return Promise.resolve(false);
+    try {
+      return Promise.resolve(_openFileViewerForAnchor(anchor));
+    } catch (_) {
+      return Promise.resolve(false);
+    }
+  };
 })();

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -30141,6 +30141,25 @@ body.kb-wb-resizing .kb-wb-divider { z-index: var(--z-popover); }
 .kb-qa-mm-action .kb-wb-mm-canvas { border: 1px solid var(--kb-border); border-radius: 10px; background: #fff; min-height: 90px; cursor: pointer; }
 .kb-qa-mm-action .kb-mm-loading { color: var(--kb-muted, #9DB4A6); font-size: 12px; padding: 26px 16px; text-align: center; }
 .kb-qa-mm-action .kb-mm-fail { color: var(--kb-danger, #C0392B); font-size: 12px; padding: 26px 16px; text-align: center; }
+/* 未找到时的跨库引导卡片（前往对应个人库目录并自动重问） */
+.kb-qa-suggest {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px 12px;
+  margin-top: 12px; padding: 8px 10px;
+  border: 1px dashed rgba(217, 119, 6, .45); border-radius: 8px;
+  background: rgba(217, 119, 6, .07);
+  font-size: 12px; color: var(--kb-muted, #9DB4A6);
+}
+.kb-qa-suggest-txt b { color: var(--kb-fg-2, #35513F); }
+.kb-qa-suggest-txt code {
+  font-size: 11px; color: var(--kb-fg-2, #35513F);
+  background: rgba(14, 159, 110, .08); border-radius: 4px; padding: 0 4px;
+}
+.kb-qa-suggest-btn {
+  font-size: 12px; color: #fff; background: var(--kb-green, #0E9F6E);
+  border: 1px solid transparent; border-radius: 8px; padding: 4px 14px; cursor: pointer;
+  transition: background .15s;
+}
+.kb-qa-suggest-btn:hover { background: var(--kb-green-strong, #0C8A5F); }
 .kb-qa-refs-toggle {
   font-size: 12px; color: var(--kb-accent); background: var(--kb-accent-weak);
   border: 1px solid var(--kb-blue-line); border-radius: 8px; padding: 4px 12px; cursor: pointer;
@@ -31340,3 +31359,99 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   background: #F7F9F7; font-size: 13px; color: #1F2A24; outline: none; box-sizing: border-box;
 }
 .kb-share-config-input:focus { border-color: var(--color-brand, #0E9F6E); background: #fff; }
+
+/* ── KB 问答回答卡视觉分层（评审改版：正文给人看，引用给溯源，操作主按钮化）── */
+/* 正文阅读：加大行高，降低密度 */
+.kb-qa-msg.is-ai .kb-qa-msg-body { line-height: 1.6; }
+.kb-qa-msg.is-ai .kb-qa-msg-body p { margin: 6px 0; }
+
+/* 明确“未找到/无相关”结论：浅灰提示块，和有效信息隔离 */
+.kb-qa-msg.is-ai .kb-qa-msg-body.is-notfound {
+  background: #f7f8fa; color: #666; border-style: dashed;
+  border-color: var(--kb-border, #DDE4DD);
+}
+
+/* 资料来源折叠区：与正文/操作区分割开 */
+.kb-qa-src {
+  margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--kb-border, #DDE4DD);
+}
+.kb-qa-src-toggle {
+  font-size: 11.5px; color: #888; background: transparent; border: none; padding: 2px 0;
+  cursor: pointer; letter-spacing: .2px; user-select: none;
+}
+.kb-qa-src-toggle:hover { color: var(--kb-accent, #2F6FED); }
+.kb-qa-src-list { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
+.kb-qa-src-list[hidden] { display: none; }
+.kb-qa-src-row {
+  display: flex; align-items: center; gap: 6px; min-width: 0;
+}
+.kb-qa-src-path {
+  flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px; color: #666; text-align: left;
+  background: transparent; border: none; padding: 1px 2px; cursor: pointer; border-radius: 4px;
+}
+.kb-qa-src-path:hover { color: var(--kb-accent, #2F6FED); background: rgba(47, 111, 237, .06); }
+.kb-qa-src-copy {
+  flex: none; width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center;
+  font-size: 11px; color: #999; background: transparent; border: none; cursor: pointer; border-radius: 4px;
+  opacity: 0; transition: opacity .12s, color .12s;
+}
+.kb-qa-src-row:hover .kb-qa-src-copy { opacity: 1; }
+.kb-qa-src-copy:hover { color: var(--kb-accent, #2F6FED); background: rgba(47, 111, 237, .08); }
+
+/* 「生成脑图」主操作按钮：主题色填充，与引用区拉开间距 */
+.kb-qa-mm-btn {
+  background: var(--kb-green, #0E9F6E); border-color: transparent; color: #fff;
+  box-shadow: 0 1px 3px rgba(14, 159, 110, .25);
+}
+.kb-qa-mm-btn:hover:not(:disabled) { background: #0C8A5F; color: #fff; }
+.kb-qa-mm-btn:disabled { background: #B9D8C9; color: #fff; box-shadow: none; }
+.kb-qa-mm-action { margin-top: 14px; padding-top: 10px; border-top: 1px solid var(--kb-border, #E4EAE4); }
+.kb-qa-mm-action .kb-mm-msg { margin-top: 12px; }
+
+/* ── AI 解析卡（同样分层：结论/文档/来源）── */
+.kb-wb-one-liner {
+  display: flex; gap: 8px; align-items: flex-start; padding: 10px 12px;
+  background: #f7f8fa; border: 1px solid var(--kb-border, #E4EAE4);
+  border-radius: 10px; margin-bottom: 14px; line-height: 1.6;
+}
+.kb-wb-one-liner-tag {
+  flex: none; font-size: 11.5px; padding: 2px 8px; border-radius: 999px;
+  background: rgba(14, 159, 110, .12); color: var(--kb-green, #0E9F6E);
+  white-space: nowrap; align-self: flex-start;
+}
+.kb-wb-one-liner-text { font-size: 13px; color: #44554C; }
+.kb-wb-doc {
+  background: #fff; border: 1px solid var(--kb-border, #E4EAE4);
+  border-radius: 10px; padding: 10px 12px; margin-bottom: 8px;
+}
+.kb-wb-doc-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
+.kb-wb-doc-name { font-weight: 600; font-size: 13px; color: var(--kb-text, #22372B); }
+.kb-wb-doc-text { margin-top: 6px; font-size: 12.5px; color: #66756C; line-height: 1.6; }
+.kb-wb-analysis-body .kb-qa-chip {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10.5px; color: #888; background: transparent;
+  border: 1px solid var(--kb-border, #E4EAE4); border-radius: 6px;
+  max-width: 320px;
+}
+.kb-wb-analysis-body .kb-qa-chip:hover { color: var(--kb-accent, #2F6FED); border-color: rgba(47, 111, 237, .4); }
+
+/* AI 回答正文“人读友好”排版：结构分块 + 行间距 + 列表缩进 */
+.kb-qa-msg.is-ai .kb-qa-msg-body { white-space: normal; overflow-wrap: break-word; }
+.kb-qa-msg.is-ai .kb-qa-msg-body b { font-weight: 600; color: var(--kb-text, #22372B); }
+.kb-qa-msg.is-ai .kb-qa-msg-body code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .92em; color: #35513F;
+  background: rgba(14, 159, 110, .1); border-radius: 4px; padding: 0 4px;
+}
+.kb-qa-msg.is-ai .kb-qa-msg-body .kb-a-block { margin: 7px 0; }
+.kb-qa-msg.is-ai .kb-qa-msg-body .kb-a-line { line-height: 1.6; margin: 2px 0; }
+.kb-qa-msg.is-ai .kb-qa-msg-body .kb-a-li {
+  position: relative; padding-left: 17px; margin: 2px 0; line-height: 1.6; color: var(--kb-text, #22372B);
+}
+.kb-qa-msg.is-ai .kb-qa-msg-body .kb-a-li::before {
+  content: '•'; position: absolute; left: 3px; color: var(--kb-green, #0E9F6E);
+}
+.kb-qa-msg.is-ai .kb-qa-msg-body .kb-a-li.is-num { padding-left: 0; }
+.kb-qa-msg.is-ai .kb-qa-msg-body .kb-a-li.is-num::before { content: none; }

--- a/test/main/features/kb_qa.test.ts
+++ b/test/main/features/kb_qa.test.ts
@@ -12,10 +12,24 @@ vi.mock('../../../src/main/model/core-agent/ask-materials', () => ({
   formatEvidence: (result: any) => `ask_materials (evidence: ${(result.hits || []).length})`,
 }));
 
+vi.mock('../../../src/main/features/kb_vector', () => ({
+  listFiles: vi.fn(() => []),
+  readFileChunks: vi.fn(() => []),
+}));
+
+vi.mock('../../../src/main/features/kb_summary', () => ({
+  kbSummarize: vi.fn(),
+}));
+
 import { kbAskStream, _internals } from '../../../src/main/features/kb_qa';
 import { askMaterials } from '../../../src/main/model/core-agent/ask-materials';
+import * as kbVector from '../../../src/main/features/kb_vector';
+import { kbSummarize } from '../../../src/main/features/kb_summary';
 
 const askMaterialsMock = vi.mocked(askMaterials);
+const kbSummarizeMock = vi.mocked(kbSummarize);
+const listFilesMock = vi.mocked(kbVector.listFiles);
+const readChunksMock = vi.mocked(kbVector.readFileChunks);
 
 function collect(gen: AsyncGenerator<any>) {
   const events: any[] = [];
@@ -38,6 +52,10 @@ const HIT = {
 
 beforeEach(() => {
   askMaterialsMock.mockReset();
+  listFilesMock.mockReset();
+  readChunksMock.mockReset();
+  kbSummarizeMock.mockReset();
+  kbSummarizeMock.mockResolvedValue({ docs: [], oneLiner: '', source: 'degraded', fingerprint: 'fp' });
 });
 
 describe('kb_qa kbAskStream', () => {
@@ -45,6 +63,42 @@ describe('kb_qa kbAskStream', () => {
     const events = await collect(kbAskStream('u1', { question: '  ' }, { stream: fakeStream() } as any));
     expect(events).toEqual([{ type: 'error', text: 'empty question' }]);
     expect(askMaterialsMock).not.toHaveBeenCalled();
+  });
+
+  it('answers meta questions about the assistant itself without retrieval', async () => {
+    const events = await collect(kbAskStream('u1', { question: '你会干什么？' }, { stream: fakeStream() } as any));
+    const final = events[events.length - 1];
+    expect(final.type).toBe('final');
+    expect(final.text).toContain('知识库问答助手');
+    expect(final.notFound).toBeFalsy();
+    expect(askMaterialsMock).not.toHaveBeenCalled();
+    const events2 = await collect(kbAskStream('u1', { question: '你能做什么' }, { stream: fakeStream() } as any));
+    expect(events2[events2.length - 1].text).toContain('知识库问答助手');
+  });
+
+  it('answers library-overview questions via kb.summary instead of retrieval', async () => {
+    kbSummarizeMock.mockResolvedValue({
+      docs: [
+        { name: 'a.pdf', file: 'a.pdf', text: '班级建设要点' },
+        { name: 'b.md', file: 'b.md', text: '复盘记录' },
+      ],
+      oneLiner: '这个库主要沉淀班级建设与复盘资料。',
+      source: 'generated',
+      fingerprint: 'fp',
+    } as any);
+    const stream = fakeStream('x');
+    const events = await collect(kbAskStream('u1', { question: '这个知识库讲的什么', dir: '班级建设资料' }, { stream } as any));
+    const final = events[events.length - 1];
+    expect(final.type).toBe('final');
+    expect(final.text).toContain('一句话概括：这个库主要沉淀班级建设与复盘资料。');
+    expect(final.text).toContain('班级建设资料');
+    expect(final.text).toContain('a.pdf');
+    expect(askMaterialsMock).not.toHaveBeenCalled();
+    expect(kbSummarizeMock).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ dir: '班级建设资料' }),
+      expect.any(Object),
+    );
   });
 
   it('says plainly there is no material instead of fabricating', async () => {
@@ -131,6 +185,75 @@ describe('kb_qa kbAskStream', () => {
       fsMod.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  it('scopes retrieval to the current personal-library dir', async () => {
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: true, hits: [HIT], query: 'q', summary: ['evidence ready'],
+    } as any);
+    const stream = fakeStream('ok');
+    await collect(kbAskStream('u1', { question: 'q', dir: '归档测试/子目录' }, { stream } as any));
+    expect(askMaterialsMock).toHaveBeenCalledWith(expect.objectContaining({
+      dir: '归档测试/子目录',
+      scope: 'global',
+    }));
+    // 候选集放宽：至少 finalK*3，供每文件封顶后裁回 k 条
+    expect(askMaterialsMock).toHaveBeenCalledWith(expect.objectContaining({ k: 24 }));
+  });
+
+  it('caps evidence at two chunks per file and spans sources', async () => {
+    const mk = (file: string, chunkIdx: number, score: number) => ({
+      source: 'library', scope: 'global', path: file, chunkIdx, snippet: 's', score,
+    });
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: true,
+      hits: [
+        mk('a.md', 1, 0.05), mk('a.md', 2, 0.04), mk('a.md', 3, 0.03),
+        mk('b.md', 1, 0.02), mk('c.md', 1, 0.01),
+      ],
+      query: 'q', summary: ['evidence ready'],
+    } as any);
+    const stream = fakeStream('ok');
+    const events = await collect(kbAskStream('u1', { question: 'q' }, { stream } as any));
+    const final = events[events.length - 1];
+    const files = final.evidence.map((e: { path: string }) => e.path);
+    expect(files.filter((f: string) => f === 'a.md')).toHaveLength(2); // 每文件 ≤2
+    expect(files).toContain('b.md');
+    expect(files).toContain('c.md');
+  });
+
+  it('keeps only anchors that actually appear in the answer text', async () => {
+    const bHit = { ...HIT, path: 'notes/b.md', chunkIdx: 1, score: 0.03 };
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: true, hits: [HIT, bHit], query: 'q', summary: ['evidence ready'],
+    } as any);
+    // 回答只引用 b.md 的锚点 → 引用只显示 b，a 被剔除
+    const stream = fakeStream('根据 ', 'notes/b.md#chunk 1', ' 的回答。');
+    const events = await collect(kbAskStream('u1', { question: 'q' }, { stream } as any));
+    const final = events[events.length - 1];
+    expect(final.evidence.map((e: { path: string }) => e.path)).toEqual(['notes/b.md']);
+  });
+
+  it('falls back to full retrieval evidence when the answer cites nothing', async () => {
+    const bHit = { ...HIT, path: 'notes/b.md', chunkIdx: 1, score: 0.03 };
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: true, hits: [HIT, bHit], query: 'q', summary: ['evidence ready'],
+    } as any);
+    const stream = fakeStream('回答里一个锚点都没标。');
+    const events = await collect(kbAskStream('u1', { question: 'q' }, { stream } as any));
+    const final = events[events.length - 1];
+    expect(final.evidence.map((e: { path: string }) => e.path)).toEqual(['notes/a.md', 'notes/b.md']);
+  });
+
+  it('suppresses citation chips when the answer says nothing was found', async () => {
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: true, hits: [HIT], query: 'q', summary: ['evidence ready'],
+    } as any);
+    // 目录内只检索到无关弱命中：模型如实说“未找到”，不应把该命中当“引用”展示
+    const stream = fakeStream('资料中未找到任何与 AST.pdf 相关的内容，仅检索到 notes/a.md，但无关。');
+    const events = await collect(kbAskStream('u1', { question: 'AST.pdf 讲了什么' }, { stream } as any));
+    const final = events[events.length - 1];
+    expect(final.evidence).toEqual([]);
+  });
 });
 
 describe('kb_qa multi-turn history', () => {
@@ -149,5 +272,78 @@ describe('kb_qa multi-turn history', () => {
     const opts = stream.mock.calls[0][0] as { systemPrompt: string };
     expect(opts.systemPrompt).toContain('用户：第一问');
     expect(opts.systemPrompt).toContain('助手：第一答');
+  });
+});
+
+describe('kb_qa filename-target & cross-lib suggestion', () => {
+  const ready = (rel: string) => ({
+    id: 1, rel_path: rel, kind: 'text', bytes: 10, mtime: 1, sha1: rel,
+    status: 'ready', error: null, chunks: 2, created_at: 0, updated_at: 0,
+  });
+
+  it('detects a target filename in the question', () => {
+    expect(_internals.detectTargetFilename('AST.pdf 讲了什么？')).toBe('AST.pdf');
+    expect(_internals.detectTargetFilename('《初中词汇-8词-真实试跑.md》内容')).toBe('初中词汇-8词-真实试跑.md');
+    expect(_internals.detectTargetFilename('什么是向量检索')).toBeNull();
+  });
+
+  it('pins an in-scope file when vector search misses the filename', async () => {
+    listFilesMock.mockReturnValue([ready('from-tasks/sub/AST.pdf')] as any);
+    readChunksMock.mockImplementation((_u: string, rel: string) =>
+      (rel.endsWith('AST.pdf') ? [{ chunk_idx: 3, title: null, content: 'AST 解析器相关内容……' }] : []) as any);
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: false, reason: 'no_material', hits: [], query: 'q', summary: [],
+    } as any);
+    const stream = fakeStream('根据 from-tasks/sub/AST.pdf#chunk 3，这是 AST 解析器的说明。');
+    const events = await collect(kbAskStream('u1', { question: 'AST.pdf 讲了什么', dir: 'from-tasks' }, { stream } as any));
+    const final = events[events.length - 1];
+    expect(final.noMaterial).toBeUndefined();
+    expect(final.evidence).toEqual([expect.objectContaining({ path: 'from-tasks/sub/AST.pdf', chunkIdx: 3 })]);
+    expect(final.suggestion).toBeFalsy();
+  });
+
+  it('suggests another personal dir when the file lives there', async () => {
+    listFilesMock.mockReturnValue([ready('归档测试/AST.pdf')] as any);
+    readChunksMock.mockImplementation((_u: string, rel: string) =>
+      (rel.endsWith('AST.pdf') ? [{ chunk_idx: 0, title: null, content: 'AST 解析器' }] : []) as any);
+    askMaterialsMock.mockResolvedValue({
+      hasEvidence: false, reason: 'no_material', hits: [], query: 'q', summary: [],
+    } as any);
+    const stream = fakeStream('ok');
+    const events = await collect(kbAskStream('u1', { question: 'AST.pdf 讲了什么', dir: 'from-tasks' }, { stream } as any));
+    const final = events[events.length - 1];
+    expect(final.evidence).toEqual([]);
+    expect(final.noMaterial).toBe(true);
+    expect(final.suggestion).toMatchObject({ dir: '归档测试', path: '归档测试/AST.pdf' });
+  });
+
+  it('falls back to whole-library topic search for a non-filename question', async () => {
+    listFilesMock.mockReturnValue([] as any);
+    readChunksMock.mockReturnValue([] as any);
+    askMaterialsMock
+      .mockResolvedValueOnce({ hasEvidence: false, reason: 'no_material', hits: [], query: 'q', summary: [] } as any)
+      .mockResolvedValueOnce({
+        hasEvidence: true,
+        hits: [{ source: 'library', scope: 'global', path: '归档测试/AST.pdf', chunkIdx: 5, snippet: 'AST 解析', title: null, score: 0.02 }],
+        query: 'q', summary: ['evidence ready'],
+      } as any);
+    const stream = fakeStream('ok');
+    const events = await collect(kbAskStream('u1', { question: '讲讲括号平衡的语义不变量', dir: 'from-tasks' }, { stream } as any));
+    const final = events[events.length - 1];
+    expect(final.suggestion).toMatchObject({ dir: '归档测试', path: '归档测试/AST.pdf', chunkIdx: 5 });
+    expect(askMaterialsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns no suggestion when nothing exists anywhere', async () => {
+    listFilesMock.mockReturnValue([] as any);
+    readChunksMock.mockReturnValue([] as any);
+    askMaterialsMock
+      .mockResolvedValueOnce({ hasEvidence: false, reason: 'no_material', hits: [], query: 'q', summary: [] } as any)
+      .mockResolvedValueOnce({ hasEvidence: false, reason: 'no_material', hits: [], query: 'q', summary: [] } as any);
+    const stream = fakeStream('ok');
+    const events = await collect(kbAskStream('u1', { question: '完全不存在的东西', dir: 'from-tasks' }, { stream } as any));
+    const final = events[events.length - 1];
+    expect(final.noMaterial).toBe(true);
+    expect(final.suggestion).toBeNull();
   });
 });

--- a/test/main/model/core-agent/anchor-resolver.test.ts
+++ b/test/main/model/core-agent/anchor-resolver.test.ts
@@ -142,6 +142,37 @@ describe('anchor_resolver', () => {
     expect(res.reason).toBe('no_cache');
   });
 
+  it('falls back to kb-joined text when a rich doc lacks file-indexer cache', async () => {
+    const mod = await import('../../../../src/main/model/core-agent/anchor-resolver');
+    const { userContextsDir } = await import('../../../../src/main/paths');
+    const dir = userContextsDir(TEST_UID);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'doc.pdf'), '%PDF-1.4 not really a pdf');
+    // 该 pdf 已进 kb 向量索引（有 chunk 文本），但没进 file-indexer 缓存 →
+    // 解析器应从向量库按 chunk 拼接降级定位，而不是直接报 no_cache。
+    const kb = await import('../../../../src/main/features/kb_vector');
+    await kb.upsertFile(TEST_UID, {
+      relPath: 'doc.pdf',
+      kind: 'pdf',
+      bytes: 24,
+      mtime: 1,
+      sha1: 'doc.pdf',
+      chunks: [{ title: 'p.5', content: 'alpha one two three', embedding: new Array(512).fill(0) }],
+    });
+    const res = await mod.resolveAnchor({
+      userId: TEST_UID,
+      source: 'library',
+      scope: 'global',
+      path: 'doc.pdf',
+      chunkIdx: 1, // kb_chunks 的 chunk_idx 从 1 开始（upsertFile 用 i+1），title 'p.5' 存于此行
+      quote: 'alpha one two three',
+    });
+    expect(res.resolved).toBe(true);
+    expect(res.text).toContain('alpha one two three');
+    // file-indexer 缓存缺失时，页码从向量库 pdf chunk title（p.5）兜底取得
+    expect(res.page).toBe(5);
+  });
+
   it('returns bad_input for an attachment without a cid', async () => {
     const mod = await import('../../../../src/main/model/core-agent/anchor-resolver');
     const res = await mod.resolveAnchor({

--- a/test/renderer/kb-workbench.test.ts
+++ b/test/renderer/kb-workbench.test.ts
@@ -238,7 +238,7 @@ describe('KB workbench (S1 skeleton)', () => {
     cb({ type: 'final', text: '基于 引用回答。', evidence: [
       { source: 'library', scope: 'global', path: 'notes/a.md', chunkIdx: 2, snippet: 's', score: 0.02 },
     ] });
-    expect(streamBody.textContent).toBe('基于 引用回答。');
+    expect(streamBody.innerHTML).toContain('基于 引用回答。');
     // final 追加了引用 chips（appendChild 被调用）
     expect(streamBody.appendChild).toHaveBeenCalled();
     // typing 态已移除
@@ -325,5 +325,34 @@ describe('KB workbench (S1 skeleton)', () => {
     input._listeners.input({ target: input });
     expect(els['kb-wb-files'].innerHTML).toContain('无匹配文档');
     expect(els['kb-wb-files'].innerHTML).not.toContain('＋ 添加内容');
+  });
+});
+
+describe('kb file-viewer highlight pure helpers', () => {
+  it('strips ordered-list numbers and inline bold (regression: AAR复盘 chunk7)', () => {
+    const { windowMock } = loadScript();
+    const u = windowMock.__kbFvUtils;
+    expect(u.cleanQuote('1. 先**选定并本地试跑**一个 skills 目录')).toBe('先选定并本地试跑一个 skills 目录');
+  });
+
+  it('strips heading/quote/bullet prefixes but keeps table rows', () => {
+    const { windowMock } = loadScript();
+    const u = windowMock.__kbFvUtils;
+    expect(u.stripMdMarks('> 引用要点')).toBe('引用要点');
+    expect(u.stripMdMarks('- 提交证据')).toBe('提交证据');
+    expect(u.stripMdMarks('## 卡点与突破')).toBe('卡点与突破');
+    expect(u.stripMdMarks('| A | B |')).toBe('| A | B |');
+  });
+
+  it('collapses whitespace via normSpace', () => {
+    const { windowMock } = loadScript();
+    expect(windowMock.__kbFvUtils.normSpace('  先 选定\n 并 ')).toBe('先 选定 并');
+  });
+
+  it('extracts significant tokens for block-level matching', () => {
+    const { windowMock } = loadScript();
+    const tokens = windowMock.__kbFvUtils.significantTokens('先选定并本地试跑一个 skills 目录');
+    expect(tokens).toContain('skills');
+    expect(tokens.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## 动机（Why）
KB 问答与文件预览体验迭代（承接知识库模块主线）：
- 用户问"这个知识库讲了什么/你是谁"这类**非检索问题**会被误送去向量检索、答非所问；
- 个人库目录无命中时没有任何引导，用户不知道"内容在另一个个人库"；
- 摘要偶发卡死占住模型锁（无超时 abort）；
- 引用锚点对 PDF 无法定位页码；文件预览缺少拖拽/缩放/分页/高亮。

## 改动（What）
- `kb_qa.ts`：跨库引导（KbCrossLibSuggestion）、元问题识别（META_QUESTION_RE→能力说明）、全库概览路由（LIBRARY_OVERVIEW_RE→kb.summary）、证据作答系统提示强化
- `kb_summary.ts`：120s 超时先 abort 上游请求再降级（释放模型锁）；容量参数化
- `ipc/index.ts`：新增 `kbqa.askStream` 流式问答
- `anchor-resolver.ts`/`anchored-source-view.js`：PDF chunk 标题→起始页码、chunk 反查原文、space 作用域；锚点点击打开源文档
- `kb-workbench.js`/`style.css`：文件预览查看器（拖拽移动/调大小/缩放/分页/文本高亮）
- 测试：kb_qa 20 / kb-workbench 13 / anchor-resolver 6（共 39 例）

## 验证（How）
- `npm run typecheck`（tsc --noEmit）通过
- 规范测试入口（Electron-as-Node）3 文件 39 用例全绿
- 推送前审计（cogseed-open-source-audit diff，基线 origin/develop）：`PASS_WITH_WARNINGS`；豁免 2 条 HIGH 均为 develop 既有基线问题（SBOM 缺口——本 PR 未动依赖；sherpa-onnx 为 .gitignore 本地下载模型词表），WIP 内容零命中

## 关联
- COGSEED-39 知识库问答链路（跨库/元问题/概览路由）；文件预览与锚点定位为其配套

## 检查清单
- [x] 提交邮箱 noreply（cx677），email-gate 可过
- [x] 基于最新 origin/develop 的干净分支 dev/cx677-kb-qa（单提交）
- [x] typecheck + 相关单测 + 审计扫描通过
