### PR TITLE
fix(tokens): style.css 字面量同值 token 化 + 修正 12 处非白名单 radius（cicd 门禁首测暴露）

### DIFF
--- a/scripts/design-tokens-baseline.json
+++ b/scripts/design-tokens-baseline.json
@@ -1,8 +1,7 @@
 {
   "onboarding.css": {
     "color": 92,
-    "zIndex": 4,
-    "fontSize": 54,
+    "fontSize": 26,
     "radius": 11
   },
   "plugins.css": {
@@ -11,20 +10,19 @@
     "radius": 2
   },
   "recall-local.css": {
-    "color": 530,
-    "zIndex": 1,
-    "fontSize": 43,
+    "color": 526,
+    "fontSize": 13,
     "radius": 13
   },
   "style.css": {
-    "color": 2277,
-    "zIndex": 63,
-    "fontSize": 441,
+    "color": 1602,
+    "zIndex": 12,
+    "fontSize": 360,
     "radius": 300
   },
   "workspace.css": {
-    "color": 511,
-    "fontSize": 72,
+    "color": 510,
+    "fontSize": 10,
     "radius": 71
   }
 }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -4,27 +4,27 @@
      primary, mint tints. Token names are stable so the rest of the stylesheet
      inherits without a sweep. New tokens land here in the same diff that
      introduces their first usage. */
-  --bg: #FBFDFC;
-  --surface: #ffffff;
-  --surface-2: #EDF3EF;
-  --surface-3: #DCE5DF;
+  --bg: var(--color-bg);
+  --surface: var(--color-surface);
+  --surface-2: var(--color-surface-2);
+  --surface-3: var(--color-surface-3);
   --card: rgba(255, 255, 255, 0.95);
-  --text: #14281E;
-  --text-2: #3E5A4C;
-  --muted: #6E8578;
+  --text: var(--color-ink);
+  --text-2: var(--color-ink-2);
+  --muted: var(--color-muted);
   --border: rgba(24, 84, 60, 0.09);
   --border-strong: rgba(24, 84, 60, 0.18);
-  --primary: #0E9F6E;
-  --primary-hover: #0A7A55;
-  --primary-soft: #E2F5EC;
-  --primary-text: #0A7A55;
-  --success: #16a34a;
-  --success-soft: #dcfce7;
-  --warn: #d97706;
-  --danger: #dc2626;
-  --danger-hover: #b91c1c;
-  --control-stop: #5B6470;
-  --control-stop-hover: #46505B;
+  --primary: var(--color-brand);
+  --primary-hover: var(--color-brand-hover);
+  --primary-soft: var(--color-brand-soft);
+  --primary-text: var(--color-brand-hover);
+  --success: var(--color-success);
+  --success-soft: var(--color-success-soft);
+  --warn: var(--color-warning);
+  --danger: var(--color-danger);
+  --danger-hover: var(--color-danger-hover);
+  --control-stop: var(--color-control-stop);
+  --control-stop-hover: var(--color-control-stop-hover);
   --radius-lg: 20px;
   --radius-md: 14px;
   --radius-sm: 10px;
@@ -479,7 +479,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .search-modal {
   width: min(720px, calc(100vw - 80px));
   max-height: calc(100vh - 160px);
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 12px;
   box-shadow: 0 30px 60px rgba(0, 0, 0, 0.2);
   display: flex;
@@ -588,7 +588,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .search-history-item {
   border: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   color: #475569;
   padding: 3px 10px;
   border-radius: 100px;
@@ -715,8 +715,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-weight: 500;
 }
 .search-result-kind.is-context { background: #ecfeff; color: #0e7490; }
-.search-result-kind.is-chat    { background: #E2F5EC; color: #0A7A55; }
-.search-result-kind.is-skill   { background: #fef3c7; color: #b45309; }
+.search-result-kind.is-chat    { background: var(--color-brand-soft); color: var(--color-brand-hover); }
+.search-result-kind.is-skill   { background: var(--color-warning-soft); color: #b45309; }
 .search-result-kind.is-agent   { background: #fce7f3; color: #be185d; }
 .search-result-title {
   flex: 1;
@@ -754,8 +754,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   overflow: hidden;
 }
 .search-result-snippet mark {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--color-warning-soft);
+  color: var(--color-warning-text);
   padding: 0 1px;
   border-radius: 2px;
 }
@@ -960,8 +960,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .hub-chip.is-signed-row:hover { background: var(--primary-soft); border-radius: var(--radius-sm); }
 .hub-chip-avatar.is-gradient {
   border: none;
-  background: linear-gradient(135deg, #0E9F6E, #3EC6A0);
-  color: #fff;
+  background: linear-gradient(135deg, var(--color-brand), #3EC6A0);
+  color: var(--color-surface);
   font-weight: 700;
   font-size: 13px;
 }
@@ -1041,7 +1041,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .hub-chip-menu-item:focus-visible { outline: 2px solid var(--primary); outline-offset: -2px; }
 .hub-chip-menu-item-icon { width: 15px; height: 15px; flex: none; }
 .hub-chip-menu-item.is-danger { color: var(--danger); }
-.hub-chip-menu-item.is-danger:hover { background: var(--danger-soft, #fef2f2); }
+.hub-chip-menu-item.is-danger:hover { background: var(--danger-soft, var(--color-danger-soft)); }
 /* 设置项 active：当前视图是 settings 时高亮（boot.js 同步）。 */
 .hub-chip-menu-item.is-active { background: var(--primary-soft); color: var(--primary-text); font-weight: 600; }
 .hub-chip-menu-sep {
@@ -1247,7 +1247,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex: 1;
   min-width: 0;
   border: 1px solid var(--primary);
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   font-size: 13px;
   padding: 2px 6px;
@@ -1255,11 +1255,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-family: inherit;
   outline: none;
 }
-.project-rename-input.is-error { border-color: #dc2626; box-shadow: 0 0 0 2px rgba(220,38,38,0.12); }
+.project-rename-input.is-error { border-color: var(--color-danger); box-shadow: 0 0 0 2px rgba(220,38,38,0.12); }
 
 .project-inline-error {
   font-size: 11px;
-  color: #dc2626;
+  color: var(--color-danger);
   padding: 2px 8px 4px 26px;  /* align below the name (caret + icon offset) */
   line-height: 1.3;
 }
@@ -1402,7 +1402,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   right: 0;
   bottom: -1px;
   height: 2px;
-  background: linear-gradient(90deg, transparent, var(--accent, #0E9F6E), transparent);
+  background: linear-gradient(90deg, transparent, var(--accent, var(--color-brand)), transparent);
   animation: project-detail-loading-slide 1.1s ease-in-out infinite;
 }
 
@@ -1820,11 +1820,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .project-side-icon-btn[hidden] { display: none; }
 .project-side-icon-btn.is-primary {
   background: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
 }
 .project-side-icon-btn.is-primary:hover {
   background: var(--primary-hover);
-  color: #fff;
+  color: var(--color-surface);
 }
 
 .project-side-card-count,
@@ -3112,7 +3112,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .conv-item-menu:hover {
   background: rgba(20, 71, 55, 0.08);
-  color: #3E5A4C;
+  color: var(--color-ink-2);
 }
 
 .conv-item-title {
@@ -3171,7 +3171,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   color: var(--muted);
 }
 
-.conv-item-badge.setup { background: rgba(34,197,94,0.12); color: #16a34a; }
+.conv-item-badge.setup { background: rgba(34,197,94,0.12); color: var(--color-success); }
 .conv-item-badge.run { background: rgba(168,85,247,0.12); color: #7c3aed; }
 
 .conv-status-badge {
@@ -3224,7 +3224,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 0 5px;
   border-radius: 8px;
   background: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
   font-size: var(--font-size-1);
   line-height: 14px;
   text-align: center;
@@ -3295,10 +3295,10 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 15px;
   place-items: center;
   padding: 0 3px;
-  border-radius: 9px;
+  border-radius: var(--radius-2);
   box-shadow: 0 0 0 2px var(--surface);
   pointer-events: none;
-  color: #fff;
+  color: var(--color-surface);
   background: var(--primary);
   font-size: 10px;
   font-weight: 700;
@@ -3454,7 +3454,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-radius: 8px;
   background: #ed921a;
   box-shadow: none;
-  color: #fff;
+  color: var(--color-surface);
   font-size: 12px;
   font-weight: 600;
   flex: 0 0 auto;
@@ -3510,7 +3510,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .skill-tree-node:hover { background: #f1f5f9; }
-.skill-tree-node.active { background: #E2F5EC; color: var(--primary); }
+.skill-tree-node.active { background: var(--color-brand-soft); color: var(--primary); }
 .skill-tree-node.active .skill-tree-label { font-weight: 600; }
 .skill-tree-node.is-selected:not(.active) {
   background: var(--primary-soft);
@@ -3538,8 +3538,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 /* Distinct colors per icon type */
 .skill-tree-icon.icon-folder { color: #f59e0b; }
 .skill-tree-icon.icon-file { color: #64748b; }
-.skill-tree-icon.icon-file[data-ext="md"] { color: #0E9F6E; }
-.skill-tree-icon.icon-file[data-ext="py"] { color: #16a34a; }
+.skill-tree-icon.icon-file[data-ext="md"] { color: var(--color-brand); }
+.skill-tree-icon.icon-file[data-ext="py"] { color: var(--color-success); }
 .skill-tree-icon.icon-file[data-ext="json"] { color: #eab308; }
 .skill-tree-icon.icon-file[data-ext="sh"] { color: #a855f7; }
 
@@ -3595,7 +3595,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex-direction: column;
   min-width: 0;
   overflow: hidden;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 /* Detail content container: the header owns the chrome; document sections use the
@@ -3607,7 +3607,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   overflow-y: auto;
   padding: 0 0 56px;
   width: 100%;
-  background: #fff;
+  background: var(--color-surface);
 }
 #skills-detail-content {
   padding-top: 0;
@@ -3632,7 +3632,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin: 0 0 22px;
   padding: 14px 20px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .skills-doc-title {
@@ -3658,7 +3658,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   transition: background 0.12s;
 }
 .skills-doc-title.editable:hover {
-  background: #E2F5EC;
+  background: var(--color-brand-soft);
   color: var(--primary);
 }
 
@@ -3682,7 +3682,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agents-detail-source.is-version,
 .skills-doc-source.is-version { border-color: rgba(100, 116, 139, 0.18); background: rgba(100, 116, 139, 0.035); color: var(--muted); }
 .agents-detail-source.is-platform,
-.skills-doc-source.is-platform { border-color: rgba(14, 159, 110, 0.22); background: rgba(14, 159, 110, 0.05); color: #0A7A55; }
+.skills-doc-source.is-platform { border-color: rgba(14, 159, 110, 0.22); background: rgba(14, 159, 110, 0.05); color: var(--color-brand-hover); }
 .agents-detail-source.is-user,
 .skills-doc-source.is-user { border-color: rgba(100, 116, 139, 0.22); background: rgba(100, 116, 139, 0.04); color: #475569; }
 .agents-detail-source.is-status,
@@ -3711,7 +3711,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   gap: 18px;
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text, #111827);
   box-shadow: none;
   font-size: 13px;
@@ -3723,7 +3723,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .detail-category-select.open .ai-select-trigger,
 .detail-category-select .ai-select-trigger:focus {
   border-color: #cbd5e1;
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 0 0 3px rgba(14, 159, 110, 0.08);
 }
 .detail-category-select .ai-select-label {
@@ -3745,7 +3745,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
    so both detail pages read as one chrome family. */
 .skills-doc-title.is-editing {
   outline: none;
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 0 0 1px var(--border-strong) inset;
   cursor: text;
 }
@@ -3822,7 +3822,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .skills-detail-category .ai-select-trigger,
 .agents-detail-output-format .ai-select-trigger {
-  background: #fff;
+  background: var(--color-surface);
 }
 .agents-detail-output-text {
   color: var(--text);
@@ -3878,7 +3878,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skills-chat-toolbar {
   padding: 8px 12px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   flex-shrink: 0;
   display: flex;
   justify-content: flex-end;
@@ -3955,7 +3955,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   padding: 10px 12px 12px 10px;
   border-top: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
 }
 .skills-chat-input-area.drag-over,
 .agents-chat-input-area.drag-over {
@@ -4004,7 +4004,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .skills-chat-input-area textarea:focus {
   border-color: var(--primary);
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .skills-chat-input-area .chat-send-btn {
@@ -4101,8 +4101,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-width: 22px;
   padding: 1px 8px;
   border-radius: 999px;
-  background: #E2F5EC;
-  color: #0E9F6E;
+  background: var(--color-brand-soft);
+  color: var(--color-brand);
   font-size: 12px;
   font-weight: 700;
   text-align: center;
@@ -4131,7 +4131,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex-direction: column;
   gap: 10px;
   padding: 14px 16px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 10px;
   cursor: pointer;
@@ -4212,7 +4212,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skill-card.is-disabled .skill-card-name { color: #6b7280; }
 .skill-card:hover .skill-card-more,
 .skill-card.is-menu-open .skill-card-more { visibility: visible; }
-.skill-card-more:hover { background: rgba(20, 71, 55, 0.08); color: #3E5A4C; }
+.skill-card-more:hover { background: rgba(20, 71, 55, 0.08); color: var(--color-ink-2); }
 
 .skill-card-desc {
   flex: 1;
@@ -4288,7 +4288,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 4px 9px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   font: inherit;
   font-size: 12px;
@@ -4316,7 +4316,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid var(--primary);
   border-radius: 8px;
   background: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -4336,7 +4336,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agent-card-use:hover,
 .skill-card-use:hover,
 .agent-dialog-btn:hover {
-  background: var(--primary-hover, #0E9F6E);
+  background: var(--primary-hover, var(--color-brand));
   box-shadow: 0 6px 14px rgba(91, 87, 214, 0.18);
 }
 
@@ -4388,7 +4388,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   position: fixed;
   z-index: var(--z-popover);
   min-width: 96px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 6px;
   box-shadow: 0 6px 20px rgba(20, 71, 55, 0.12);
@@ -4402,8 +4402,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   user-select: none;
 }
 .skill-row-menu-item:hover { background: #f1f5f9; }
-.skill-row-menu-item.is-danger { color: #dc2626; }
-.skill-row-menu-item.is-danger:hover { background: #fef2f2; }
+.skill-row-menu-item.is-danger { color: var(--color-danger); }
+.skill-row-menu-item.is-danger:hover { background: var(--color-danger-soft); }
 
 /* ─── Skills detail view (replaces grid) ────────────────────────────── */
 
@@ -4416,7 +4416,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skills-detail-breadcrumb {
   padding: 12px 24px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   flex-shrink: 0;
 }
 
@@ -4442,7 +4442,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   gap: 4px;
   padding: 3px 10px;
   border: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   color: var(--muted);
   font-size: 11px;
   font-weight: 500;
@@ -4536,7 +4536,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .skill-file-status.is-saving { color: #64748b; }
 .skill-file-status.is-ok     { color: #047857; }
-.skill-file-status.is-err    { color: #b91c1c; }
+.skill-file-status.is-err    { color: var(--color-danger-hover); }
 .skill-file-editor {
   flex: 1;
   min-height: 300px;
@@ -4544,7 +4544,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 12px 14px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 13px;
   line-height: 1.55;
@@ -4556,7 +4556,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skill-file-editor:focus {
   outline: none;
   border-color: var(--primary);
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 0 0 3px rgba(14, 159, 110, 0.1);
 }
 
@@ -4658,7 +4658,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chart-bar-fill {
   height: 100%;
-  background: linear-gradient(90deg, #0E9F6E, #0A7A55);
+  background: linear-gradient(90deg, var(--color-brand), var(--color-brand-hover));
   border-radius: 4px;
   transition: width 0.4s ease;
   min-width: 2px;
@@ -4678,17 +4678,17 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin: 0.6em 0;
   font-size: 13px;
   color: var(--text);
-  --db-accent: #0E9F6E;
-  --db-accent-strong: #0A7A55;
+  --db-accent: var(--color-brand);
+  --db-accent-strong: var(--color-brand-hover);
   --db-accent-soft: rgba(91, 87, 214, 0.12);
   --db-accent-faint: rgba(91, 87, 214, 0.06);
-  --db-good: #16a34a;
+  --db-good: var(--color-success);
   --db-good-soft: rgba(22, 163, 74, 0.1);
-  --db-bad: #dc2626;
+  --db-bad: var(--color-danger);
   --db-bad-soft: rgba(220, 38, 38, 0.09);
-  --db-warn: #d97706;
+  --db-warn: var(--color-warning);
   --db-warn-soft: rgba(217, 119, 6, 0.11);
-  --db-info: #0E9F6E;
+  --db-info: var(--color-brand);
   --db-info-soft: rgba(14, 159, 110, 0.09);
   --db-radius: 8px;
   --db-border: rgba(20, 71, 55, 0.1);
@@ -4697,9 +4697,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   --db-surface-soft: rgba(248, 250, 252, 0.92);
 }
 .dashboard[data-theme-color="neutral"] { --db-accent: #64748b; --db-accent-strong: #475569; --db-accent-soft: rgba(100, 116, 139, 0.12); --db-accent-faint: rgba(100, 116, 139, 0.06); }
-.dashboard[data-theme-color="success"] { --db-accent: #16a34a; --db-accent-strong: #15803d; --db-accent-soft: rgba(22, 163, 74, 0.12); --db-accent-faint: rgba(22, 163, 74, 0.06); }
-.dashboard[data-theme-color="warning"] { --db-accent: #d97706; --db-accent-strong: #b45309; --db-accent-soft: rgba(217, 119, 6, 0.14); --db-accent-faint: rgba(217, 119, 6, 0.07); }
-.dashboard[data-theme-color="danger"]  { --db-accent: #dc2626; --db-accent-strong: #b91c1c; --db-accent-soft: rgba(220, 38, 38, 0.12); --db-accent-faint: rgba(220, 38, 38, 0.06); }
+.dashboard[data-theme-color="success"] { --db-accent: var(--color-success); --db-accent-strong: #15803d; --db-accent-soft: rgba(22, 163, 74, 0.12); --db-accent-faint: rgba(22, 163, 74, 0.06); }
+.dashboard[data-theme-color="warning"] { --db-accent: var(--color-warning); --db-accent-strong: #b45309; --db-accent-soft: rgba(217, 119, 6, 0.14); --db-accent-faint: rgba(217, 119, 6, 0.07); }
+.dashboard[data-theme-color="danger"]  { --db-accent: var(--color-danger); --db-accent-strong: var(--color-danger-hover); --db-accent-soft: rgba(220, 38, 38, 0.12); --db-accent-faint: rgba(220, 38, 38, 0.06); }
 .dashboard[data-theme-style="card"] {
   padding: 12px;
   border: 1px solid var(--db-border);
@@ -4837,7 +4837,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   color: var(--muted);
 }
 .dashboard .db-metric-delta[data-tone="positive"] { color: #15803d; background: var(--db-good-soft); }
-.dashboard .db-metric-delta[data-tone="negative"] { color: #b91c1c; background: var(--db-bad-soft); }
+.dashboard .db-metric-delta[data-tone="negative"] { color: var(--color-danger-hover); background: var(--db-bad-soft); }
 .dashboard .db-metric-delta[data-tone="warning"]  { color: #b45309; background: var(--db-warn-soft); }
 
 /* Alert — color-coded banner. */
@@ -4861,7 +4861,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 18px;
   border-radius: 50%;
   background: var(--db-info);
-  color: #fff;
+  color: var(--color-surface);
   font-size: 11px;
   font-weight: 700;
   line-height: 1;
@@ -4957,18 +4957,18 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .dashboard .db-chart-axis    { stroke: rgba(100, 116, 139, 0.34); stroke-width: 1; }
 .dashboard .db-chart-line    { fill: none; stroke: var(--db-accent); stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
 .dashboard .db-chart-area    { fill: var(--db-accent); opacity: 0.16; stroke: none; }
-.dashboard .db-chart-dot     { fill: var(--db-accent); stroke: #fff; stroke-width: 1.4; }
+.dashboard .db-chart-dot     { fill: var(--db-accent); stroke: var(--color-surface); stroke-width: 1.4; }
 .dashboard .db-chart-bar-rect { fill: var(--db-accent); opacity: 0.88; }
 .dashboard .db-chart-xlabel,
 .dashboard .db-chart-ylabel  { font-size: var(--font-size-1); fill: var(--muted); font-family: inherit; }
-.dashboard .db-chart-bar-rect[data-idx="0"], .dashboard .db-chart-dot[data-idx="0"] { fill: #0E9F6E; }
-.dashboard .db-chart-bar-rect[data-idx="1"], .dashboard .db-chart-dot[data-idx="1"] { fill: #16a34a; }
+.dashboard .db-chart-bar-rect[data-idx="0"], .dashboard .db-chart-dot[data-idx="0"] { fill: var(--color-brand); }
+.dashboard .db-chart-bar-rect[data-idx="1"], .dashboard .db-chart-dot[data-idx="1"] { fill: var(--color-success); }
 .dashboard .db-chart-bar-rect[data-idx="2"], .dashboard .db-chart-dot[data-idx="2"] { fill: #ea580c; }
 .dashboard .db-chart-bar-rect[data-idx="3"], .dashboard .db-chart-dot[data-idx="3"] { fill: #9333ea; }
 .dashboard .db-chart-bar-rect[data-idx="4"], .dashboard .db-chart-dot[data-idx="4"] { fill: #0891b2; }
 .dashboard .db-chart-bar-rect[data-idx="5"], .dashboard .db-chart-dot[data-idx="5"] { fill: #ca8a04; }
-.dashboard .db-chart-slice[data-idx="0"] { fill: #0E9F6E; }
-.dashboard .db-chart-slice[data-idx="1"] { fill: #16a34a; }
+.dashboard .db-chart-slice[data-idx="0"] { fill: var(--color-brand); }
+.dashboard .db-chart-slice[data-idx="1"] { fill: var(--color-success); }
 .dashboard .db-chart-slice[data-idx="2"] { fill: #ea580c; }
 .dashboard .db-chart-slice[data-idx="3"] { fill: #9333ea; }
 .dashboard .db-chart-slice[data-idx="4"] { fill: #0891b2; }
@@ -4976,8 +4976,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .dashboard .db-chart-legend { list-style: none; padding: 8px 4px 0; margin: 0; display: flex; flex-wrap: wrap; gap: 6px 14px; font-size: 12px; }
 .dashboard .db-chart-legend li { display: flex; align-items: center; gap: 6px; color: var(--text); }
 .dashboard .db-chart-legend .db-chart-swatch { display: inline-block; width: 10px; height: 10px; border-radius: 2px; }
-.dashboard .db-chart-legend li[data-idx="0"] .db-chart-swatch { background: #0E9F6E; }
-.dashboard .db-chart-legend li[data-idx="1"] .db-chart-swatch { background: #16a34a; }
+.dashboard .db-chart-legend li[data-idx="0"] .db-chart-swatch { background: var(--color-brand); }
+.dashboard .db-chart-legend li[data-idx="1"] .db-chart-swatch { background: var(--color-success); }
 .dashboard .db-chart-legend li[data-idx="2"] .db-chart-swatch { background: #ea580c; }
 .dashboard .db-chart-legend li[data-idx="3"] .db-chart-swatch { background: #9333ea; }
 .dashboard .db-chart-legend li[data-idx="4"] .db-chart-swatch { background: #0891b2; }
@@ -5223,7 +5223,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .welcome-carry-pending-badge {
   font-size: 11px;
   font-weight: 600;
-  color: var(--primary-text, #0a7a55);
+  color: var(--primary-text, var(--color-brand-hover));
   background: color-mix(in srgb, var(--primary) 14%, transparent);
   border-radius: 999px;
   padding: 2px 8px;
@@ -5640,7 +5640,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 0;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   cursor: pointer;
   transition: all 0.15s;
@@ -5662,7 +5662,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 4px 10px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   font-family: inherit;
   font-size: 12px;
@@ -5677,7 +5677,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-header-action-btn.is-pinned {
   color: var(--text);
   border-color: var(--border);
-  background: #fff;
+  background: var(--color-surface);
 }
 .chat-header-action-btn.is-danger {
   color: var(--danger);
@@ -5697,7 +5697,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 0;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   font-family: inherit;
   font-size: 13px;
@@ -5774,7 +5774,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 9px;
   border: 1px solid var(--border);
   border-radius: 12px;
-  background: #fff;
+  background: var(--color-surface);
 }
 .agent-status-row.is-running { border-color: rgba(34, 197, 94, 0.38); background: rgba(34, 197, 94, 0.06); }
 .agent-status-row-main { flex: 1 1 auto; min-width: 0; }
@@ -6169,11 +6169,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .run-context-cog-bound.is-applicable::before {
   content: '✓ ';
-  color: var(--success, #16a34a);
+  color: var(--success, var(--color-success));
 }
 .run-context-cog-bound.is-forbidden::before {
   content: '✕ ';
-  color: var(--danger, #dc2626);
+  color: var(--danger, var(--color-danger));
 }
 .run-context-cog-actions {
   display: flex;
@@ -6197,7 +6197,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .run-context-cog-settled-badge {
   flex-shrink: 0;
   font-size: 11px;
-  color: var(--success, #16a34a);
+  color: var(--success, var(--color-success));
   white-space: nowrap;
 }
 
@@ -6252,7 +6252,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex: 0 0 auto;
   border: 1px solid var(--border);
   border-radius: 7px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -6281,12 +6281,12 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 10px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
 }
 .conversation-info-agent-activity-stat.is-primary {
   padding: 12px 10px;
   border-color: var(--primary);
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   color: var(--text);
 }
 .conversation-info-agent-activity-stat.is-primary span,
@@ -6320,7 +6320,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .conversation-info-agent-activity-row {
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   overflow: hidden;
 }
 .conversation-info-agent-activity-row > summary {
@@ -6411,7 +6411,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .conversation-info-collaboration-section {
   border: 1px solid var(--border);
   border-radius: 10px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   padding: 12px;
 }
 .conversation-info-collaboration-section-title {
@@ -6676,7 +6676,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   grid-template-columns: 92px minmax(0, 1fr);
   gap: 8px;
   padding: 9px 12px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
 }
 .conversation-info-carried-rows dt {
   color: var(--text-muted);
@@ -6696,7 +6696,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 10px 12px;
   border: 1px solid color-mix(in srgb, var(--primary) 22%, var(--border));
   border-radius: 8px;
-  background: color-mix(in srgb, var(--primary) 5%, var(--surface-1, #fff));
+  background: color-mix(in srgb, var(--primary) 5%, var(--surface-1, var(--color-surface)));
   color: var(--text-2);
   font-size: 11.5px;
   line-height: 1.55;
@@ -6769,7 +6769,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
 }
 .conversation-info-carried-run-head {
   display: flex;
@@ -6794,9 +6794,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-size: var(--font-size-1);
   font-weight: 650;
 }
-.conversation-info-carried-run-status.is-running { background: color-mix(in srgb, var(--primary) 14%, var(--surface-1, #fff)); color: var(--primary-text); }
-.conversation-info-carried-run-status.is-completed { background: color-mix(in srgb, #16a34a 12%, var(--surface-1, #fff)); color: #15803d; }
-.conversation-info-carried-run-status.is-failed { background: color-mix(in srgb, var(--danger) 12%, var(--surface-1, #fff)); color: var(--danger); }
+.conversation-info-carried-run-status.is-running { background: color-mix(in srgb, var(--primary) 14%, var(--surface-1, var(--color-surface))); color: var(--primary-text); }
+.conversation-info-carried-run-status.is-completed { background: color-mix(in srgb, var(--color-success) 12%, var(--surface-1, var(--color-surface))); color: #15803d; }
+.conversation-info-carried-run-status.is-failed { background: color-mix(in srgb, var(--danger) 12%, var(--surface-1, var(--color-surface))); color: var(--danger); }
 .conversation-info-carried-run-status.is-cancelled,
 .conversation-info-carried-run-status.is-timed_out { background: var(--surface-3); color: var(--muted); }
 .conversation-info-carried-run-meta {
@@ -6831,7 +6831,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .conversation-info-carried-section {
   border: 1px solid var(--border);
   border-radius: 10px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   padding: 11px 12px;
   display: grid;
   gap: 9px;
@@ -6882,7 +6882,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: color-mix(in srgb, var(--primary) 12%, #fff);
+  background: color-mix(in srgb, var(--primary) 12%, var(--color-surface));
   color: var(--primary-text);
   flex: 0 0 auto;
 }
@@ -6961,7 +6961,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 11px 12px;
   border: 1px solid var(--border);
   border-radius: 10px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   display: grid;
   gap: 7px;
 }
@@ -6983,7 +6983,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: color-mix(in srgb, var(--primary) 10%, #fff);
+  background: color-mix(in srgb, var(--primary) 10%, var(--color-surface));
   color: var(--primary-text);
 }
 .conversation-info-carried-run-avatar svg { width: 14px; height: 14px; }
@@ -7013,15 +7013,15 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   background: currentColor;
 }
 .conversation-info-carried-run-status.is-running {
-  background: color-mix(in srgb, #3b82f6 12%, #fff);
-  color: #2563eb;
+  background: color-mix(in srgb, #3b82f6 12%, var(--color-surface));
+  color: var(--color-info);
 }
 .conversation-info-carried-run-status.is-completed {
-  background: color-mix(in srgb, #16a34a 12%, #fff);
+  background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
   color: #15803d;
 }
 .conversation-info-carried-run-status.is-failed {
-  background: color-mix(in srgb, var(--danger) 12%, #fff);
+  background: color-mix(in srgb, var(--danger) 12%, var(--color-surface));
   color: var(--danger);
 }
 .conversation-info-carried-run-status.is-cancelled,
@@ -7052,7 +7052,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-size: 11px;
   line-height: 1.55;
   color: var(--primary-text);
-  background: color-mix(in srgb, var(--primary) 8%, #fff);
+  background: color-mix(in srgb, var(--primary) 8%, var(--color-surface));
   border-radius: 6px;
   padding: 6px 9px;
 }
@@ -7118,11 +7118,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 9px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
 }
 .conversation-info-protocol-stat.is-primary {
   border-color: var(--primary);
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   color: var(--text);
 }
 .conversation-info-protocol-stat.is-error strong { color: var(--danger); }
@@ -7156,7 +7156,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-width: 0;
   border: 1px solid var(--border);
   border-radius: 7px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   color: var(--text);
   font: inherit;
   font-size: 12px;
@@ -7170,7 +7170,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .conversation-info-protocol-row {
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: var(--surface-1, #fff);
+  background: var(--surface-1, var(--color-surface));
   overflow: hidden;
 }
 .conversation-info-protocol-row > summary {
@@ -7405,8 +7405,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-radius: 4px;
   font-size: var(--font-size-1);
   font-weight: 500;
-  color: var(--primary-text, #0A7A55);
-  background: var(--primary-soft, #E2F5EC);
+  color: var(--primary-text, var(--color-brand-hover));
+  background: var(--primary-soft, var(--color-brand-soft));
   font-family: var(--font-sans);
   white-space: nowrap;
 }
@@ -7480,7 +7480,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .conversation-info-file-menu-btn:hover,
 .conversation-info-file-menu-btn:focus-visible {
   background: rgba(20, 71, 55, 0.08);
-  color: #3E5A4C;
+  color: var(--color-ink-2);
   outline: none;
 }
 .ctx-row-menu.conversation-info-file-menu {
@@ -7552,7 +7552,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .conv-create-agent-inline button:hover {
   color: var(--primary);
   border-color: rgba(14, 159, 110, 0.3);
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .chat-history {
@@ -7741,7 +7741,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   color: #94a3b8;
 }
 .chat-input-mirror .msg-mention {
-  color: var(--accent, #0E9F6E);
+  color: var(--accent, var(--color-brand));
   font-weight: 500;
 }
 
@@ -7866,7 +7866,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   justify-content: center;
   background: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -8053,7 +8053,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 12px;
   border-radius: 50%;
   border: 2px solid #cbd5e1;
-  border-top-color: #0E9F6E;
+  border-top-color: var(--color-brand);
   animation: chat-attach-spin 0.8s linear infinite;
   flex-shrink: 0;
 }
@@ -8134,7 +8134,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-quote-preview .chat-quote-from {
   flex: 1 1 auto;
   font-weight: 500;
-  color: #0E9F6E;
+  color: var(--color-brand);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -8175,7 +8175,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   gap: 4px;
   padding: 2px 6px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 8px;
   font-size: 11.5px;
@@ -8403,7 +8403,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   max-width: 240px;
 }
 .chat-message.user .chat-msg-attach {
-  background: #fff;
+  background: var(--color-surface);
   border-color: rgba(14, 159, 110, 0.2);
   color: #1e293b;
 }
@@ -8415,7 +8415,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex: 0 0 auto;
   line-height: 1;
 }
-.chat-message.user .chat-msg-attach-icon { color: #3E5A4C; }
+.chat-message.user .chat-msg-attach-icon { color: var(--color-ink-2); }
 .chat-msg-attach.is-image {
   padding: 4px;
   flex-direction: column;
@@ -8465,7 +8465,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   aspect-ratio: 16 / 9;
   overflow: hidden;
   border-radius: 4px;
-  background: #000;
+  background: var(--color-black);
   cursor: pointer;
 }
 .chat-msg-attach-video {
@@ -8474,7 +8474,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 100%;
   border-radius: 0;
   object-fit: contain;
-  background: #000;
+  background: var(--color-black);
   cursor: pointer;
 }
 .chat-msg-attach.is-video .chat-msg-attach-label {
@@ -8574,7 +8574,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin: 6px 0;
   overflow: hidden;
   border-radius: 6px;
-  background: #000;
+  background: var(--color-black);
   cursor: pointer;
 }
 .chat-md-video {
@@ -8584,7 +8584,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-radius: 0;
   margin: 0;
   object-fit: contain;
-  background: #000;
+  background: var(--color-black);
   cursor: pointer;
 }
 .chat-md-video::-webkit-media-controls-fullscreen-button,
@@ -8629,7 +8629,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   object-fit: contain;
   border-radius: 6px;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
-  background: #0f172a;
+  background: var(--color-overlay-ink);
   /* JS sets `transform: translate(...) scale(...)` for zoom + pan. The
      transition makes wheel / keyboard zoom feel smooth; we suppress it
      during active drag-to-pan via JS by setting style.transition='none'
@@ -8646,7 +8646,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   position: absolute;
   top: -12px;
   right: -12px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--muted, #6b7280);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
 }
@@ -8662,8 +8662,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 32px;
   border-radius: 8px;
   border: none;
-  background: #fff;
-  color: #0f172a;
+  background: var(--color-surface);
+  color: var(--color-overlay-ink);
   font-size: 12px;
   font-weight: 600;
   line-height: 1;
@@ -8707,7 +8707,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 92vw;
   height: 92vh;
   max-width: 1280px;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 10px;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
   display: flex;
@@ -8726,7 +8726,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-file-viewer-title {
   font-size: 13px;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -8764,7 +8764,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chat-file-viewer-md-actions .ctx-viewer-action-icon-btn:hover {
   background: #e2e8f0;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
 }
 .chat-file-viewer-md-actions .ctx-viewer-action-icon-btn.btn-primary {
   background: transparent;
@@ -8817,7 +8817,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chat-file-viewer-reveal:hover,
 .chat-file-viewer-add-library:hover:not(:disabled),
-.chat-file-viewer-save-app:hover:not(:disabled) { background: #e2e8f0; color: #0f172a; }
+.chat-file-viewer-save-app:hover:not(:disabled) { background: #e2e8f0; color: var(--color-overlay-ink); }
 .chat-file-viewer-add-library svg,
 .chat-file-viewer-save-app svg,
 .chat-file-viewer-reveal svg { display: block; }
@@ -8834,7 +8834,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 5px 8px;
   border-radius: 6px;
   background: rgba(20, 71, 55, 0.94);
-  color: #fff;
+  color: var(--color-surface);
   font-size: 12px;
   font-weight: 500;
   line-height: 1.25;
@@ -8854,7 +8854,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex: 1;
   min-height: 0;
   overflow: auto;
-  background: #fff;
+  background: var(--color-surface);
 }
 .chat-file-viewer.is-office .chat-file-viewer-body {
   background: #eef2f7;
@@ -8891,7 +8891,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chat-file-viewer-md {
   padding: 24px 32px;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
   font-size: 14px;
   line-height: 1.7;
   max-width: 880px;
@@ -8906,7 +8906,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 24px 32px;
   box-sizing: border-box;
   overflow: auto;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
   font-size: 14px;
   line-height: 1.7;
 }
@@ -8950,7 +8950,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
   line-height: 1.55;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
   background: #f8fafc;
   white-space: pre-wrap;
   word-break: break-word;
@@ -9050,7 +9050,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 0;
   font: inherit;
   font-size: 13px;
-  color: #3E5A4C;
+  color: var(--color-ink-2);
   text-align: left;
   cursor: pointer;
 }
@@ -9107,7 +9107,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chat-msg-produced-menu-btn:hover {
   background: rgba(100, 116, 139, 0.14);
-  color: #3E5A4C;
+  color: var(--color-ink-2);
 }
 @media (hover: none) {
   .chat-msg-produced-menu-btn { opacity: 1; }
@@ -9118,13 +9118,13 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 16px;
   color: currentColor;
 }
-.chat-file-kind-icon.is-image { color: #16a34a; }
+.chat-file-kind-icon.is-image { color: var(--color-success); }
 .chat-file-kind-icon.is-video { color: #7c3aed; }
 .chat-file-kind-icon.is-audio { color: #db2777; }
-.chat-file-kind-icon.is-pdf { color: #dc2626; }
-.chat-file-kind-icon.is-doc { color: #0E9F6E; }
+.chat-file-kind-icon.is-pdf { color: var(--color-danger); }
+.chat-file-kind-icon.is-doc { color: var(--color-brand); }
 .chat-file-kind-icon.is-spreadsheet { color: #16803a; }
-.chat-file-kind-icon.is-presentation { color: #d97706; }
+.chat-file-kind-icon.is-presentation { color: var(--color-warning); }
 .chat-file-kind-icon.is-text,
 .chat-file-kind-icon.is-file { color: #64748b; }
 .chat-file-kind-icon.is-data { color: #0891b2; }
@@ -9240,7 +9240,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 26px 32px 24px;
   border: 1px solid rgba(15, 23, 42, 0.08);
   border-radius: 6px;
-  background: var(--surface, #fff);
+  background: var(--surface, var(--color-surface));
   color: var(--text, #111827);
   box-shadow: 0 24px 64px rgba(15, 23, 42, 0.18);
 }
@@ -9296,7 +9296,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .conversation-merge-picker-search:focus {
   border-color: rgba(14, 159, 110, 0.42);
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 0 0 3px rgba(14, 159, 110, 0.09);
 }
 .conversation-merge-picker-search::-webkit-search-cancel-button { opacity: 0.5; }
@@ -9356,8 +9356,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   box-sizing: border-box;
   border: 1px solid #cbd5d1;
   border-radius: 6px;
-  background: #fff;
-  color: #fff;
+  background: var(--color-surface);
+  color: var(--color-surface);
   transition: background 120ms ease, border-color 120ms ease;
 }
 .conversation-merge-picker-checkbox .ui-icon { width: 15px; height: 15px; stroke-width: 2.4; }
@@ -9429,7 +9429,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-width: 146px;
   border-color: #76bda2;
   background: #76bda2;
-  color: #fff;
+  color: var(--color-surface);
   box-shadow: none;
 }
 .conversation-merge-picker-footer .btn.conversation-merge-picker-confirm:hover:not(:disabled) {
@@ -9544,7 +9544,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-input-form .form-field-input {
   padding: 6px 10px;
   border: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 6px;
   font-size: 13px;
   font-family: inherit;
@@ -9767,19 +9767,19 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: min(360px, 100%);
   max-width: 100%;
   min-width: 280px;
-  background: #fff;
+  background: var(--color-surface);
   border-color: rgba(0,0,0,0.08);
 }
 .chat-marketplace-request.is-installed {
-  background: #fff;
+  background: var(--color-surface);
   border-color: rgba(34, 197, 94, 0.26);
 }
 .chat-marketplace-request.is-skipped {
-  background: #fff;
+  background: var(--color-surface);
   border-color: rgba(148, 163, 184, 0.35);
 }
 .chat-marketplace-request.is-failed {
-  background: #fff;
+  background: var(--color-surface);
   border-color: rgba(239, 68, 68, 0.28);
 }
 .chat-marketplace-request-head {
@@ -9870,7 +9870,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: block;
   width: 100%;
   border: 0;
-  background: #fff;
+  background: var(--color-surface);
 }
 .chat-artifact-unavailable {
   min-height: 180px;
@@ -9879,7 +9879,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex-direction: column;
   justify-content: center;
   gap: 6px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--muted);
 }
 .chat-artifact-unavailable-title {
@@ -9898,7 +9898,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   position: fixed;
   z-index: var(--z-popover);
   min-width: 176px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 6px;
   box-shadow: 0 6px 20px rgba(20, 71, 55, 0.12);
@@ -9914,8 +9914,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chat-artifact-menu-item:hover,
 .app-row-menu-item:hover { background: #f1f5f9; }
-.app-row-menu-item.is-danger { color: #dc2626; }
-.app-row-menu-item.is-danger:hover { background: #fef2f2; }
+.app-row-menu-item.is-danger { color: var(--color-danger); }
+.app-row-menu-item.is-danger:hover { background: var(--color-danger-soft); }
 
 /* In-app artifact viewer opened from a chat artifact card's `⋯` menu. */
 .chat-artifact-viewer {
@@ -9937,7 +9937,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 92vw;
   height: 92vh;
   max-width: 1280px;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 10px;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
   display: flex;
@@ -9956,7 +9956,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-artifact-viewer-title {
   font-size: 13px;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -9969,7 +9969,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 100%;
   height: auto;
   border: 0;
-  background: #fff;
+  background: var(--color-surface);
 }
 .chat-queue-header {
   display: flex;
@@ -9992,7 +9992,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin-left: 4px;
   border-radius: 9px;
   background: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
   font-weight: 600;
   text-align: center;
 }
@@ -10084,7 +10084,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .chat-queue-btn:hover {
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   border-color: var(--border-strong);
 }
@@ -10097,7 +10097,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-queue-item.editing {
   flex-direction: column;
   align-items: stretch;
-  background: #fff;
+  background: var(--color-surface);
   border-color: var(--primary);
   padding: 8px;
 }
@@ -10168,7 +10168,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin: 8px 0;
   padding: 14px 16px;
   border: 1px solid var(--border-strong, #e5e7eb);
-  border-left: 3px solid var(--danger, #dc2626);
+  border-left: 3px solid var(--danger, var(--color-danger));
   border-radius: 10px;
   background: #fffaf9;
   display: flex;
@@ -10190,7 +10190,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .delete-confirm-title {
   font-weight: 600;
-  color: var(--danger, #dc2626);
+  color: var(--danger, var(--color-danger));
 }
 .delete-confirm-path-list {
   display: flex;
@@ -10205,7 +10205,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .delete-confirm-path code {
   display: block;
   padding: 6px 10px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border-strong, #e5e7eb);
   border-radius: 6px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
@@ -10233,7 +10233,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-top: 1px dashed var(--border, #e5e7eb);
 }
 .delete-confirm-card.is-confirmed .delete-confirm-result {
-  color: var(--danger, #dc2626);
+  color: var(--danger, var(--color-danger));
 }
 .delete-confirm-card.is-cancelled .delete-confirm-result {
   color: #6b7280;
@@ -10267,7 +10267,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   transition: color 0.12s, background 0.12s;
 }
 .chat-msg-from.is-agent-link:hover {
-  color: var(--primary, #0E9F6E);
+  color: var(--primary, var(--color-brand));
   background: rgba(14, 159, 110, 0.08);
 }
 .chat-msg-from.is-agent-link:focus-visible,
@@ -10337,7 +10337,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 10px 12px;
   border: 1px solid var(--border-strong, #cbd5e1);
   border-radius: 6px;
-  background: var(--surface, #fff);
+  background: var(--surface, var(--color-surface));
   color: var(--text, #1f2937);
   font: inherit;
   line-height: 1.55;
@@ -10347,7 +10347,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chat-message-edit-input:focus {
   outline: 0;
-  border-color: var(--primary, #2563eb);
+  border-color: var(--primary, var(--color-info));
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 12%, transparent);
 }
 .chat-message-edit-actions {
@@ -10367,7 +10367,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
  * can scan a long reply for "who's this routed to". Skipped automatically
  * inside <code>/<pre>/<a> nodes by the renderer's DOM walker. */
 .msg-mention {
-  color: var(--accent, #0E9F6E);
+  color: var(--accent, var(--color-brand));
   font-weight: 500;
 }
 
@@ -10536,7 +10536,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 4px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 10px 28px rgba(20, 71, 55, 0.14), 0 2px 8px rgba(20, 71, 55, 0.08);
 }
 .chat-bubble-more-menu[hidden] { display: none; }
@@ -10734,7 +10734,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 0;
   border: 1px solid var(--border-strong);
   border-radius: 50%;
-  background: #fff;
+  background: var(--color-surface);
   color: transparent;
   cursor: pointer;
   box-shadow: 0 1px 4px rgba(20, 71, 55, 0.08);
@@ -10756,7 +10756,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-message.is-message-selected > .chat-message-select-check {
   border-color: var(--primary);
   background: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
 }
 
 .chat-message.is-message-selected > .chat-bubble {
@@ -10834,7 +10834,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 0 12px;
   border: 1px solid var(--border);
   border-radius: 9px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   font-family: inherit;
   font-size: 12.5px;
@@ -10856,7 +10856,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chat-reference-new-task:hover {
   border-color: color-mix(in srgb, var(--primary) 35%, var(--border));
-  background: color-mix(in srgb, var(--primary) 3%, #fff);
+  background: color-mix(in srgb, var(--primary) 3%, var(--color-surface));
 }
 .chat-reference-new-task:disabled { cursor: wait; opacity: 0.62; }
 .chat-reference-existing { margin-top: 14px; }
@@ -10890,7 +10890,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid var(--border);
   border-radius: 9px;
   outline: none;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   font-family: inherit;
   font-size: 12.5px;
@@ -11001,7 +11001,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin: 0 0 8px;
 }
 .chat-space-asset-refs-label {
-  color: #0E9F6E;
+  color: var(--color-brand);
   font-size: 11px;
   font-weight: 600;
 }
@@ -11050,7 +11050,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-reference-title {
   margin-bottom: 4px;
   overflow: hidden;
-  color: #0E9F6E;
+  color: var(--color-brand);
   font-size: 12px;
   font-weight: 500;
   line-height: 1.35;
@@ -11166,7 +11166,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .chat-message.assistant .chat-bubble {
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   border: 1px solid var(--border);
   border-bottom-left-radius: 4px;
@@ -11330,9 +11330,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .stream-process-line.kind-out   { color: #94a3b8; }
 .stream-process-line.kind-context { color: #94a3b8; }
 .stream-process-line.kind-meta  { color: #94a3b8; }
-.stream-process-line.kind-warn  { color: #d97706; }
+.stream-process-line.kind-warn  { color: var(--color-warning); }
 .stream-process-line.kind-err   { color: #ef4444; font-weight: 500; }
-.stream-process-line.kind-info  { color: #0E9F6E; }
+.stream-process-line.kind-info  { color: var(--color-brand); }
 .stream-process-icon {
   width: 13px;
   height: 13px;
@@ -11512,7 +11512,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-toolbar-btn:hover {
   color: var(--primary);
   border-color: rgba(14, 159, 110, 0.25);
-  background: #fff;
+  background: var(--color-surface);
 }
 
 /* Composer chips — recipient / workspace / project / skill all share P3 chrome
@@ -12013,7 +12013,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   position: sticky;
   top: 0;
   z-index: 2;
-  background: #fff;
+  background: var(--color-surface);
   margin-top: 6px;
   padding: 8px 8px 4px;
   border-top: 1px solid var(--border);
@@ -12114,7 +12114,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .model-chip-seg-btn.is-active {
   background: var(--primary);
   border-color: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
   font-weight: 600;
 }
 .model-chip-seg-btn.is-disabled {
@@ -12127,7 +12127,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   z-index: var(--z-popover);
   min-width: 200px;
   max-width: 280px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 12px;
   box-shadow: 0 8px 28px rgba(20, 71, 55, 0.12);
@@ -12221,7 +12221,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   position: fixed;
   width: 250px;
   max-height: 250px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 12px;
   box-shadow: 0 12px 36px rgba(20, 71, 55, 0.18);
@@ -12238,7 +12238,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 4px;
   padding: 8px 8px 0;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .skill-picker-tab {
@@ -12284,7 +12284,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .skill-picker-header input:focus {
   border-color: var(--primary);
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .skill-picker-list {
@@ -12340,7 +12340,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 8px 10px;
   font-size: 11.5px;
   color: #b45309;
-  background: #fef3c7;
+  background: var(--color-warning-soft);
   border-radius: 6px;
   margin: 4px 6px 6px 6px;
   line-height: 1.4;
@@ -12620,7 +12620,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skill-tree-node.is-menu-open .ctx-row-menu-btn,
 .contexts-section-header.is-menu-open .ctx-row-menu-btn,
 .ctx-row-menu-btn.ctx-root-menu-btn { visibility: visible; }
-.ctx-row-menu-btn:hover { background: rgba(20, 71, 55, 0.08); color: #3E5A4C; }
+.ctx-row-menu-btn:hover { background: rgba(20, 71, 55, 0.08); color: var(--color-ink-2); }
 .ctx-row-menu-icon { width: 16px; height: 16px; display: block; }
 .skill-tree-node.active .ctx-row-menu-btn { color: var(--primary); }
 .skill-tree-node.active .ctx-row-menu-btn:hover { background: rgba(14, 159, 110, 0.12); }
@@ -12634,7 +12634,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   z-index: var(--z-popover);
   min-width: 156px;
   max-width: 240px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: 0 6px 20px rgba(20, 71, 55, 0.12);
@@ -12662,8 +12662,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   cursor: default;
 }
 .ctx-row-menu-item.is-disabled:hover { background: transparent; }
-.ctx-row-menu-item.is-danger { color: #dc2626; }
-.ctx-row-menu-item.is-danger:hover { background: #fef2f2; }
+.ctx-row-menu-item.is-danger { color: var(--color-danger); }
+.ctx-row-menu-item.is-danger:hover { background: var(--color-danger-soft); }
 
 /* Drag-drop visuals — applied to row when something is dragged over it,
    to the source row while it's being dragged, and to the tree container
@@ -12858,7 +12858,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 1px 4px;
   font: inherit;
   font-size: 13px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   outline: none;
 }
@@ -12978,7 +12978,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .contexts-editor-header {
   padding: 12px 20px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -12999,7 +12999,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex: 1;
   overflow-y: auto;
   padding: 20px 28px 28px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   font-size: 14px;
   line-height: 1.7;
@@ -13064,7 +13064,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   outline: none;
 }
 .ctx-viewer-editor:focus {
-  border-color: var(--primary, #0E9F6E);
+  border-color: var(--primary, var(--color-brand));
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.12);
 }
 
@@ -13076,7 +13076,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   gap: 4px;
   padding: 6px 8px;
   margin-bottom: 8px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 6px;
 }
@@ -13129,7 +13129,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px dashed var(--border);
   border-radius: 6px;
   padding: 14px 16px;
-  background: #fff;
+  background: var(--color-surface);
   min-height: 380px;
   overflow: auto;
 }
@@ -13259,7 +13259,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .modal-overlay.open { display: flex; }
 
 .modal {
-  background: #fff;
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: 28px;
   min-width: 400px;
@@ -13328,7 +13328,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   color: var(--text, #111827);
 }
 .modal-close-btn:focus-visible {
-  outline: 2px solid var(--primary, #0E9F6E);
+  outline: 2px solid var(--primary, var(--color-brand));
   outline-offset: 2px;
 }
 .modal-close-btn:disabled {
@@ -13381,7 +13381,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .form-row select:focus {
   outline: none;
   border-color: var(--primary);
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .form-msg { font-size: 13px; min-height: 18px; margin-top: 6px; }
@@ -13499,7 +13499,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .btn {
   padding: 8px 16px;
   border: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   border-radius: 8px;
   font-size: 13px;
@@ -13513,7 +13513,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .btn-primary {
   background: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
   border-color: var(--primary);
 }
 
@@ -13617,7 +13617,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   box-shadow: 0 0 12px rgba(91, 87, 214, 0.45);
 }
 .plan-rail-bar-cell.is-failed { background: var(--danger); }
-.plan-rail-bar-cell.is-blocked { background: #d97706; opacity: 0.75; }
+.plan-rail-bar-cell.is-blocked { background: var(--color-warning); opacity: 0.75; }
 .plan-rail-control {
   flex: 0 0 auto;
   display: inline-flex;
@@ -13709,10 +13709,10 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .plan-rail-step.is-pending .plan-rail-svg-icon { color: #64748b; }
 .plan-rail-step.is-in_progress .plan-rail-svg-icon { color: var(--primary); }
-.plan-rail-step.is-done .plan-rail-svg-icon { color: #16a34a; }
+.plan-rail-step.is-done .plan-rail-svg-icon { color: var(--color-success); }
 .plan-rail-step.is-failed .plan-rail-svg-icon { color: var(--danger); }
 .plan-rail-step.is-skipped .plan-rail-svg-icon { color: #94a3b8; }
-.plan-rail-step.is-blocked .plan-rail-svg-icon { color: #d97706; }
+.plan-rail-step.is-blocked .plan-rail-svg-icon { color: var(--color-warning); }
 .plan-rail-step-num {
   font-variant-numeric: tabular-nums;
   opacity: 0.6;
@@ -13812,7 +13812,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .access-denied.open { display: flex; }
 
 .access-denied-box {
-  background: #fff;
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: 32px 36px;
   max-width: 420px;
@@ -13864,7 +13864,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .agents-grid-scroll {
@@ -13913,8 +13913,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-width: 22px;
   padding: 1px 8px;
   border-radius: 999px;
-  background: #E2F5EC;
-  color: #0E9F6E;
+  background: var(--color-brand-soft);
+  color: var(--color-brand);
   font-size: 12px;
   font-weight: 700;
   text-align: center;
@@ -13946,7 +13946,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex-direction: column;
   gap: 2px;
   padding: 14px 16px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 10px;
   cursor: pointer;
@@ -14077,7 +14077,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agent-card:hover .agent-card-more,
 .agent-card:focus-within .agent-card-more,
 .agent-card.is-menu-open .agent-card-more { visibility: visible; }
-.agent-card-more:hover { background: rgba(20, 71, 55, 0.08); color: #3E5A4C; }
+.agent-card-more:hover { background: rgba(20, 71, 55, 0.08); color: var(--color-ink-2); }
 
 .agent-card-desc {
   flex: 1;
@@ -14133,7 +14133,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agents-detail-breadcrumb {
   padding: 12px 24px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   flex-shrink: 0;
 }
 
@@ -14141,7 +14141,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   position: fixed;
   z-index: var(--z-popover);
   min-width: 96px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 6px;
   box-shadow: 0 6px 20px rgba(20, 71, 55, 0.12);
@@ -14155,8 +14155,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   user-select: none;
 }
 .agent-row-menu-item:hover { background: #f1f5f9; }
-.agent-row-menu-item.is-danger { color: #dc2626; }
-.agent-row-menu-item.is-danger:hover { background: #fef2f2; }
+.agent-row-menu-item.is-danger { color: var(--color-danger); }
+.agent-row-menu-item.is-danger:hover { background: var(--color-danger-soft); }
 
 .agents-detail-col {
   flex: 1;
@@ -14190,7 +14190,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agents-detail-header {
   padding: 14px 20px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   flex-shrink: 0;
 }
 
@@ -14241,7 +14241,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid var(--border-strong);
   border-radius: 6px;
   outline: none;
-  background: #fff;
+  background: var(--color-surface);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -14261,7 +14261,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agents-detail-title-row > .agents-detail-source-row { flex-shrink: 0; }
 .agents-detail-title-row > .detail-actions { flex-shrink: 0; margin-left: auto; }
 .agents-detail-name.is-editing {
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 0 0 1px var(--border-strong) inset;
 }
 .agents-detail-name.is-editing:focus {
@@ -14393,7 +14393,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .agents-profile-block.is-nested {
   height: 100%;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .agents-profile-block-head {
@@ -14402,7 +14402,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   gap: 8px;
   font-size: 12px;
   font-weight: 700;
-  color: #3E5A4C;
+  color: var(--color-ink-2);
 }
 
 .agents-profile-block-count {
@@ -14410,7 +14410,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 1px 7px;
   border-radius: 999px;
   background: rgba(79, 70, 229, 0.10);
-  color: #0E9F6E;
+  color: var(--color-brand);
   font-size: 11px;
   text-align: center;
 }
@@ -14442,7 +14442,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-width: 0;
   padding: 9px 10px;
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid rgba(148, 163, 184, 0.16);
 }
 
@@ -14501,7 +14501,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-width: 0;
   padding: 9px 10px;
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid rgba(148, 163, 184, 0.16);
 }
 
@@ -14539,13 +14539,13 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .agents-detail-content {
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .agents-detail-header {
   padding: 14px 20px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   flex-shrink: 0;
 }
 
@@ -14619,11 +14619,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-size: 23px;
   line-height: 1.1;
   font-weight: 800;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
 }
 
 .agents-detail-stat.is-memory .agents-detail-stat-value {
-  color: #0f172a;
+  color: var(--color-overlay-ink);
 }
 
 .agents-detail-stat-value small {
@@ -14778,7 +14778,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .agents-memory-add {
   border: 1px solid var(--border, #e5e7eb);
-  background: #fff;
+  background: var(--color-surface);
   color: #475569;
   border-radius: 999px;
   padding: 1px 8px;
@@ -14831,20 +14831,20 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .agents-memory-chip-remove:hover {
   background: rgba(20, 71, 55, 0.08);
-  color: #0f172a;
+  color: var(--color-overlay-ink);
 }
 
 .agents-detail-body {
   align-items: center;
   padding: 0 0 56px;
   gap: 22px;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .agents-detail-hero {
   width: 100%;
   padding: 28px 24px 16px;
-  background: #fff;
+  background: var(--color-surface);
   border-bottom: 0;
   display: flex;
   flex-direction: column;
@@ -14990,7 +14990,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-height: 26px;
   padding: 4px 10px;
   background: #edf1f6;
-  color: #3E5A4C;
+  color: var(--color-ink-2);
   font-weight: 650;
 }
 
@@ -15053,7 +15053,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-height: 220px;
   padding: 12px;
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border-strong);
   overflow-y: auto;
 }
@@ -15114,7 +15114,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 13px 15px;
   border-radius: 8px;
   border: 1px solid rgba(244, 63, 94, 0.16);
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .agents-memory-card-head {
@@ -15266,7 +15266,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agents-detail-workflow.is-editing {
   padding: 12px;
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border-strong);
   border-color: var(--border-strong);
 }
@@ -15297,7 +15297,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .agent-chat-link {
@@ -15337,7 +15337,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .agents-chat-input-area {
   border-top: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   padding: 10px 12px 12px 10px;
   display: grid;
   grid-template-columns: 30px minmax(0, 1fr) 34px;
@@ -15364,7 +15364,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .agents-chat-input-area textarea:focus {
   border-color: var(--primary);
-  background: #fff;
+  background: var(--color-surface);
 }
 .agents-chat-input-area .chat-send-btn {
   width: 34px;
@@ -15447,7 +15447,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
+  color: var(--color-surface);
   background: linear-gradient(135deg, var(--primary), #3EC6A0);
   box-shadow: 0 8px 22px rgba(14, 159, 110, 0.28);
 }
@@ -15493,8 +15493,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-radius: 50%;
   font-size: 20px;
   font-weight: 700;
-  color: #fff;
-  background: linear-gradient(135deg, #0E9F6E, #3EC6A0);
+  color: var(--color-surface);
+  background: linear-gradient(135deg, var(--color-brand), #3EC6A0);
 }
 .hub-account-avatar.is-gradient::after {
   content: '';
@@ -15550,8 +15550,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .hub-hero-cta { margin-top: 4px; }
 
 .hub-alert {
-  background: var(--warn, #fef3c7);
-  color: #92400e;
+  background: var(--warn, var(--color-warning-soft));
+  color: var(--color-warning-text);
   border-radius: var(--radius-sm);
   padding: 8px 12px;
   font-size: 12px;
@@ -15760,7 +15760,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   white-space: nowrap;
   transition: background .15s, border-color .15s;
 }
-.hub-btn-mini:hover { background: #fef2f2; border-color: var(--danger); }
+.hub-btn-mini:hover { background: var(--color-danger-soft); border-color: var(--danger); }
 .hub-btn-mini-ghost { color: var(--primary-text); }
 .hub-btn-mini-ghost:hover { background: var(--primary-soft); border-color: var(--primary); }
 
@@ -15853,7 +15853,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   cursor: pointer;
 }
 .hub-deletion-check input { margin-top: 2px; }
-.hub-alert-danger { background: #fef2f2; color: var(--danger); }
+.hub-alert-danger { background: var(--color-danger-soft); color: var(--danger); }
 
 /* ── Hub account icon polish (SVG via modules/icons.js) ──────────────── */
 .hub-alert-icon { width: 15px; height: 15px; flex: none; margin-right: 6px; vertical-align: -2px; }
@@ -16168,7 +16168,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 18px;
   margin: 2px;
   border-radius: 50%;
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 1px 3px rgba(15, 23, 42, .2);
   transition: transform .15s;
 }
@@ -16312,7 +16312,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-weight: 600;
 }
 .messaging-scan-button,
-.messaging-link-button { border-color: var(--primary); background: var(--primary); color: #fff; }
+.messaging-link-button { border-color: var(--primary); background: var(--primary); color: var(--color-surface); }
 .messaging-scan-button:hover:not(:disabled),
 .messaging-link-button:hover:not(:disabled) { filter: brightness(1.04); }
 .messaging-secondary-button { border-color: var(--border); background: var(--surface); color: var(--text-2); }
@@ -16406,7 +16406,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 8px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--muted);
   text-align: center;
 }
@@ -17299,7 +17299,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .feedback-textarea:focus {
   outline: none;
-  border-color: var(--primary, #0E9F6E);
+  border-color: var(--primary, var(--color-brand));
   box-shadow: 0 0 0 3px rgba(14,159,110,.12);
 }
 .feedback-meta-row,
@@ -17329,7 +17329,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 8px;
   padding: 8px;
-  background: #fff;
+  background: var(--color-surface);
 }
 .feedback-image-thumb {
   position: relative;
@@ -17356,7 +17356,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 22px;
   height: 22px;
   border: 2px solid rgba(255, 255, 255, 0.72);
-  border-top-color: var(--primary, #0E9F6E);
+  border-top-color: var(--primary, var(--color-brand));
   border-radius: 50%;
   animation: feedback-spin 0.8s linear infinite;
   box-shadow: 0 1px 8px rgba(20, 71, 55, 0.16);
@@ -17365,7 +17365,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 22px;
   height: 22px;
   border: 2px solid #cbd5e1;
-  border-top-color: var(--primary, #0E9F6E);
+  border-top-color: var(--primary, var(--color-brand));
   border-radius: 50%;
   animation: feedback-spin 0.8s linear infinite;
 }
@@ -17383,7 +17383,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-color: rgba(220, 38, 38, 0.35);
 }
 .feedback-image-item.is-failed .feedback-image-name {
-  color: #b91c1c;
+  color: var(--color-danger-hover);
 }
 .feedback-image-remove {
   position: absolute;
@@ -17401,7 +17401,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .feedback-image-remove:hover {
   background: #f1f5f9;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
 }
 
 /* ── Custom dropdown (AiSelect) ────────────────────────────────────────── */
@@ -17419,7 +17419,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   justify-content: space-between;
   gap: 10px;
   padding: 8px 12px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 8px;
   cursor: pointer;
@@ -17431,7 +17431,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .ai-select-trigger:hover { border-color: #cbd5e1; }
 .ai-select.open .ai-select-trigger,
 .ai-select-trigger:focus {
-  border-color: var(--primary, #0E9F6E);
+  border-color: var(--primary, var(--color-brand));
   outline: none;
   box-shadow: 0 0 0 3px rgba(14,159,110,.12);
 }
@@ -17466,7 +17466,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   /* Base layer for body-portaled popovers. `_aiSelectMount` also raises
      this dynamically against currently open app overlays. */
   z-index: var(--z-modal-popover);
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 8px;
   box-shadow: 0 10px 24px rgba(20,71,55,.12);
@@ -17486,7 +17486,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .ai-select-item:hover { background: #f3f4f6; }
 .ai-select-item.active {
   background: rgba(14,159,110,.08);
-  color: var(--primary, #0E9F6E);
+  color: var(--primary, var(--color-brand));
 }
 .ai-select-item-label {
   font-size: 13px;
@@ -17495,10 +17495,10 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   gap: 6px;
 }
-.ai-select-item.active .ai-select-item-label { color: var(--primary, #0E9F6E); font-weight: 500; }
+.ai-select-item.active .ai-select-item-label { color: var(--primary, var(--color-brand)); font-weight: 500; }
 .ai-select-option-icon {
   display: inline-flex;
-  color: #d97706;
+  color: var(--color-warning);
 }
 .ai-select-svg-icon {
   width: 14px;
@@ -17608,7 +17608,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .entry-row.is-default .entry-rank {
   background: var(--primary);
-  color: #fff;
+  color: var(--color-surface);
 }
 
 .entry-main {
@@ -18014,7 +18014,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .method-tile:hover {
   background: rgba(14,159,110,.04);
-  border-color: var(--primary, #0E9F6E);
+  border-color: var(--primary, var(--color-brand));
 }
 .method-tile:active { transform: scale(0.98); }
 .method-title {
@@ -18047,7 +18047,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin-bottom: 10px;
 }
 .oauth-flow-stage.ok { color: #047857; }
-.oauth-flow-stage.error { color: #b91c1c; }
+.oauth-flow-stage.error { color: var(--color-danger-hover); }
 .oauth-flow-actions {
   display: flex;
   gap: 8px;
@@ -18086,7 +18086,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-family: inherit;
   font-size: 13px;
 }
-.oauth-input:focus { outline: none; border-color: var(--primary, #0E9F6E); }
+.oauth-input:focus { outline: none; border-color: var(--primary, var(--color-brand)); }
 
 /* :disabled — the shared .btn already carries padding / radius / color from
    line 3100 block; keep only the semantic state here. */
@@ -18111,7 +18111,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .devtools-card {
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 10px;
-  background: #fff;
+  background: var(--color-surface);
   padding: 14px 16px;
   display: flex;
   flex-direction: column;
@@ -18195,8 +18195,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .devtools-list-model               { color: var(--text-muted, #6b7280); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 .devtools-list-status              { font-weight: 500; }
 .devtools-list-status.ok           { color: #059669; }
-.devtools-list-status.err          { color: #dc2626; }
-.devtools-list-status.abort        { color: #d97706; }
+.devtools-list-status.err          { color: var(--color-danger); }
+.devtools-list-status.abort        { color: var(--color-warning); }
 .devtools-list-preview             {
   margin-top: 4px;
   font-size: 11px;
@@ -18281,7 +18281,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15), 0 1px 1px rgba(0, 0, 0, 0.06);
   transition: transform 0.18s ease;
 }
@@ -18289,11 +18289,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   background: #d1d5db;
 }
 .toggle-switch input[type="checkbox"]:checked {
-  background: #0E9F6E;
+  background: var(--color-brand);
   box-shadow: inset 0 0 0 1px rgba(14, 159, 110, 0.5);
 }
 .toggle-switch input[type="checkbox"]:checked:hover {
-  background: #0A7A55;
+  background: var(--color-brand-hover);
 }
 .toggle-switch input[type="checkbox"]:checked::after { transform: translateX(14px); }
 .toggle-switch input[type="checkbox"]:focus-visible {
@@ -18318,8 +18318,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin: 8px 0;
   padding: 6px 10px;
   border-radius: 6px;
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--color-warning-soft);
+  color: var(--color-warning-text);
   border: 1px solid #fde68a;
   font-size: 12px;
 }
@@ -18354,10 +18354,10 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 /* Session-kind badges (agent-edit / skill-edit / KB image vision). conv (主对话)
    intentionally has no badge — it's the default. */
-.devtools-list-badge.is-kind-agent       { background: #fef3c7; color: #92400e; }
+.devtools-list-badge.is-kind-agent       { background: var(--color-warning-soft); color: var(--color-warning-text); }
 .devtools-list-badge.is-kind-skill       { background: #ecfccb; color: #4d7c0f; }
 .devtools-list-badge.is-kind-extract-img { background: #fce7f3; color: #9d174d; }
-.devtools-list-badge.is-kind-cli         { background: #E2F5EC; color: #0A7A55; }
+.devtools-list-badge.is-kind-cli         { background: var(--color-brand-soft); color: var(--color-brand-hover); }
 
 /* ── Devtools skill-metrics table ── */
 .devtools-skill-metrics-summary {
@@ -18419,8 +18419,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   line-height: 1.5;
 }
 .devtools-skill-badge.is-custom   { background: #ecfccb; color: #4d7c0f; }
-.devtools-skill-badge.is-platform { background: #E2F5EC; color: #0A7A55; }
-.devtools-skill-badge.is-b        { background: #fef3c7; color: #92400e; }
+.devtools-skill-badge.is-platform { background: var(--color-brand-soft); color: var(--color-brand-hover); }
+.devtools-skill-badge.is-b        { background: var(--color-warning-soft); color: var(--color-warning-text); }
 
 .devtools-skill-health {
   display: inline-flex;
@@ -18437,16 +18437,16 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-variant-numeric: tabular-nums;
   opacity: 0.75;
 }
-.devtools-skill-health.is-healthy { background: #dcfce7; color: #166534; }
-.devtools-skill-health.is-underused { background: #fef3c7; color: #92400e; }
+.devtools-skill-health.is-healthy { background: var(--color-success-soft); color: #166534; }
+.devtools-skill-health.is-underused { background: var(--color-warning-soft); color: var(--color-warning-text); }
 .devtools-skill-health.is-needs_review { background: #ffedd5; color: #9a3412; }
 .devtools-skill-health.is-ineffective { background: #fee2e2; color: #991b1b; }
 .devtools-skill-health.is-insufficient_data { background: #f1f5f9; color: #475569; }
 
 .devtools-skill-metrics-days { display: inline-flex; gap: 4px; margin-right: 6px; }
 .devtools-skill-metrics-days .btn.active {
-  background: var(--primary, #0E9F6E);
-  color: #fff;
+  background: var(--primary, var(--color-brand));
+  color: var(--color-surface);
   border-color: transparent;
 }
 
@@ -18498,7 +18498,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 /* 图片图标(透明底)用白底衬托，避免彩色圆背景干扰 logo 配色 */
 .avatar-circle:has(.avatar-img) {
-  background: #fff;
+  background: var(--color-surface);
 }
 .avatar-circle.is-clickable {
   cursor: pointer;
@@ -18529,7 +18529,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex-direction: column;
   gap: 12px;
   padding: 12px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 12px;
   box-shadow: 0 12px 32px rgba(20, 71, 55, 0.14);
@@ -18568,7 +18568,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .avatar-picker-icon-cell:hover { background: #f1f5f9; }
 .avatar-picker-icon-cell.is-active {
   background: rgba(14, 159, 110, 0.1);
-  color: var(--primary, #0E9F6E);
+  color: var(--primary, var(--color-brand));
   border-color: rgba(14, 159, 110, 0.4);
 }
 .avatar-picker-color-cell {
@@ -18577,7 +18577,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 28px;
 }
 .avatar-picker-color-cell.is-active {
-  outline: 2px solid var(--primary, #0E9F6E);
+  outline: 2px solid var(--primary, var(--color-brand));
   outline-offset: 2px;
   transform: scale(1.05);
 }
@@ -18591,8 +18591,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-size: 11px;
   font-weight: 600;
   border-radius: 999px;
-  background: #E2F5EC;
-  color: #0A7A55;
+  background: var(--color-brand-soft);
+  color: var(--color-brand-hover);
   white-space: nowrap;
   vertical-align: middle;
 }
@@ -18631,12 +18631,12 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agents-ext-peer-state { font-size: 12px; color: var(--cs-ink-soft, #666); }
 .agents-ext-peer-kind {
   font-size: 11px; padding: 1px 7px; border-radius: 999px;
-  background: #E2F5EC; color: #0A7A55; white-space: nowrap;
+  background: var(--color-brand-soft); color: var(--color-brand-hover); white-space: nowrap;
 }
 .agents-ext-peers-meta { font-size: 11px; color: var(--cs-ink-soft, #666); }
 .agents-ext-peer-actions { margin-left: auto; display: flex; gap: 6px; align-items: center; }
 .agents-ext-peer-actions .btn.is-danger {
-  color: #dc2626; border-color: rgba(220, 38, 38, 0.35);
+  color: var(--color-danger); border-color: rgba(220, 38, 38, 0.35);
 }
 .agents-ext-peer-actions .btn.is-danger:hover {
   background: rgba(220, 38, 38, 0.08);
@@ -18727,7 +18727,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background: #fff;
+  background: var(--color-surface);
 }
 .marketplace-header {
   display: flex;
@@ -18749,7 +18749,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-radius: 6px;
   cursor: pointer;
 }
-.marketplace-tab.is-active { background: var(--accent-soft, #E2F5EC); color: var(--text); }
+.marketplace-tab.is-active { background: var(--accent-soft, var(--color-brand-soft)); color: var(--text); }
 .marketplace-status-filter {
   display: flex;
   align-items: center;
@@ -18840,9 +18840,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   color: var(--text);
 }
 .marketplace-chip.is-active {
-  background: var(--accent, #0E9F6E);
+  background: var(--accent, var(--color-brand));
   border-color: transparent;
-  color: #fff;
+  color: var(--color-surface);
 }
 
 .marketplace-body {
@@ -18871,7 +18871,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 8px 12px;
   border-radius: var(--radius-md, 8px);
   background: rgba(14, 159, 110, 0.08);
-  color: #0A7A55;
+  color: var(--color-brand-hover);
   font-size: 12px;
   line-height: 1.5;
 }
@@ -18903,7 +18903,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 28px;
   border-radius: 50%;
   border: 3px solid #cbd5e1;
-  border-top-color: #0E9F6E;
+  border-top-color: var(--color-brand);
   animation: marketplace-upload-spin 0.8s linear infinite;
 }
 .marketplace-upload-loading-text {
@@ -18921,7 +18921,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skill-card-chip.is-platform {
   border-color: rgba(14, 159, 110, 0.22);
   background: rgba(14, 159, 110, 0.05);
-  color: #0A7A55;
+  color: var(--color-brand-hover);
 }
 .marketplace-card-chip.is-user,
 .agent-card-chip.is-user,
@@ -18986,7 +18986,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background: #fff;
+  background: var(--color-surface);
 }
 .marketplace-card-header { display: flex; align-items: baseline; gap: 8px; }
 .marketplace-card-name {
@@ -19051,7 +19051,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .agent-card-chip.spaces-gate.is-gate-failed {
   border-color: rgba(239, 68, 68, 0.28);
   background: rgba(239, 68, 68, 0.05);
-  color: #b91c1c;
+  color: var(--color-danger-hover);
 }
 .agent-card-chip.spaces-gate.is-gate-not-checked {
   border-color: rgba(100, 116, 139, 0.18);
@@ -19109,7 +19109,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 /* Keyboard focus must stay visible — this is the only affordance for reaching
    the panel without a pointer. */
 .skill-card-shield:focus-visible {
-  outline: 2px solid var(--primary, #0E9F6E);
+  outline: 2px solid var(--primary, var(--color-brand));
   outline-offset: 2px;
   border-radius: 3px;
 }
@@ -19174,7 +19174,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background: #fff;
+  background: var(--color-surface);
 }
 /* Marketplace detail header — padding mirrors `.agents-detail-header` so the in-app and
    marketplace detail pages share one chrome density. */
@@ -19194,9 +19194,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .marketplace-detail-version { font-size: 12px; color: var(--muted); margin-left: 8px; font-weight: 400; }
 .marketplace-detail-meta-row { display: flex; gap: 6px; flex-wrap: nowrap; flex-shrink: 0; }
 .marketplace-detail-sync-prod-btn {
-  background: var(--primary-soft, #E2F5EC);
+  background: var(--primary-soft, var(--color-brand-soft));
   border-color: rgba(91, 87, 214, 0.28);
-  color: var(--primary-text, #0A7A55);
+  color: var(--primary-text, var(--color-brand-hover));
 }
 .marketplace-detail-sync-prod-btn:hover {
   background: rgba(91, 87, 214, 0.16);
@@ -19258,7 +19258,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .marketplace-skill-file:last-child { border-bottom: none; }
 .marketplace-skill-file:hover { background: rgba(79,70,229,0.04); }
-.marketplace-skill-file.is-active { background: var(--accent-soft, #E2F5EC); color: var(--text); font-weight: 500; }
+.marketplace-skill-file.is-active { background: var(--accent-soft, var(--color-brand-soft)); color: var(--text); font-weight: 500; }
 .marketplace-skill-file-body { min-width: 0; overflow-x: auto; }
 .marketplace-skill-code {
   font-size: 12px;
@@ -19512,7 +19512,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 52px;
   border-radius: 50%;
   background: var(--accent-soft, rgba(59, 130, 246, 0.12));
-  color: var(--accent, #0E9F6E);
+  color: var(--accent, var(--color-brand));
   margin-bottom: 4px;
 }
 .auto-tpl-hero-clock { width: 24px; height: 24px; }
@@ -19888,7 +19888,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   gap: 16px;
   padding: 12px 20px 0;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   flex-shrink: 0;
 }
 .connectors-tab {
@@ -19900,7 +19900,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   color: var(--text-muted, #6b7280);
   border-bottom: 2px solid transparent;
 }
-.connectors-tab.is-active { color: var(--text); border-bottom-color: #0E9F6E; }
+.connectors-tab.is-active { color: var(--text); border-bottom-color: var(--color-brand); }
 .connectors-grid-scroll { flex: 1; display: flex; flex-direction: column; overflow-y: auto; padding: 20px 28px 28px; }
 .connectors-group { flex-shrink: 0; padding: 6px 0; }
 .connectors-group-label {
@@ -19957,7 +19957,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
+  color: var(--color-surface);
   font-size: 14px;
   font-weight: 700;
   letter-spacing: -0.04em;
@@ -20073,11 +20073,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .connector-card:hover .connector-card-menu-btn,
 .connector-card:focus-within .connector-card-menu-btn,
 .connector-card.is-menu-open .connector-card-menu-btn { visibility: visible; }
-.connector-card-menu-btn:hover { background: rgba(20, 71, 55, 0.08); color: #3E5A4C; }
+.connector-card-menu-btn:hover { background: rgba(20, 71, 55, 0.08); color: var(--color-ink-2); }
 .connector-card-menu-popover {
   position: fixed;
   z-index: var(--z-popover);
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid rgba(20, 71, 55, 0.12);
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(20, 71, 55, 0.12);
@@ -20092,7 +20092,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   user-select: none;
 }
 .connector-card-menu-item:hover { background: rgba(20, 71, 55, 0.05); }
-.connector-card-menu-item.is-danger { color: #dc2626; }
+.connector-card-menu-item.is-danger { color: var(--color-danger); }
 .connector-card-menu-item.is-danger:hover { background: rgba(220, 38, 38, 0.08); }
 
 /* Disabled-but-connected card: muted look so the user can tell at a glance which connector
@@ -20119,7 +20119,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   cursor: pointer;
   padding: 4px 8px;
 }
-.connector-card-foot .btn-link:hover { color: #0E9F6E; }
+.connector-card-foot .btn-link:hover { color: var(--color-brand); }
 
 /* Tab count badge */
 .connectors-tab { display: inline-flex; align-items: center; gap: 6px; }
@@ -20141,7 +20141,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .connectors-detail-header {
   padding: 14px 20px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   display: flex;
   align-items: center;
   gap: 12px;
@@ -20182,7 +20182,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: min(520px, 92vw);
   max-height: 88vh;
   overflow: auto;
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 12px;
   padding: 20px 24px;
   display: flex;
@@ -20198,7 +20198,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 6px 8px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: #fff;
+  background: var(--color-surface);
 }
 #connectors-connect-modal .form-hint { font-size: 11px; display: inline-block; }
 #connectors-connect-modal .modal-actions { display: flex; gap: 8px; justify-content: flex-end; }
@@ -20222,7 +20222,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex-direction: column;
   min-height: 0;
   border-left: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   box-shadow: -12px 0 28px rgba(20, 71, 55, 0.05);
   z-index: var(--z-sticky);
@@ -20263,7 +20263,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   cursor: pointer;
 }
 .chat-md-drawer-close:hover {
-  color: #0f172a;
+  color: var(--color-overlay-ink);
   background: #f1f5f9;
   border-color: #e2e8f0;
 }
@@ -20291,7 +20291,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   z-index: var(--z-popover);
   min-width: 160px;
   padding: 4px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(20, 71, 55, 0.12);
@@ -20325,7 +20325,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .context-menu-icon .ui-icon { width: 16px; height: 16px; }
 .context-menu-label { min-width: 0; }
 .context-menu-item:hover,
-.context-menu-item.is-active { background: var(--accent-soft, #E2F5EC); }
+.context-menu-item.is-active { background: var(--accent-soft, var(--color-brand-soft)); }
 .context-menu-item.is-disabled { color: #94a3b8; cursor: not-allowed; }
 .context-menu-item.is-disabled:hover { background: transparent; }
 
@@ -20378,7 +20378,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .memory-detail-header {
   padding: 14px 20px;
   border-bottom: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   flex-shrink: 0;
 }
 .memory-detail-title-row {
@@ -20603,7 +20603,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-radius: 5px;
   background: transparent;
   border: 1.5px solid var(--border-strong);
-  color: #fff;
+  color: var(--color-surface);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -20727,7 +20727,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .driver-badge-icon { width: 10px; height: 10px; }
 .driver-badge--install { color: #0ea5e9; background: color-mix(in srgb, #0ea5e9 12%, transparent); }
-.driver-badge--cli { color: #8b5cf6; background: color-mix(in srgb, #8b5cf6 12%, transparent); }
+.driver-badge--cli { color: var(--color-violet); background: color-mix(in srgb, var(--color-violet) 12%, transparent); }
 .driver-badge--mcp { color: #10b981; background: color-mix(in srgb, #10b981 12%, transparent); }
 
 /* Public runtime styles synced from the desktop distribution. */
@@ -20741,7 +20741,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid rgba(255, 255, 255, 0.28);
   border-radius: 6px;
   background: rgba(20, 71, 55, 0.72);
-  color: #fff;
+  color: var(--color-surface);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -20802,7 +20802,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid rgba(255, 255, 255, 0.28);
   border-radius: 6px;
   background: rgba(20, 71, 55, 0.72);
-  color: #fff;
+  color: var(--color-surface);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -20846,7 +20846,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 14px 16px;
   border: 1px solid #e2e8f0;
   border-radius: 10px;
-  background: #fff;
+  background: var(--color-surface);
 }
 .chat-md-audio-icon {
   grid-row: 1 / span 2;
@@ -20868,7 +20868,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   white-space: nowrap;
   font-size: 13px;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
 }
 .chat-md-audio {
   display: block;
@@ -20900,7 +20900,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 18px;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 10px 28px rgba(20, 71, 55, 0.08);
 }
 .chat-file-viewer-audio-icon {
@@ -20923,7 +20923,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   white-space: nowrap;
   font-size: 13px;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--color-overlay-ink);
 }
 .chat-file-viewer-audio {
   width: 100%;
@@ -20986,7 +20986,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   top: 1px;
   width: 5px;
   height: 8px;
-  border: solid #fff;
+  border: solid var(--color-surface);
   border-width: 0 2px 2px 0;
   transform: rotate(45deg);
 }
@@ -21079,7 +21079,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 6px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 16px 40px rgba(20, 71, 55, 0.18);
 }
 .bash-permission-mode-menu[hidden] {
@@ -21206,7 +21206,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   height: 34px;
   border-radius: 8px;
   color: #166534;
-  background: #dcfce7;
+  background: var(--color-success-soft);
 }
 
 .interactive-cli-terminal-icon,
@@ -21259,7 +21259,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .interactive-cli-status[data-status="running"] {
   color: #166534;
-  background: #dcfce7;
+  background: var(--color-success-soft);
 }
 
 .interactive-cli-status[data-status="error"],
@@ -21269,7 +21269,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .interactive-cli-prompt {
-  color: #92400e;
+  color: var(--color-warning-text);
   background: rgba(245, 158, 11, 0.16);
 }
 
@@ -21708,7 +21708,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-collaboration-status[data-busy="1"] { opacity: .72; }
 
 .model-authorization-list { display: grid; gap: 10px; margin-top: 12px; }
-.model-authorization-card { display: grid; gap: 8px; padding: 14px; border: 1px solid var(--border, #e5e7eb); border-radius: 12px; background: var(--surface-1, #fff); }
+.model-authorization-card { display: grid; gap: 8px; padding: 14px; border: 1px solid var(--border, #e5e7eb); border-radius: 12px; background: var(--surface-1, var(--color-surface)); }
 .model-authorization-card-head { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; }
 .model-authorization-card-title { font-weight: 650; }
 .model-authorization-card-meta { color: var(--text-muted, #6b7280); font-size: 12px; }
@@ -21722,36 +21722,36 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .model-authorization-model-remove-icon { width: 13px; height: 13px; }
 .model-authorization-steps { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 18px 12px; }
 .model-authorization-step { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border-radius: 999px; background: var(--surface-2, #f3f4f6); color: var(--text-muted, #6b7280); font-size: 12px; }
-.model-authorization-step.is-active { background: var(--accent-soft, #E2F5EC); color: var(--accent, #0E9F6E); font-weight: 650; }
-.model-authorization-step.is-done { background: var(--accent-soft, #E2F5EC); color: var(--accent, #0E9F6E); }
+.model-authorization-step.is-active { background: var(--accent-soft, var(--color-brand-soft)); color: var(--accent, var(--color-brand)); font-weight: 650; }
+.model-authorization-step.is-done { background: var(--accent-soft, var(--color-brand-soft)); color: var(--accent, var(--color-brand)); }
 .model-authorization-step-check { font-size: 11px; font-weight: 800; }
 .model-authorization-body { display: grid; gap: 14px; }
 .model-authorization-choice-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; }
-.model-authorization-choice { text-align: left; padding: 14px; border: 1px solid var(--border, #e5e7eb); border-radius: 12px; background: var(--surface-1, #fff); }
-.model-authorization-choice:hover { border-color: var(--accent, #0E9F6E); }
+.model-authorization-choice { text-align: left; padding: 14px; border: 1px solid var(--border, #e5e7eb); border-radius: 12px; background: var(--surface-1, var(--color-surface)); }
+.model-authorization-choice:hover { border-color: var(--accent, var(--color-brand)); }
 .model-authorization-provider-main { min-width: 0; overflow-wrap: anywhere; }
 .model-authorization-model-list { display: grid; gap: 6px; max-height: 280px; overflow: auto; border: 1px solid var(--border, #e5e7eb); border-radius: 12px; padding: 8px; }
 .model-authorization-model-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 8px; border-radius: 8px; }
 .model-authorization-model-row > span { min-width: 0; overflow-wrap: anywhere; }
 .model-authorization-model-row:hover { background: var(--surface-2, #f3f4f6); }
-.model-authorization-warning { border: 1px solid var(--warning, #f59e0b); background: var(--warning-soft, #fffbeb); color: var(--warning-text, #92400e); border-radius: 10px; padding: 10px 12px; }
+.model-authorization-warning { border: 1px solid var(--warning, #f59e0b); background: var(--warning-soft, #fffbeb); color: var(--warning-text, var(--color-warning-text)); border-radius: 10px; padding: 10px 12px; }
 .model-authorization-progress { color: var(--text-muted, #6b7280); font-size: 13px; }
 .model-authorization-provider-grid { grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); }
 .model-authorization-provider-card { display: flex; gap: 10px; align-items: flex-start; cursor: pointer; }
-.model-authorization-provider-card:hover { border-color: var(--accent, #0E9F6E); box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06); }
+.model-authorization-provider-card:hover { border-color: var(--accent, var(--color-brand)); box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06); }
 .model-authorization-provider-logo {
   display: inline-flex; align-items: center; justify-content: center;
   width: 34px; height: 34px; flex-shrink: 0; border-radius: 10px;
-  background: color-mix(in srgb, var(--provider-color, #6b7280) 14%, #fff);
+  background: color-mix(in srgb, var(--provider-color, #6b7280) 14%, var(--color-surface));
   color: var(--provider-color, #6b7280);
   font-size: 16px; font-weight: 750; line-height: 1;
 }
 .model-authorization-provider-main { display: grid; gap: 3px; min-width: 0; }
 .model-authorization-provider-title { font-weight: 650; display: block; }
-.model-authorization-provider-note { display: block; color: var(--warning-text, #92400e); font-size: 12px; line-height: 1.45; }
+.model-authorization-provider-note { display: block; color: var(--warning-text, var(--color-warning-text)); font-size: 12px; line-height: 1.45; }
 .model-authorization-provider-configured { display: inline-block; margin-left: 6px; padding: 1px 8px; border-radius: 999px; background: var(--surface-2, #f3f4f6); color: var(--text-muted, #6b7280); font-size: 11px; font-weight: 600; vertical-align: middle; }
-.model-authorization-provider-badge { display: inline-block; margin-left: 6px; padding: 1px 8px; border-radius: 999px; background: var(--accent-soft, #E2F5EC); color: var(--accent, #0E9F6E); font-size: 11px; font-weight: 650; vertical-align: middle; }
-.model-authorization-provider-docs { display: block; color: var(--accent, #0E9F6E); font-size: 12px; text-decoration: none; }
+.model-authorization-provider-badge { display: inline-block; margin-left: 6px; padding: 1px 8px; border-radius: 999px; background: var(--accent-soft, var(--color-brand-soft)); color: var(--accent, var(--color-brand)); font-size: 11px; font-weight: 650; vertical-align: middle; }
+.model-authorization-provider-docs { display: block; color: var(--accent, var(--color-brand)); font-size: 12px; text-decoration: none; }
 .model-authorization-provider-docs:hover { text-decoration: underline; }
 .model-authorization-provider-card-custom { opacity: 0.9; }
 .model-authorization-provider-card-custom:hover { opacity: 1; }
@@ -21762,10 +21762,10 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .model-authorization-key-toggle {
   display: inline-flex; align-items: center; justify-content: center;
   width: 36px; border: 1px solid var(--border, #e5e7eb); border-radius: 8px;
-  background: var(--surface-1, #fff); color: var(--text-muted, #6b7280);
+  background: var(--surface-1, var(--color-surface)); color: var(--text-muted, #6b7280);
   cursor: pointer; padding: 0;
 }
-.model-authorization-key-toggle:hover { border-color: var(--accent, #0E9F6E); color: var(--accent, #0E9F6E); }
+.model-authorization-key-toggle:hover { border-color: var(--accent, var(--color-brand)); color: var(--accent, var(--color-brand)); }
 
 .model-authorization-model-chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .model-authorization-model-chip {
@@ -21774,7 +21774,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid var(--border, #e5e7eb); background: var(--surface-2, #f3f4f6);
   color: var(--text-muted, #6b7280);
 }
-.model-authorization-model-chip.is-default { border-color: var(--accent, #0E9F6E); background: var(--accent-soft, #E2F5EC); color: var(--accent, #0E9F6E); font-weight: 650; }
+.model-authorization-model-chip.is-default { border-color: var(--accent, var(--color-brand)); background: var(--accent-soft, var(--color-brand-soft)); color: var(--accent, var(--color-brand)); font-weight: 650; }
 .model-authorization-chip-check { font-size: 11px; font-weight: 800; }
 .model-authorization-auth-type {
   display: inline-block; padding: 1px 8px; border-radius: 999px;
@@ -21784,12 +21784,12 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 #skills-cognition-personal-ontology {
   --personal-onto-bg: hsl(150 25% 98%);
-  --personal-onto-card: #fff;
+  --personal-onto-card: var(--color-surface);
   --personal-onto-border: hsl(152 22% 90%);
   --personal-onto-fg: hsl(155 32% 12%);
   --personal-onto-muted: hsl(152 12% 47%);
   --personal-onto-primary: hsl(158 85% 26%);
-  --personal-onto-accent: #0E9F6E;
+  --personal-onto-accent: var(--color-brand);
   --personal-onto-green: hsl(142 76% 36%);
   --personal-onto-red: hsl(0 84% 45%);
   --personal-onto-orange: hsl(38 92% 45%);
@@ -21841,7 +21841,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .personal-onto-modal {
-  background: var(--personal-onto-card, var(--card, #fff));
+  background: var(--personal-onto-card, var(--card, var(--color-surface)));
   color: var(--personal-onto-fg, var(--fg, #111827));
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0,0,0,.18);
@@ -21853,7 +21853,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .cognition-capture-overlay { position: fixed; inset: 0; z-index: var(--z-modal); display: grid; place-items: center; background: rgba(20, 34, 42, .32); padding: 24px; }
-.cognition-capture-modal { width: min(600px, 100%); max-height: min(720px, calc(100vh - 48px)); overflow: auto; border: 1px solid #d9e1e8; border-radius: 10px; background: #fff; box-shadow: 0 18px 50px rgba(20, 34, 42, .18); color: #17263b; }
+.cognition-capture-modal { width: min(600px, 100%); max-height: min(720px, calc(100vh - 48px)); overflow: auto; border: 1px solid #d9e1e8; border-radius: 10px; background: var(--color-surface); box-shadow: 0 18px 50px rgba(20, 34, 42, .18); color: #17263b; }
 .cognition-capture-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; border-bottom: 1px solid #e6ecef; padding: 18px 20px 15px; }
 .cognition-capture-header strong, .cognition-capture-header span { display: block; }
 .cognition-capture-header strong { font-size: 18px; line-height: 1.35; }
@@ -21863,28 +21863,28 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .cognition-capture-status { margin: 0; border-left: 3px solid #277b5d; background: #eef8f2; color: #276148; padding: 9px 11px; font-size: 12px; line-height: 1.5; }
 .cognition-capture-status-error { border-left-color: #b34a4a; background: #fff3f3; color: #9b3a3a; }
 .cognition-capture-body label { display: grid; gap: 6px; color: #66778d; font-size: 12px; }
-.cognition-capture-body input, .cognition-capture-body textarea { width: 100%; border: 1px solid #d9e1e8; border-radius: 5px; background: #fff; color: #17263b; padding: 9px 10px; font: inherit; font-size: 13px; }
+.cognition-capture-body input, .cognition-capture-body textarea { width: 100%; border: 1px solid #d9e1e8; border-radius: 5px; background: var(--color-surface); color: #17263b; padding: 9px 10px; font: inherit; font-size: 13px; }
 .cognition-capture-body input:disabled, .cognition-capture-body textarea:disabled { background: #f5f7f9; color: #8a98a8; cursor: wait; }
 .cognition-capture-body textarea { min-height: 74px; resize: vertical; line-height: 1.55; }
 .cognition-capture-body input:focus, .cognition-capture-body textarea:focus { outline: none; border-color: #277b5d; box-shadow: 0 0 0 3px rgba(39,123,93,.12); }
 .cognition-capture-note { margin: 0; border-left: 3px solid #b97816; background: #fff8e8; color: #7b5b25; padding: 9px 11px; font-size: 12px; line-height: 1.5; }
 .cognition-capture-error { margin: 0; border: 1px solid #e7b8b8; background: #fff3f3; color: #9b3a3a; padding: 9px 11px; font-size: 12px; line-height: 1.5; }
 .cognition-capture-actions { display: flex; justify-content: flex-end; gap: 8px; border-top: 1px solid #e6ecef; padding: 14px 20px 18px; }
-.cognition-capture-actions .btn { border: 1px solid #d9e1e8; border-radius: 5px; background: #fff; color: #17263b; cursor: pointer; padding: 8px 12px; }
-.cognition-capture-actions .btn-primary { border-color: #277b5d; background: #277b5d; color: #fff; }
+.cognition-capture-actions .btn { border: 1px solid #d9e1e8; border-radius: 5px; background: var(--color-surface); color: #17263b; cursor: pointer; padding: 8px 12px; }
+.cognition-capture-actions .btn-primary { border-color: #277b5d; background: #277b5d; color: var(--color-surface); }
 /* Expense workbench: dense operational surface with bounded responsive tracks. */
 .expense-workbench {
   --ew-bg: var(--surface-2, #f6f7f9);
-  --ew-panel: var(--surface, #fff);
+  --ew-panel: var(--surface, var(--color-surface));
   --ew-border: var(--border, #e5e7eb);
   --ew-border-strong: var(--border-strong, #cbd5e1);
   --ew-text: var(--text, #172033);
   --ew-muted: var(--muted, #667085);
-  --ew-primary: var(--primary, #2563eb);
+  --ew-primary: var(--primary, var(--color-info));
   --ew-primary-soft: color-mix(in srgb, var(--ew-primary) 10%, var(--ew-panel));
   --ew-success: #15803d;
   --ew-warning: #b45309;
-  --ew-danger: #b91c1c;
+  --ew-danger: var(--color-danger-hover);
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -22105,7 +22105,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   margin-top: 12px;
   border: 1px solid var(--border, #d7dce4);
   border-radius: 6px;
-  background: var(--surface, #fff);
+  background: var(--surface, var(--color-surface));
   color: var(--text, #1f2937);
   padding: 14px;
 }
@@ -22121,7 +22121,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-height: 34px;
   border: 1px solid var(--border, #cfd6e0);
   border-radius: 4px;
-  background: var(--input-bg, #fff);
+  background: var(--input-bg, var(--color-surface));
   color: inherit;
   font: inherit;
   padding: 7px 8px;
@@ -22189,8 +22189,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 5px 10px;
 }
 .conversation-info-cogseed-action.is-danger {
-  color: var(--danger, #dc2626);
-  border-color: color-mix(in srgb, var(--danger, #dc2626) 45%, transparent);
+  color: var(--danger, var(--color-danger));
+  border-color: color-mix(in srgb, var(--danger, var(--color-danger)) 45%, transparent);
 }
 .conversation-info-cogseed-grid {
   display: grid;
@@ -22239,12 +22239,12 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 /* Recall cognition console. */
-.skills-cognition-console { display: flex; flex: 1 1 auto; flex-direction: column; height: 100%; min-height: 0; gap: 0; padding: 0; box-sizing: border-box; background: var(--card, #fff); }
-.skills-cognition-tabs { display: flex; flex: none; align-items: center; gap: 8px; min-width: 0; min-height: 48px; padding: 6px 20px; overflow-x: auto; overflow-y: hidden; border-bottom: 1px solid var(--border, #e5e7eb); background: color-mix(in srgb, var(--card, #fff) 96%, var(--fg, #111827) 4%); }
+.skills-cognition-console { display: flex; flex: 1 1 auto; flex-direction: column; height: 100%; min-height: 0; gap: 0; padding: 0; box-sizing: border-box; background: var(--card, var(--color-surface)); }
+.skills-cognition-tabs { display: flex; flex: none; align-items: center; gap: 8px; min-width: 0; min-height: 48px; padding: 6px 20px; overflow-x: auto; overflow-y: hidden; border-bottom: 1px solid var(--border, #e5e7eb); background: color-mix(in srgb, var(--card, var(--color-surface)) 96%, var(--fg, #111827) 4%); }
 .skills-cognition-tab { display: flex; align-items: center; gap: 9px; width: auto; min-width: max-content; min-height: 34px; margin: 0; padding: 7px 9px; border: 0; border-radius: 6px; background: transparent; color: var(--muted-fg, #6b7280); cursor: pointer; font: inherit; font-size: 13px; text-align: left; white-space: nowrap; }
-.skills-cognition-tab:hover { color: var(--fg, #111827); background: color-mix(in srgb, var(--primary, #0E9F6E) 6%, transparent); }
-.skills-cognition-tab.is-active { color: var(--fg, #111827); background: color-mix(in srgb, var(--primary, #0E9F6E) 11%, var(--card, #fff)); box-shadow: inset 0 -2px 0 var(--primary, #0E9F6E); font-weight: 600; }
-.skills-cognition-page { min-height: 100%; overflow: visible; padding: 18px 24px 28px; background: var(--card, #fff); display: flex; flex-direction: column; }
+.skills-cognition-tab:hover { color: var(--fg, #111827); background: color-mix(in srgb, var(--primary, var(--color-brand)) 6%, transparent); }
+.skills-cognition-tab.is-active { color: var(--fg, #111827); background: color-mix(in srgb, var(--primary, var(--color-brand)) 11%, var(--card, var(--color-surface))); box-shadow: inset 0 -2px 0 var(--primary, var(--color-brand)); font-weight: 600; }
+.skills-cognition-page { min-height: 100%; overflow: visible; padding: 18px 24px 28px; background: var(--card, var(--color-surface)); display: flex; flex-direction: column; }
 /* tab 切换只改 pane 的 hidden 属性（_cognitionSetPageVisibility），而上面这条
    类规则里的 display 会盖掉 UA 的 [hidden]{display:none}。少了这条守卫，六个
    pane 会全部保留布局、在 overflow:hidden 的 .skills-cognition-main 里首尾相接
@@ -22269,7 +22269,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   gap: 12px;
   width: 100%;
   padding: 14px;
-  background: var(--surface, #fff);
+  background: var(--surface, var(--color-surface));
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 12px;
   cursor: pointer;
@@ -22283,7 +22283,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 40px;
   height: 40px;
   border-radius: 10px;
-  background: var(--primary-soft, #e2f5ec);
+  background: var(--primary-soft, var(--color-brand-soft));
   color: var(--primary-text, #0f8a5f);
   display: inline-flex;
   align-items: center;
@@ -22331,7 +22331,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .connections-tab.is-active {
   color: var(--text, #111827);
   font-weight: 600;
-  border-bottom: 2px solid var(--primary, #0E9F6E);
+  border-bottom: 2px solid var(--primary, var(--color-brand));
   margin-bottom: -1px;
 }
 .connections-body {
@@ -22353,11 +22353,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 0;
 }
 .skills-cognition-stat-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-bottom: 14px; }
-.skills-cognition-stat { display: flex; flex-direction: column; gap: 3px; padding: 12px; border: 1px solid var(--border, #e5e7eb); border-radius: 8px; background: var(--card, #fff); }
+.skills-cognition-stat { display: flex; flex-direction: column; gap: 3px; padding: 12px; border: 1px solid var(--border, #e5e7eb); border-radius: 8px; background: var(--card, var(--color-surface)); }
 .skills-cognition-stat strong { font-size: 22px; line-height: 1; color: var(--fg, #111827); }
 .skills-cognition-stat span { color: var(--muted-fg, #6b7280); font-size: 12px; }
 .skills-cognition-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
-.skills-cognition-card { border: 1px solid var(--border, #e5e7eb); border-radius: 8px; background: var(--card, #fff); padding: 14px; }
+.skills-cognition-card { border: 1px solid var(--border, #e5e7eb); border-radius: 8px; background: var(--card, var(--color-surface)); padding: 14px; }
 .skills-cognition-card h2, .skills-cognition-card-head h2 { margin: 0; font-size: 14px; color: var(--fg, #111827); }
 .skills-cognition-card-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .skills-cognition-list { display: grid; gap: 12px; }
@@ -22365,15 +22365,15 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skills-cognition-list-card:last-child { border-bottom: 0; }
 .skills-cognition-list-card strong { font-size: 13px; color: var(--fg, #111827); }
 .skills-cognition-list-card span, .skills-cognition-meta { color: var(--muted-fg, #6b7280); font-size: 12px; }
-.skills-cognition-status { flex: none; border-radius: 999px; padding: 3px 8px; background: color-mix(in srgb, var(--primary, #0E9F6E) 10%, transparent); color: var(--primary, #0E9F6E); font-size: 11px; }
+.skills-cognition-status { flex: none; border-radius: 999px; padding: 3px 8px; background: color-mix(in srgb, var(--primary, var(--color-brand)) 10%, transparent); color: var(--primary, var(--color-brand)); font-size: 11px; }
 /* Security axis chip. Colour-coded by verdict and kept visually distinct from
    the maturity chip above, which is always primary-tinted — the two axes must
    not read as one status. `unknown` is deliberately muted rather than green:
    "not checked" must never look like "passed". */
 .skills-cognition-security { flex: none; border-radius: 999px; padding: 3px 8px; font-size: 11px; border: 1px solid transparent; }
-.skills-cognition-security[data-cognition-security="pass"] { background: color-mix(in srgb, var(--success, #16a34a) 10%, transparent); color: var(--success, #15803d); }
-.skills-cognition-security[data-cognition-security="risk"] { background: color-mix(in srgb, var(--warning, #d97706) 12%, transparent); color: var(--warning, #92400e); }
-.skills-cognition-security[data-cognition-security="blocked"] { background: color-mix(in srgb, var(--danger, #b91c1c) 12%, transparent); color: var(--danger, #b91c1c); }
+.skills-cognition-security[data-cognition-security="pass"] { background: color-mix(in srgb, var(--success, var(--color-success)) 10%, transparent); color: var(--success, #15803d); }
+.skills-cognition-security[data-cognition-security="risk"] { background: color-mix(in srgb, var(--warning, var(--color-warning)) 12%, transparent); color: var(--warning, var(--color-warning-text)); }
+.skills-cognition-security[data-cognition-security="blocked"] { background: color-mix(in srgb, var(--danger, var(--color-danger-hover)) 12%, transparent); color: var(--danger, var(--color-danger-hover)); }
 .skills-cognition-security[data-cognition-security="unknown"] { background: color-mix(in srgb, var(--muted-fg, #6b7280) 10%, transparent); color: var(--muted-fg, #6b7280); }
 .skills-cognition-card p { margin: 10px 0; color: var(--fg, #374151); font-size: 13px; line-height: 1.55; white-space: pre-wrap; }
 .skills-cognition-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
@@ -22382,10 +22382,10 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skills-cognition-band-head h2 { margin: 0; font-size: 14px; color: var(--fg, #111827); }
 .skills-cognition-band-head span { color: var(--muted-fg, #6b7280); font-size: 12px; }
 .skills-cognition-source-row { display: flex; flex-wrap: wrap; gap: 8px; }
-.skills-cognition-source-state { display: inline-flex; align-items: center; gap: 7px; min-height: 30px; padding: 4px 9px; border: 1px solid var(--border, #e5e7eb); border-radius: 8px; background: var(--card, #fff); }
+.skills-cognition-source-state { display: inline-flex; align-items: center; gap: 7px; min-height: 30px; padding: 4px 9px; border: 1px solid var(--border, #e5e7eb); border-radius: 8px; background: var(--card, var(--color-surface)); }
 .skills-cognition-source-state b { color: var(--fg, #111827); font-size: 12px; }
 .skills-cognition-source-state em { color: var(--muted-fg, #6b7280); font-size: 11px; font-style: normal; }
-.skills-cognition-source-state.is-degraded { border-color: color-mix(in srgb, var(--warning, #d97706) 35%, var(--border, #e5e7eb)); }
+.skills-cognition-source-state.is-degraded { border-color: color-mix(in srgb, var(--warning, var(--color-warning)) 35%, var(--border, #e5e7eb)); }
 .skills-cognition-capture-list { display: grid; }
 .skills-cognition-capture-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 10px; min-height: 44px; border-top: 1px solid var(--border, #eef0f3); }
 .skills-cognition-capture-row:first-child { border-top: 0; }
@@ -22401,7 +22401,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .recall-capture-control-head h2 { margin: 0; color: var(--fg, #111827); font-size: 16px; }
 .recall-capture-control-head > div > span { display: block; margin-top: 4px; color: var(--muted-fg, #6b7280); font-size: 12px; }
 .recall-capture-master { display: inline-flex; align-items: center; gap: 8px; min-height: 32px; color: var(--fg, #111827); font-size: 12px; font-weight: 600; white-space: nowrap; }
-.recall-capture-master input, .recall-capture-check input { accent-color: var(--primary, #0E9F6E); }
+.recall-capture-master input, .recall-capture-check input { accent-color: var(--primary, var(--color-brand)); }
 .recall-capture-control-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, .8fr); gap: 14px 22px; }
 .recall-capture-control-field { display: flex; min-width: 0; flex-direction: column; gap: 8px; }
 .recall-capture-control-field[hidden] { display: none; }
@@ -22409,10 +22409,10 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .recall-capture-policy-group { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); width: min(100%, 420px); padding: 3px; border: 1px solid var(--border, #dfe3e8); border-radius: 8px; background: var(--surface-subtle, #f7f8fa); }
 .recall-capture-policy { min-width: 0; min-height: 32px; border: 0; border-radius: 6px; background: transparent; color: var(--muted-fg, #6b7280); cursor: pointer; font: inherit; font-size: 12px; }
 .recall-capture-policy:hover:not(:disabled) { color: var(--fg, #111827); }
-.recall-capture-policy.is-active { background: var(--card, #fff); color: var(--primary, #0E9F6E); box-shadow: 0 1px 3px rgba(20, 71, 55, .12); font-weight: 600; }
+.recall-capture-policy.is-active { background: var(--card, var(--color-surface)); color: var(--primary, var(--color-brand)); box-shadow: 0 1px 3px rgba(20, 71, 55, .12); font-weight: 600; }
 .recall-capture-policy:disabled { cursor: not-allowed; opacity: .5; }
 .recall-capture-night-window > div { display: flex; align-items: center; gap: 8px; }
-.recall-capture-night-window input[type="time"], .recall-capture-quiet-window select { min-width: 116px; height: 34px; padding: 0 9px; border: 1px solid var(--border, #dfe3e8); border-radius: 6px; background: var(--card, #fff); color: var(--fg, #111827); font: inherit; }
+.recall-capture-night-window input[type="time"], .recall-capture-quiet-window select { min-width: 116px; height: 34px; padding: 0 9px; border: 1px solid var(--border, #dfe3e8); border-radius: 6px; background: var(--card, var(--color-surface)); color: var(--fg, #111827); font: inherit; }
 .recall-capture-quiet-window span { color: var(--muted-fg, #6b7280); font-size: 11px; }
 .recall-capture-check { display: inline-flex; align-items: center; gap: 7px; width: fit-content; color: var(--muted-fg, #6b7280); font-size: 11px; }
 .recall-capture-model-state { grid-column: 2; grid-row: 1 / span 3; display: flex; align-items: center; justify-content: space-between; gap: 12px; min-width: 0; padding: 12px 0 12px 18px; border-left: 1px solid var(--border, #e5e7eb); }
@@ -22428,7 +22428,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .recall-manual-conversation { display: grid; grid-template-columns: 18px minmax(0, 1fr) auto; min-height: 54px; align-items: center; gap: 10px; padding: 9px 4px; border-bottom: 1px solid var(--border, #e5e7eb); cursor: pointer; }
 .recall-manual-conversation:hover { background: var(--surface-subtle, #f8f9fb); }
 .recall-manual-conversation.is-added { cursor: default; }
-.recall-manual-conversation input { width: 15px; height: 15px; margin: 0; accent-color: var(--primary, #0E9F6E); }
+.recall-manual-conversation input { width: 15px; height: 15px; margin: 0; accent-color: var(--primary, var(--color-brand)); }
 .recall-manual-conversation-main { display: flex; min-width: 0; flex-direction: column; gap: 4px; }
 .recall-manual-conversation-main strong { overflow: hidden; color: var(--fg, #111827); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
 .recall-manual-conversation-main small { color: var(--muted-fg, #6b7280); font-size: var(--font-size-1); }
@@ -22436,11 +22436,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .recall-capture-filter-bar { display: flex; gap: 6px; margin-bottom: 14px; overflow-x: auto; }
 .recall-capture-filter { display: inline-flex; align-items: center; gap: 7px; min-height: 32px; padding: 0 10px; border: 1px solid transparent; border-radius: 6px; background: transparent; color: var(--muted-fg, #6b7280); cursor: pointer; font: inherit; font-size: 12px; white-space: nowrap; }
 .recall-capture-filter:hover { color: var(--fg, #111827); background: var(--surface-subtle, #f7f8fa); }
-.recall-capture-filter.is-active { border-color: var(--border, #dfe3e8); background: var(--card, #fff); color: var(--fg, #111827); }
+.recall-capture-filter.is-active { border-color: var(--border, #dfe3e8); background: var(--card, var(--color-surface)); color: var(--fg, #111827); }
 .recall-capture-filter b { display: inline-flex; min-width: 18px; min-height: 18px; align-items: center; justify-content: center; border-radius: 6px; background: var(--surface-subtle, #eef1f4); color: inherit; font-size: var(--font-size-1); }
 .recall-capture-task-list { display: grid; gap: 8px; }
-.recall-capture-task { overflow: hidden; border: 1px solid var(--border, #e1e5ea); border-radius: 8px; background: var(--card, #fff); }
-.recall-capture-task.is-selected { border-color: color-mix(in srgb, var(--primary, #0E9F6E) 42%, var(--border, #e1e5ea)); }
+.recall-capture-task { overflow: hidden; border: 1px solid var(--border, #e1e5ea); border-radius: 8px; background: var(--card, var(--color-surface)); }
+.recall-capture-task.is-selected { border-color: color-mix(in srgb, var(--primary, var(--color-brand)) 42%, var(--border, #e1e5ea)); }
 .recall-capture-task-summary { display: grid; grid-template-columns: minmax(220px, 1fr) 72px 108px 148px; width: 100%; min-height: 64px; align-items: center; gap: 12px; padding: 10px 14px; border: 0; background: transparent; color: inherit; cursor: pointer; text-align: left; }
 .recall-capture-task-summary:hover { background: var(--surface-subtle, #f8f9fb); }
 .recall-capture-task-main, .recall-capture-task-result { display: flex; min-width: 0; flex-direction: column; gap: 4px; }
@@ -22457,8 +22457,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .recall-capture-task-detail .skills-cognition-actions { margin-top: 14px; }
 .recall-capture-load-more { display: block; margin: 14px auto 0; }
 .skills-cognition-empty, .skills-cognition-loading, .skills-cognition-error { padding: 16px 10px; color: var(--muted-fg, #6b7280); text-align: center; font-size: 12px; }
-.skills-cognition-error { color: var(--danger, #b91c1c); }
-.skills-cognition-warning { margin-bottom: 14px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--warning, #d97706) 30%, transparent); border-radius: 8px; background: color-mix(in srgb, var(--warning, #d97706) 8%, transparent); color: var(--warning, #92400e); font-size: 12px; }
+.skills-cognition-error { color: var(--danger, var(--color-danger-hover)); }
+.skills-cognition-warning { margin-bottom: 14px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--warning, var(--color-warning)) 30%, transparent); border-radius: 8px; background: color-mix(in srgb, var(--warning, var(--color-warning)) 8%, transparent); color: var(--warning, var(--color-warning-text)); font-size: 12px; }
 .skills-cognition-inline-actions { display: flex; gap: 8px; margin-top: 10px; }
 @media (max-width: 800px) {
   .skills-cognition-stat-grid, .skills-cognition-columns { grid-template-columns: 1fr 1fr; }
@@ -22512,7 +22512,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   max-width: 100%;
   border-radius: 999px;
   padding: 3px 8px;
-  background: color-mix(in srgb, var(--primary, #0E9F6E) 7%, transparent);
+  background: color-mix(in srgb, var(--primary, var(--color-brand)) 7%, transparent);
   color: var(--muted-fg, #6b7280);
   font-size: 11px;
   overflow-wrap: anywhere;
@@ -22533,7 +22533,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   overflow: hidden;
   border: 0;
   border-radius: 0;
-  background: var(--card, #fff);
+  background: var(--card, var(--color-surface));
   box-shadow: none;
 }
 
@@ -22615,7 +22615,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 2px 0 10px;
   overflow-x: auto;
   border-bottom: 1px solid var(--border, #e5e7eb);
-  background: var(--card, #fff);
+  background: var(--card, var(--color-surface));
   scrollbar-width: thin;
 }
 
@@ -22630,7 +22630,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 999px;
   padding: 6px 12px;
-  background: var(--card, #fff);
+  background: var(--card, var(--color-surface));
   color: var(--muted-fg, #6b7280);
   font: inherit;
   font-size: 12px;
@@ -22643,10 +22643,10 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .recall-subtabs [data-cognition-deposition-view].is-active,
 .recall-category-chips [data-cognition-candidate-category].is-active,
 .cognition-category-filter.is-active {
-  border-color: color-mix(in srgb, var(--primary, #0E9F6E) 55%, var(--border, #e5e7eb));
-  background: color-mix(in srgb, var(--primary, #0E9F6E) 11%, transparent);
-  color: var(--primary, #0E9F6E);
-  box-shadow: inset 0 -2px 0 var(--primary, #0E9F6E);
+  border-color: color-mix(in srgb, var(--primary, var(--color-brand)) 55%, var(--border, #e5e7eb));
+  background: color-mix(in srgb, var(--primary, var(--color-brand)) 11%, transparent);
+  color: var(--primary, var(--color-brand));
+  box-shadow: inset 0 -2px 0 var(--primary, var(--color-brand));
 }
 
 .recall-subtabs [data-cognition-deposition-view]:focus-visible,
@@ -22655,7 +22655,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .skills-cognition-tab:focus-visible,
 .ability-asset-summary-card:focus-visible,
 .ability-asset-list-row:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--primary, #0E9F6E) 65%, white);
+  outline: 2px solid color-mix(in srgb, var(--primary, var(--color-brand)) 65%, white);
   outline-offset: 2px;
 }
 
@@ -22674,8 +22674,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--primary, #0E9F6E) 13%, transparent);
-  color: var(--primary, #0E9F6E);
+  background: color-mix(in srgb, var(--primary, var(--color-brand)) 13%, transparent);
+  color: var(--primary, var(--color-brand));
   font-size: 11px;
   font-weight: 700;
 }
@@ -22744,7 +22744,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   overflow: hidden;
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 16px;
-  background: var(--card, #fff);
+  background: var(--card, var(--color-surface));
 }
 
 .skills-cognition-record {
@@ -22763,7 +22763,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .skills-cognition-record:hover {
-  background: color-mix(in srgb, var(--primary, #0E9F6E) 4%, transparent);
+  background: color-mix(in srgb, var(--primary, var(--color-brand)) 4%, transparent);
 }
 
 .skills-cognition-record-head {
@@ -22795,19 +22795,19 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .ability-assets-tabs { display: flex; gap: 6px; margin-bottom: 14px; }
-.ability-assets-tab { border: 1px solid var(--border, #e5e7eb); border-radius: 999px; background: var(--card, #fff); padding: 7px 12px; color: var(--muted-fg, #6b7280); font: inherit; cursor: pointer; }
-.ability-assets-tab.is-active { border-color: var(--primary, #0E9F6E); color: var(--primary, #0E9F6E); background: color-mix(in srgb, var(--primary, #0E9F6E) 8%, transparent); font-weight: 650; }
+.ability-assets-tab { border: 1px solid var(--border, #e5e7eb); border-radius: 999px; background: var(--card, var(--color-surface)); padding: 7px 12px; color: var(--muted-fg, #6b7280); font: inherit; cursor: pointer; }
+.ability-assets-tab.is-active { border-color: var(--primary, var(--color-brand)); color: var(--primary, var(--color-brand)); background: color-mix(in srgb, var(--primary, var(--color-brand)) 8%, transparent); font-weight: 650; }
 .ability-assets-workbench { display: grid; gap: 14px; }
 .ability-asset-summary-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
-.ability-asset-summary-card { padding: 12px; border: 1px solid var(--border, #e5e7eb); border-radius: 12px; background: var(--card, #fff); }
+.ability-asset-summary-card { padding: 12px; border: 1px solid var(--border, #e5e7eb); border-radius: 12px; background: var(--card, var(--color-surface)); }
 .ability-asset-summary-card span { display: block; color: var(--muted-fg, #6b7280); font-size: 12px; }
 .ability-asset-summary-card strong { display: block; margin: 6px 0 2px; font-size: 22px; }
 .ability-asset-summary-card small { color: var(--muted-fg, #6b7280); font-size: 11px; }
 .ability-assets-management { display: grid; grid-template-columns: minmax(280px, .8fr) minmax(0, 1.2fr); gap: 14px; align-items: start; }
-.ability-asset-list, .ability-asset-detail, .ability-assets-empty, .ability-assets-tree-note, .ability-assets-usage-note { border: 1px solid var(--border, #e5e7eb); border-radius: 14px; background: var(--card, #fff); overflow: hidden; }
+.ability-asset-list, .ability-asset-detail, .ability-assets-empty, .ability-assets-tree-note, .ability-assets-usage-note { border: 1px solid var(--border, #e5e7eb); border-radius: 14px; background: var(--card, var(--color-surface)); overflow: hidden; }
 .ability-asset-list-head { padding: 12px; border-bottom: 1px solid var(--border, #e5e7eb); }
 .ability-asset-list-row { width: 100%; grid-template-columns: minmax(0, 1fr) auto; text-align: left; cursor: pointer; }
-.ability-asset-list-row.is-selected { background: color-mix(in srgb, var(--primary, #0E9F6E) 6%, transparent); }
+.ability-asset-list-row.is-selected { background: color-mix(in srgb, var(--primary, var(--color-brand)) 6%, transparent); }
 .ability-asset-row-main strong { display: block; margin-bottom: 4px; }
 .ability-asset-row-main small { display: block; color: var(--muted-fg, #6b7280); font-size: 11px; line-height: 1.45; }
 .ability-asset-detail .asset-detail-head { padding: 14px 16px; border-bottom: 1px solid var(--border, #e5e7eb); }
@@ -22827,13 +22827,13 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   min-height: 360px;
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 16px;
-  background: var(--card, #fff);
+  background: var(--card, var(--color-surface));
 }
 
 .ability-tree-stage {
   position: relative;
   overflow: hidden;
-  background: radial-gradient(circle at 50% 78%, color-mix(in srgb, var(--primary, #0E9F6E) 12%, transparent), transparent 28%), var(--card, #fff);
+  background: radial-gradient(circle at 50% 78%, color-mix(in srgb, var(--primary, var(--color-brand)) 12%, transparent), transparent 28%), var(--card, var(--color-surface));
 }
 
 .ability-tree-branch,
@@ -22853,8 +22853,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .ability-tree-template { right: 22%; top: 44%; }
 .ability-tree-skill { right: 8%; top: 18%; }
 .ability-tree-node.seed { left: 47%; bottom: 14%; }
-.ability-tree-node.bud { left: 34%; top: 34%; color: #a16207; background: #fef3c7; }
-.ability-tree-node.leaf { right: 34%; top: 31%; color: #15803d; background: #dcfce7; }
+.ability-tree-node.bud { left: 34%; top: 34%; color: #a16207; background: var(--color-warning-soft); }
+.ability-tree-node.leaf { right: 34%; top: 31%; color: #15803d; background: var(--color-success-soft); }
 .ability-tree-node.deep-leaf { right: 46%; top: 14%; color: #166534; background: #bbf7d0; }
 .ability-tree-inspector { padding: 16px; }
 .ability-tree-inspector h2 { margin: 0 0 8px; }
@@ -22871,8 +22871,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 
 .ability-asset-summary-card:hover,
 .ability-asset-summary-card.is-active {
-  border-color: var(--primary, #0E9F6E);
-  background: color-mix(in srgb, var(--primary, #0E9F6E) 6%, var(--card, #fff));
+  border-color: var(--primary, var(--color-brand));
+  background: color-mix(in srgb, var(--primary, var(--color-brand)) 6%, var(--card, var(--color-surface)));
 }
 
 .ability-asset-list-row .skills-cognition-status {
@@ -22959,7 +22959,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid rgba(14, 159, 110, 0.3);
   border-radius: 99px;
   color: #0b7a4f;
-  background: #fff;
+  background: var(--color-surface);
   font-size: 11px;
   cursor: pointer;
 }
@@ -23101,7 +23101,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .memory-template-badge.is-installed {
- color: var(--success, #16a34a); background: rgba(22, 163, 74, 0.1); border-color: rgba(22, 163, 74, 0.25); 
+ color: var(--success, var(--color-success)); background: rgba(22, 163, 74, 0.1); border-color: rgba(22, 163, 74, 0.25); 
 }
 
 .memory-template-desc {
@@ -23708,7 +23708,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .personal-onto-library-installed {
   font-size: 11px;
   font-weight: 600;
-  color: var(--success, #16a34a);
+  color: var(--success, var(--color-success));
   background: rgba(22, 163, 74, 0.08);
   border: 1px solid rgba(22, 163, 74, 0.2);
   border-radius: 99px;
@@ -23955,7 +23955,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   justify-content: center;
   border-radius: 6px;
-  background: color-mix(in srgb, var(--primary, #0e9f6e) 10%, transparent);
+  background: color-mix(in srgb, var(--primary, var(--color-brand)) 10%, transparent);
   color: var(--primary-text, #047857);
   font-size: 11px;
   font-weight: 700;
@@ -23989,7 +23989,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   justify-content: center;
   border-radius: 6px;
-  background: color-mix(in srgb, var(--primary, #0e9f6e) 10%, transparent);
+  background: color-mix(in srgb, var(--primary, var(--color-brand)) 10%, transparent);
   color: var(--primary-text, #047857);
   font-size: 11px;
   font-weight: 700;
@@ -24116,7 +24116,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   justify-content: center;
   border-radius: 6px;
-  background: color-mix(in srgb, var(--primary, #0e9f6e) 10%, transparent);
+  background: color-mix(in srgb, var(--primary, var(--color-brand)) 10%, transparent);
   color: var(--primary-text, #047857);
   font-size: 11px;
   font-weight: 700;
@@ -24229,7 +24229,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .spaces-header {
@@ -24243,7 +24243,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .spaces-header-titles {
@@ -24296,9 +24296,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .spaces-chip.is-active {
-  background: var(--accent, #0E9F6E);
+  background: var(--accent, var(--color-brand));
   border-color: transparent;
-  color: #fff;
+  color: var(--color-surface);
 }
 
 .spaces-grid-wrap {
@@ -24339,7 +24339,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex-direction: column;
   gap: 2px;
   padding: 14px 16px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 10px;
   cursor: pointer;
@@ -24381,7 +24381,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .spaces-card-invalid {
   flex: 0 0 auto;
   font-size: 11px;
-  color: #dc2626;
+  color: var(--color-danger);
   background: rgba(220, 38, 38, 0.08);
   padding: 1px 8px;
   border-radius: 10px;
@@ -24447,7 +24447,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-bottom: 1px solid var(--border);
   padding: 0 22px;
   flex-shrink: 0;
-  background: #fff;
+  background: var(--color-surface);
 }
 
 .spaces-detail-tab {
@@ -24481,7 +24481,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .spaces-detail-section {
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 14px 16px;
@@ -24492,7 +24492,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 12px 16px;
@@ -24661,7 +24661,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid var(--border);
   border-radius: 8px;
   font-size: 13px;
-  background: var(--card, #fff);
+  background: var(--card, var(--color-surface));
   color: var(--text);
   outline: none;
 }
@@ -24687,7 +24687,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-radius: 10px;
-  background: #fff;
+  background: var(--color-surface);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -24724,7 +24724,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-size: var(--font-size-1);
   line-height: 1;
   font-weight: 600;
-  color: #fff;
+  color: var(--color-surface);
   background: var(--primary);
 }
 .spaces-tpl-tag.is-visible {
@@ -24926,7 +24926,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border: 1px solid var(--border);
   border-radius: 8px;
   font-size: 12px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   outline: none;
 }
@@ -24944,7 +24944,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .spaces-res-add-label {
   font-size: 12px;
   font-weight: 600;
-  color: var(--text-2, #3E5A4C);
+  color: var(--text-2, var(--color-ink-2));
   margin-right: 2px;
 }
 .spaces-res-add-row select {
@@ -24953,7 +24953,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   border-radius: 8px;
   font-size: 12px;
   font-family: inherit;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   outline: none;
 }
@@ -24985,7 +24985,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .spaces-res-group-label {
   font-size: 11.5px;
   font-weight: 600;
-  color: var(--text-2, #3E5A4C);
+  color: var(--text-2, var(--color-ink-2));
 }
 .spaces-res-chips {
   display: flex;
@@ -25035,7 +25035,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 1px 7px;
   border: 1px solid var(--border);
   border-radius: 999px;
-  background: #fff;
+  background: var(--color-surface);
   font-size: 11px;
   color: #64748b;
 }
@@ -25070,7 +25070,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 8px 14px;
   margin: 8px 14px 0;
   border-left: 2px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   border-radius: 0 6px 6px 0;
   font-size: 12px;
   color: #475569;
@@ -25111,7 +25111,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 8px 10px;
   border: 1px solid var(--border);
   border-radius: 2px 10px 10px 10px;
-  background: #fff;
+  background: var(--color-surface);
   font-size: 13px;
   word-break: break-word;
 }
@@ -25130,7 +25130,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 7px 9px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
   color: inherit;
   font: inherit;
   font-size: 13px;
@@ -25150,7 +25150,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex-direction: column;
   min-height: 0;
   border-left: 1px solid var(--border);
-  background: #fff;
+  background: var(--color-surface);
   color: var(--text);
   box-shadow: -12px 0 28px rgba(20, 71, 55, 0.05);
   z-index: var(--z-sticky);
@@ -25187,7 +25187,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-side-tab[hidden] { display: none !important; }
 .chat-side-tab:hover { color: var(--text); }
 .chat-side-tab.is-active {
-  background: #fff;
+  background: var(--color-surface);
   border-color: var(--border);
   color: var(--text);
   /* Cover the strip's bottom border so the active tab merges with its pane. */
@@ -25272,7 +25272,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
-  background: #fff;
+  background: var(--color-surface);
 }
 /* Zoom is applied to the frame wrapper: the iframe is cross-origin, so the
    parent cannot reach inside to change its styles. */
@@ -25286,7 +25286,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   width: 100%;
   height: 100%;
   border: 0;
-  background: #fff;
+  background: var(--color-surface);
 }
 .chat-side-browser-empty {
   height: 100%;
@@ -25305,8 +25305,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 1px 6px;
   border: 1px solid #B9E3C8;
   border-radius: 999px;
-  background: #E2F5EC;
-  color: #0A7A55;
+  background: var(--color-brand-soft);
+  color: var(--color-brand-hover);
   font-size: var(--font-size-1);
   font-weight: 600;
   line-height: 1.6;
@@ -25351,7 +25351,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   transform: translate(-50%, -50%);
   width: 52px;
   height: 3px;
-  border-radius: 2px;
+  border-radius: var(--radius-1);
   background: var(--border-strong, #c8ccd4);
   opacity: 0.55;
   transition: opacity 0.15s, background-color 0.15s;
@@ -25359,7 +25359,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .terminal-resize-handle:hover::after,
 .terminal-resize-handle.is-dragging::after {
   opacity: 1;
-  background: var(--primary, #2563eb);
+  background: var(--primary, var(--color-info));
 }
 body.is-terminal-resizing {
   user-select: none;
@@ -25487,7 +25487,7 @@ body.is-terminal-resizing {
 }
 
 /* ── 情境空间详情 · 本体 tab 已删除（2026-08：空间不再按角色模板记录）── */
-.memory-group-field-project { color: var(--primary, #2563eb); font-size: 12px; margin-left: 4px; }
+.memory-group-field-project { color: var(--primary, var(--color-info)); font-size: 12px; margin-left: 4px; }
 
 /* ─── 空间详情管理面板（spaces-view 作用域覆盖，不影响 AI 团队页）─── */
 .spaces-view .agents-detail-body {
@@ -25562,7 +25562,7 @@ body.is-terminal-resizing {
   animation:cs-modal-fade-in 0.15s ease-out;
 }
 .cs-import-modal{
-  background:var(--bg,#FBFDFC);border-radius:var(--radius-lg,20px);
+  background:var(--bg,var(--color-bg));border-radius:var(--radius-lg,20px);
   width:90%;max-width:680px;max-height:85vh;
   box-shadow:0 12px 40px rgba(14,50,30,0.15);
   display:flex;flex-direction:column;
@@ -25602,7 +25602,7 @@ body.is-terminal-resizing {
 .cs-import-agent-chip.detected{
   background:var(--forest-tint,#E8F5F0);
   border-color:var(--forest-soft,#7DD4B8);
-  color:var(--forest,#0E9F6E);
+  color:var(--forest,var(--color-brand));
 }
 .cs-import-agent-dot{
   width:5px;height:5px;border-radius:50%;
@@ -25612,7 +25612,7 @@ body.is-terminal-resizing {
 .cs-import-session-item{
   padding:12px 14px;border-radius:10px;cursor:pointer;
   border:1.5px solid var(--paper-2,#E8EDE9);
-  background:var(--bg,#FBFDFC);transition:all .12s;
+  background:var(--bg,var(--color-bg));transition:all .12s;
   display:flex;align-items:flex-start;gap:10px;
 }
 .cs-import-session-item:hover{
@@ -25620,7 +25620,7 @@ body.is-terminal-resizing {
   background:var(--paper-1,#F8FAF9);
 }
 .cs-import-session-item.selected{
-  border-color:var(--forest,#0E9F6E);
+  border-color:var(--forest,var(--color-brand));
   background:var(--forest-tint,#E8F5F0);
 }
 .cs-import-session-checkbox{
@@ -25630,13 +25630,13 @@ body.is-terminal-resizing {
   margin-top:2px;
 }
 .cs-import-session-item:hover .cs-import-session-checkbox{
-  border-color:var(--forest,#0E9F6E);
+  border-color:var(--forest,var(--color-brand));
 }
 .cs-import-session-item.selected .cs-import-session-checkbox{
-  background:var(--forest,#0E9F6E);border-color:var(--forest,#0E9F6E);
+  background:var(--forest,var(--color-brand));border-color:var(--forest,var(--color-brand));
 }
 .cs-import-session-checkbox-icon{
-  width:11px;height:11px;color:#fff;opacity:0;
+  width:11px;height:11px;color:var(--color-surface);opacity:0;
   transition:opacity .12s;
 }
 .cs-import-session-item.selected .cs-import-session-checkbox-icon{
@@ -25676,7 +25676,7 @@ body.is-terminal-resizing {
   background:var(--paper-2,#F2F6F3);color:var(--ink-soft);
 }
 .cs-import-btn.primary{
-  background:var(--forest,#0E9F6E);color:#fff;
+  background:var(--forest,var(--color-brand));color:var(--color-surface);
 }
 .cs-import-btn.primary:hover{
   background:var(--forest-dark,#0A7D56);
@@ -25701,11 +25701,11 @@ body.is-terminal-resizing {
    the modal. onboarding.css scopes its rules under #cs-onboarding, so these
    un-prefixed copies apply inside the modal's .cs-import-scope wrapper. */
 .cs-import-scope{
-  --cs-ink:#14281E; --cs-ink-soft:#3E5A4C; --cs-muted:#6E8578; --cs-faint:#A3B8AC;
-  --cs-line:#E3EAE6; --cs-line-soft:#EDF3EF; --cs-line-strong:#C8D5CE;
-  --cs-forest:#0E9F6E; --cs-forest-deep:#0A7A55; --cs-forest-weak:#E2F5EC;
+  --cs-ink:var(--color-ink); --cs-ink-soft:var(--color-ink-2); --cs-muted:var(--color-muted); --cs-faint:var(--color-faint);
+  --cs-line:#E3EAE6; --cs-line-soft:var(--color-surface-2); --cs-line-strong:#C8D5CE;
+  --cs-forest:var(--color-brand); --cs-forest-deep:var(--color-brand-hover); --cs-forest-weak:var(--color-brand-soft);
   --cs-bud:#E09B2D; --cs-bud-weak:#FBF1DC; --cs-clay:#DE5B45; --cs-clay-weak:#FBE9E5;
-  --cs-grad:linear-gradient(135deg,#0E9F6E,#0A7A55);
+  --cs-grad:linear-gradient(135deg,var(--color-brand),var(--color-brand-hover));
   --cs-mono:'SF Mono',ui-monospace,'Menlo',monospace;
   --cs-radius:6px;
   color:var(--cs-ink);font-size:14px;line-height:1.5;
@@ -25721,17 +25721,17 @@ body.is-terminal-resizing {
 .cs-import-scope .cs-agent-item{display:flex;align-items:center;gap:10px;padding:14px 16px;cursor:pointer;
   border-bottom:1px solid var(--cs-line-soft);transition:background .15s}
 .cs-import-scope .cs-agent-item:hover{background:#F3FAF6}
-.cs-import-scope .cs-agent-item.active{background:#fff;border-left:3px solid var(--cs-forest);padding-left:13px}
+.cs-import-scope .cs-agent-item.active{background:var(--color-surface);border-left:3px solid var(--cs-forest);padding-left:13px}
 .cs-import-scope .cs-agent-item .ai-icon{width:32px;height:32px;border-radius:8px;background:var(--cs-forest-weak);
   display:grid;place-items:center;flex-shrink:0}
 .cs-import-scope .cs-agent-item .ai-icon svg{width:16px;height:16px;color:var(--cs-forest)}
 .cs-import-scope .cs-agent-item.active .ai-icon{background:var(--cs-forest);box-shadow:0 2px 8px rgba(14,159,110,.25)}
-.cs-import-scope .cs-agent-item.active .ai-icon svg{color:#fff}
+.cs-import-scope .cs-agent-item.active .ai-icon svg{color:var(--color-surface)}
 .cs-import-scope .cs-agent-item .ai-info{min-width:0;flex:1}
 .cs-import-scope .cs-agent-item .ai-name{font-size:13px;font-weight:650;color:var(--cs-ink);white-space:nowrap;
   overflow:hidden;text-overflow:ellipsis}
 .cs-import-scope .cs-agent-item .ai-version{font-size:11px;color:var(--cs-muted);margin-top:2px}
-.cs-import-scope .cs-asset-content{background:#fff;overflow-y:auto;padding:16px}
+.cs-import-scope .cs-asset-content{background:var(--color-surface);overflow-y:auto;padding:16px}
 .cs-import-scope .cs-asset-panel{display:grid;grid-template-columns:150px 1fr;gap:16px;align-items:start}
 .cs-import-scope .cs-asset-tabs{display:flex;flex-direction:column;gap:6px;position:sticky;top:0}
 .cs-import-scope .cs-asset-tab{display:flex;align-items:center;gap:10px;width:100%;padding:11px 14px;
@@ -25744,9 +25744,9 @@ body.is-terminal-resizing {
 .cs-import-scope .cs-asset-tab .ash-title{font-size:13px;font-weight:700;color:var(--cs-ink);flex:1}
 .cs-import-scope .cs-asset-tab.active .ash-title{color:var(--cs-forest-deep)}
 .cs-import-scope .cs-asset-tab .ash-count{font-size:11.5px;color:var(--cs-muted);font-weight:600}
-.cs-import-scope .cs-asset-panes{border:1px solid var(--cs-line);border-radius:10px;background:#fff;
+.cs-import-scope .cs-asset-panes{border:1px solid var(--cs-line);border-radius:10px;background:var(--color-surface);
   min-height:200px;max-height:56vh;overflow-y:auto}
-.cs-import-scope .cs-asset-section-body{display:none;background:#fff}
+.cs-import-scope .cs-asset-section-body{display:none;background:var(--color-surface)}
 .cs-import-scope .cs-asset-section-body.active{display:block}
 .cs-import-scope .cs-show-more{display:block;width:100%;padding:10px 16px;background:var(--cs-line-soft);
   border:none;border-top:1px solid var(--cs-line);color:var(--cs-ink-soft);font-size:12px;cursor:pointer;
@@ -25766,16 +25766,16 @@ body.is-terminal-resizing {
 .cs-import-scope .cs-src strong{display:block;font-size:13.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .cs-import-scope .cs-src small{display:-webkit-box;-webkit-line-clamp:2;line-clamp:2;-webkit-box-orient:vertical;
   overflow:hidden;margin-top:2px;color:var(--cs-muted);font-size:11.5px;line-height:1.45}
-.cs-import-scope .cs-state{padding:16px;font-size:12.5px;color:var(--cs-muted);line-height:1.6;background:#fff;
+.cs-import-scope .cs-state{padding:16px;font-size:12.5px;color:var(--cs-muted);line-height:1.6;background:var(--color-surface);
   border-bottom:1px solid var(--cs-line)}
 .cs-import-scope .cs-state:last-child{border-bottom:0}
 .cs-import-scope .cs-state.err{color:#8A3A2C;background:var(--cs-clay-weak)}
 .cs-import-scope .cs-state.loading{color:var(--cs-forest-deep)}
 .cs-import-scope .cs-mode{margin-top:14px;display:flex;align-items:center;justify-content:space-between;gap:14px;
-  padding:12px 16px;border:1px solid var(--cs-line);border-radius:10px;background:#fff;font-size:12.5px;color:var(--cs-ink-soft)}
+  padding:12px 16px;border:1px solid var(--cs-line);border-radius:10px;background:var(--color-surface);font-size:12.5px;color:var(--cs-ink-soft)}
 .cs-import-scope .cs-import-bar{display:flex;flex-direction:column;gap:10px;padding:14px 16px;border-top:1px solid var(--cs-line)}
 .cs-import-scope .cs-import-btn{align-self:flex-start;display:inline-flex;align-items:center;gap:7px;
-  padding:9px 18px;border-radius:var(--cs-radius);background:var(--cs-grad);color:#fff;font-weight:650;font-size:12.5px}
+  padding:9px 18px;border-radius:var(--cs-radius);background:var(--cs-grad);color:var(--color-surface);font-weight:650;font-size:12.5px}
 .cs-import-scope .cs-import-btn:hover{background:var(--cs-forest-deep)}
 .cs-import-scope .cs-import-btn:disabled{opacity:.5;cursor:not-allowed}
 .cs-import-scope .cs-import-result{font-size:12px;color:var(--cs-muted);line-height:1.6}
@@ -25813,7 +25813,7 @@ body.is-terminal-resizing {
 }
 .cw-modal{
   width:min(760px,calc(100vw - 32px));max-height:88vh;
-  background:var(--surface,#fff);border:1px solid var(--border,rgba(24,84,60,.09));
+  background:var(--surface,var(--color-surface));border:1px solid var(--border,rgba(24,84,60,.09));
   border-radius:var(--radius-lg,20px);box-shadow:0 24px 64px rgba(16,55,38,0.18);
   display:flex;flex-direction:column;overflow:hidden;
   animation:cw-slide-in 0.18s ease-out;
@@ -25824,24 +25824,24 @@ body.is-terminal-resizing {
 }
 .cw-head-icon{
   width:44px;height:44px;border-radius:12px;flex-shrink:0;display:grid;place-items:center;
-  background:linear-gradient(135deg,var(--primary-soft,#E2F5EC),var(--surface-2,#EDF3EF));
+  background:linear-gradient(135deg,var(--primary-soft,var(--color-brand-soft)),var(--surface-2,var(--color-surface-2)));
   border:1px solid var(--border,rgba(24,84,60,.09));
-  color:var(--primary,#0E9F6E);
+  color:var(--primary,var(--color-brand));
 }
 .cw-head-icon svg{width:22px;height:22px}
 .cw-head-copy{flex:1;min-width:0}
 .cw-kicker{
   font-family:var(--font-mono,ui-monospace,Menlo,monospace);
   font-size: var(--font-size-1);font-weight:700;letter-spacing:0.2em;
-  color:var(--primary,#0E9F6E);text-transform:uppercase;margin-bottom:6px;
+  color:var(--primary,var(--color-brand));text-transform:uppercase;margin-bottom:6px;
 }
-.cw-title{font-size:18px;font-weight:650;color:var(--text,#14281E);letter-spacing:-0.01em}
+.cw-title{font-size:18px;font-weight:650;color:var(--text,var(--color-ink));letter-spacing:-0.01em}
 .cw-close{
   width:28px;height:28px;border-radius:6px;display:grid;place-items:center;
-  color:var(--muted,#6E8578);transition:color .12s,background .12s;flex-shrink:0;
+  color:var(--muted,var(--color-muted));transition:color .12s,background .12s;flex-shrink:0;
   background:transparent;border:none;
 }
-.cw-close:hover{background:var(--surface-2,#EDF3EF);color:var(--text,#14281E)}
+.cw-close:hover{background:var(--surface-2,var(--color-surface-2));color:var(--text,var(--color-ink))}
 .cw-close svg{width:15px;height:15px}
 .cw-steps{display:flex;align-items:center;gap:8px;padding:14px 24px;}
 .cw-step{
@@ -25849,57 +25849,57 @@ body.is-terminal-resizing {
   padding:8px 10px;border-radius:6px;
   background:transparent;
   border:none;
-  color:var(--muted,#6E8578);
+  color:var(--muted,var(--color-muted));
   transition:color .18s,background .18s;
 }
 .cw-step:not(:disabled){cursor:pointer}
-.cw-step:not(:disabled):hover{background:var(--surface-2,#EDF3EF);color:var(--text-2,#3E5A4C)}
+.cw-step:not(:disabled):hover{background:var(--surface-2,var(--color-surface-2));color:var(--text-2,var(--color-ink-2))}
 .cw-step:disabled{opacity:.55;cursor:not-allowed}
 /* 当前步 / 已完成步用主题绿文字区分（无框）。 */
 .cw-step.is-active{
   background:transparent;
-  border:none;color:var(--primary,#0E9F6E);
+  border:none;color:var(--primary,var(--color-brand));
   font-weight:600;
 }
-.cw-step.is-done{background:transparent;border:none;color:var(--primary-text,#0A7A55)}
-.cw-step.is-done:not(:disabled):hover{background:var(--surface-2,#EDF3EF);color:var(--primary-text,#0A7A55)}
+.cw-step.is-done{background:transparent;border:none;color:var(--primary-text,var(--color-brand-hover))}
+.cw-step.is-done:not(:disabled):hover{background:var(--surface-2,var(--color-surface-2));color:var(--primary-text,var(--color-brand-hover))}
 .cw-step-num{
   width:22px;height:22px;border-radius:50%;display:grid;place-items:center;
-  font-size:11px;font-weight:700;background:var(--surface-2,#EDF3EF);
+  font-size:11px;font-weight:700;background:var(--surface-2,var(--color-surface-2));
   border:1px solid var(--border-strong,rgba(24,84,60,.18));
-  color:var(--text-2,#3E5A4C);flex-shrink:0;transition:all .18s;
+  color:var(--text-2,var(--color-ink-2));flex-shrink:0;transition:all .18s;
 }
 .cw-step.is-active .cw-step-num,
-.cw-step.is-done .cw-step-num{background:var(--primary-soft,#E2F5EC);border-color:color-mix(in srgb,var(--primary,#0E9F6E) 45%,transparent);color:var(--primary,#0E9F6E)}
+.cw-step.is-done .cw-step-num{background:var(--primary-soft,var(--color-brand-soft));border-color:color-mix(in srgb,var(--primary,var(--color-brand)) 45%,transparent);color:var(--primary,var(--color-brand))}
 .cw-step-num svg{width:12px;height:12px}
 .cw-step-label{
   font-size:12.5px;font-weight:500;white-space:nowrap;
   overflow:hidden;text-overflow:ellipsis;
 }
 .cw-body{flex:1;overflow-y:auto;padding:22px 24px 24px;min-height:320px}
-.cw-section-intro h3{font-size:15px;font-weight:650;color:var(--text,#14281E);margin:0 0 4px}
-.cw-section-intro p{font-size:12.5px;color:var(--muted,#6E8578);margin:0 0 8px;line-height:1.6}
+.cw-section-intro h3{font-size:15px;font-weight:650;color:var(--text,var(--color-ink));margin:0 0 4px}
+.cw-section-intro p{font-size:12.5px;color:var(--muted,var(--color-muted));margin:0 0 8px;line-height:1.6}
 .cw-section-intro-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:2px}
 .cw-section-intro-head h3{margin:0}
 .cw-section-intro-head .cw-privacy-note{margin-top:0}
-.cw-loading{padding:40px 20px;text-align:center;color:var(--muted,#6E8578);font-size:13px;
+.cw-loading{padding:40px 20px;text-align:center;color:var(--muted,var(--color-muted));font-size:13px;
   display:flex;flex-direction:column;align-items:center;gap:12px}
 .cw-loading::before{content:'';width:22px;height:22px;border-radius:50%;
-  border:2px solid var(--border-strong,rgba(24,84,60,.18));border-top-color:var(--primary,#0E9F6E);
+  border:2px solid var(--border-strong,rgba(24,84,60,.18));border-top-color:var(--primary,var(--color-brand));
   animation:cw-spin .8s linear infinite}
 .cw-source-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
-.cw-source-meta{font-size:11.5px;color:var(--muted,#6E8578)}
+.cw-source-meta{font-size:11.5px;color:var(--muted,var(--color-muted))}
 .cw-source-tabs{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px}
 .cw-source-tab{
   display:inline-flex;align-items:center;gap:6px;
   padding:6px 12px;border-radius:999px;
   border:1px solid var(--border-strong,rgba(24,84,60,.18));
-  background:var(--surface,#fff);color:var(--text-2,#3E5A4C);
+  background:var(--surface,var(--color-surface));color:var(--text-2,var(--color-ink-2));
   font-size:12.5px;font-weight:600;cursor:pointer;
   transition:border-color .12s,background .12s,color .12s;
 }
-.cw-source-tab:hover{border-color:var(--primary,#0E9F6E);color:var(--primary,#0E9F6E)}
-.cw-source-tab.is-active{background:var(--primary-soft,#E2F5EC);color:var(--primary-text,#0A7A55);border-color:color-mix(in srgb,var(--primary,#0E9F6E) 45%,transparent)}
+.cw-source-tab:hover{border-color:var(--primary,var(--color-brand));color:var(--primary,var(--color-brand))}
+.cw-source-tab.is-active{background:var(--primary-soft,var(--color-brand-soft));color:var(--primary-text,var(--color-brand-hover));border-color:color-mix(in srgb,var(--primary,var(--color-brand)) 45%,transparent)}
 .cw-source-tab-count{
   font-size:11px;font-weight:600;
   color:inherit;opacity:.75;
@@ -25910,92 +25910,92 @@ body.is-terminal-resizing {
 .cw-search{
   flex:1;min-width:0;display:flex;align-items:center;gap:8px;
   padding:0 12px;height:38px;border:1px solid var(--border-strong,rgba(24,84,60,.18));
-  border-radius:var(--radius-sm,10px);background:var(--surface,#fff);
+  border-radius:var(--radius-sm,10px);background:var(--surface,var(--color-surface));
   transition:border-color .12s,box-shadow .12s;
 }
-.cw-search:focus-within{border-color:var(--text-2,#3E5A4C);box-shadow:0 0 0 3px rgba(62,90,76,0.10)}
-.cw-search svg{width:15px;height:15px;color:var(--muted,#6E8578);flex-shrink:0}
+.cw-search:focus-within{border-color:var(--text-2,var(--color-ink-2));box-shadow:0 0 0 3px rgba(62,90,76,0.10)}
+.cw-search svg{width:15px;height:15px;color:var(--muted,var(--color-muted));flex-shrink:0}
 .cw-search input{
   flex:1;min-width:0;border:none;outline:none;background:transparent;
-  font:inherit;font-size:13px;color:var(--text,#14281E);
+  font:inherit;font-size:13px;color:var(--text,var(--color-ink));
 }
 .cw-select-all{
   height:38px;padding:0 14px;border-radius:var(--radius-sm,10px);
-  border:1px solid var(--border-strong,rgba(24,84,60,.18));background:var(--surface,#fff);
-  color:var(--text-2,#3E5A4C);font-size:12.5px;font-weight:600;transition:all .12s;
+  border:1px solid var(--border-strong,rgba(24,84,60,.18));background:var(--surface,var(--color-surface));
+  color:var(--text-2,var(--color-ink-2));font-size:12.5px;font-weight:600;transition:all .12s;
 }
-.cw-select-all:hover{border-color:var(--text-2,#3E5A4C);color:var(--text-2,#3E5A4C)}
-.cw-session-count{font-size:12px;color:var(--muted,#6E8578);white-space:nowrap}
+.cw-select-all:hover{border-color:var(--text-2,var(--color-ink-2));color:var(--text-2,var(--color-ink-2))}
+.cw-session-count{font-size:12px;color:var(--muted,var(--color-muted));white-space:nowrap}
 .cw-session-list{
   max-height:clamp(280px,calc(88vh - 360px),600px);overflow-y:auto;border:1px solid var(--border,rgba(24,84,60,.09));
-  border-radius:var(--radius-md,14px);background:var(--surface,#fff);
+  border-radius:var(--radius-md,14px);background:var(--surface,var(--color-surface));
 }
 .cw-session-row{
   display:flex;align-items:center;gap:12px;padding:12px 14px;
   border-bottom:1px solid var(--border,rgba(24,84,60,.09));cursor:pointer;transition:background .1s;
 }.cw-session-row:last-child{border-bottom:0}
-.cw-session-row:hover{background:var(--surface-2,#EDF3EF)}
-.cw-session-row.is-selected{background:var(--surface-2,#EDF3EF)}
+.cw-session-row:hover{background:var(--surface-2,var(--color-surface-2))}
+.cw-session-row.is-selected{background:var(--surface-2,var(--color-surface-2))}
 .cw-check{
   width:20px;height:20px;border-radius:6px;border:1.5px solid var(--border-strong,rgba(24,84,60,.18));
-  display:grid;place-items:center;color:#fff;flex-shrink:0;transition:all .12s;
+  display:grid;place-items:center;color:var(--color-surface);flex-shrink:0;transition:all .12s;
 }
-.cw-session-row.is-selected .cw-check{background:var(--primary,#0E9F6E);border-color:var(--primary,#0E9F6E)}
+.cw-session-row.is-selected .cw-check{background:var(--primary,var(--color-brand));border-color:var(--primary,var(--color-brand))}
 .cw-check svg{width:12px;height:12px;opacity:0}
 .cw-session-row.is-selected .cw-check svg{opacity:1}
 .cw-session-source{
   flex-shrink:0;font-size: var(--font-size-1);font-weight:700;letter-spacing:0.05em;
-  color:var(--text-2,#3E5A4C);background:var(--surface-2,#EDF3EF);
+  color:var(--text-2,var(--color-ink-2));background:var(--surface-2,var(--color-surface-2));
   border-radius:999px;padding:3px 9px;text-transform:uppercase;
 }
 .cw-session-body{flex:1;min-width:0;display:flex;flex-direction:column;gap:3px}
 .cw-session-title{
-  font-size:13px;color:var(--text,#14281E);white-space:nowrap;
+  font-size:13px;color:var(--text,var(--color-ink));white-space:nowrap;
   overflow:hidden;text-overflow:ellipsis;
 }
 .cw-session-meta{
-  font-size:11.5px;color:var(--muted,#6E8578);white-space:nowrap;
+  font-size:11.5px;color:var(--muted,var(--color-muted));white-space:nowrap;
   overflow:hidden;text-overflow:ellipsis;
 }
-.cw-import-head h3{font-size:15px;font-weight:650;color:var(--text,#14281E);margin:0 0 4px}
-.cw-import-head p{font-size:12.5px;color:var(--muted,#6E8578);margin:0 0 10px;line-height:1.6}
+.cw-import-head h3{font-size:15px;font-weight:650;color:var(--text,var(--color-ink));margin:0 0 4px}
+.cw-import-head p{font-size:12.5px;color:var(--muted,var(--color-muted));margin:0 0 10px;line-height:1.6}
 .cw-progress-track{
-  height:6px;background:var(--surface-2,#EDF3EF);border-radius:999px;
+  height:6px;background:var(--surface-2,var(--color-surface-2));border-radius:999px;
   overflow:hidden;margin:12px 0 16px;
 }
 .cw-progress-bar{
-  height:100%;width:0;background:linear-gradient(90deg,var(--primary,#0E9F6E),#2BC48C);
+  height:100%;width:0;background:linear-gradient(90deg,var(--primary,var(--color-brand)),#2BC48C);
   border-radius:999px;transition:width .2s;
 }
 .cw-import-list{display:flex;flex-direction:column;gap:8px}
 .cw-import-row{
   display:flex;align-items:center;gap:12px;padding:12px 14px;
   border:1px solid var(--border,rgba(24,84,60,.09));
-  border-radius:var(--radius-sm,10px);background:var(--surface,#fff);
+  border-radius:var(--radius-sm,10px);background:var(--surface,var(--color-surface));
 }
 .cw-import-row.is-running{background:#FFF8E6;border-color:#F1C75B;animation:cw-import-pulse 1.2s ease-in-out infinite}
 @keyframes cw-import-pulse{0%,100%{background:#FFF8E6}50%{background:#FFEFC7}}
 .cw-import-row.is-pending{background:#EAF3EE;border-color:#9CC3AE;animation:cw-import-pending 1.4s ease-in-out infinite}
 @keyframes cw-import-pending{0%,100%{background:#EAF3EE}50%{background:#D7E9E0}}
-.cw-import-row.is-ok{background:var(--surface-2,#EDF3EF);border-color:var(--border-strong,rgba(24,84,60,.2))}
+.cw-import-row.is-ok{background:var(--surface-2,var(--color-surface-2));border-color:var(--border-strong,rgba(24,84,60,.2))}
 .cw-import-row.is-degraded{background:#FBF3E0;border-color:#E3C56B}
-.cw-import-row.is-exists{background:var(--surface-2,#EDF3EF);border-color:var(--border-strong,rgba(24,84,60,.2))}
+.cw-import-row.is-exists{background:var(--surface-2,var(--color-surface-2));border-color:var(--border-strong,rgba(24,84,60,.2))}
 .cw-import-row.is-fail{background:#FBE9E5;border-color:#E9A89B}
 .cw-import-source{
   flex-shrink:0;font-size: var(--font-size-1);font-weight:700;letter-spacing:0.05em;
-  color:var(--text-2,#3E5A4C);background:var(--surface-2,#EDF3EF);
+  color:var(--text-2,var(--color-ink-2));background:var(--surface-2,var(--color-surface-2));
   border-radius:999px;padding:3px 9px;text-transform:uppercase;
 }
 .cw-import-title{
-  flex:1;min-width:0;font-size:12.5px;color:var(--text,#14281E);
+  flex:1;min-width:0;font-size:12.5px;color:var(--text,var(--color-ink));
   white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
 }
 .cw-import-status{flex-shrink:0;font-size:11.5px;font-weight:650}
-.cw-import-row.is-waiting .cw-import-status{color:var(--muted,#6E8578)}
+.cw-import-row.is-waiting .cw-import-status{color:var(--muted,var(--color-muted))}
 .cw-import-row.is-running .cw-import-status{color:#9A6B00}
-.cw-import-row.is-ok .cw-import-status{color:var(--text-2,#3E5A4C)}
+.cw-import-row.is-ok .cw-import-status{color:var(--text-2,var(--color-ink-2))}
 .cw-import-row.is-degraded .cw-import-status{color:#9A6B00}
-.cw-import-row.is-exists .cw-import-status{color:var(--muted,#6E8578)}
+.cw-import-row.is-exists .cw-import-status{color:var(--muted,var(--color-muted))}
 .cw-import-row.is-fail .cw-import-status{color:#B23B2A}
 .cw-done-summary{
   display:flex;flex-direction:column;align-items:center;gap:6px;
@@ -26003,13 +26003,13 @@ body.is-terminal-resizing {
 }
 .cw-done-icon{
   width:48px;height:48px;border-radius:50%;
-  background:linear-gradient(135deg,var(--primary,#0E9F6E),var(--primary-hover,#0A7A55));
-  color:#fff;display:grid;place-items:center;margin-bottom:4px;
+  background:linear-gradient(135deg,var(--primary,var(--color-brand)),var(--primary-hover,var(--color-brand-hover)));
+  color:var(--color-surface);display:grid;place-items:center;margin-bottom:4px;
   box-shadow:0 6px 18px rgba(14,159,110,0.28);
 }
 .cw-done-icon svg{width:24px;height:24px}
-.cw-done-title{font-size:15px;font-weight:500;color:var(--text,#14281E)}
-.cw-done-meta{font-size:12.5px;color:var(--muted,#6E8578)}
+.cw-done-title{font-size:15px;font-weight:500;color:var(--text,var(--color-ink))}
+.cw-done-meta{font-size:12.5px;color:var(--muted,var(--color-muted))}
 .cw-done-hint{
   display:flex;align-items:flex-start;gap:10px;margin:2px 0 12px;
   padding:12px 14px;border-radius:var(--radius-sm,10px);
@@ -26021,7 +26021,7 @@ body.is-terminal-resizing {
 .cw-done-row{
   display:flex;align-items:center;gap:12px;padding:12px 14px;flex-wrap:wrap;
   border:1px solid var(--border,rgba(24,84,60,.09));
-  border-radius:var(--radius-sm,10px);background:var(--surface,#fff);
+  border-radius:var(--radius-sm,10px);background:var(--surface,var(--color-surface));
 }
 .cw-done-row.is-degraded{background:#FBF3E0;border-color:#E3C56B}
 .cw-done-row .cw-done-title{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -26034,32 +26034,32 @@ body.is-terminal-resizing {
 }
 /* 后台提炼中标记：绿色（区别于黄色「未提炼」）。 */
 .cw-done-tag.is-pending{
-  color:var(--primary-text,#0A7A55);background:var(--primary-soft,#E2F5EC);
+  color:var(--primary-text,var(--color-brand-hover));background:var(--primary-soft,var(--color-brand-soft));
 }
 /* 已存在的会话标记：绿色（区别于黄色「未提炼」）。 */
 .cw-done-tag.is-exists{
-  color:var(--primary-text,#0A7A55);background:var(--primary-soft,#E2F5EC);
+  color:var(--primary-text,var(--color-brand-hover));background:var(--primary-soft,var(--color-brand-soft));
 }
 .cw-btn{
   display:inline-flex;align-items:center;justify-content:center;gap:6px;
   height:36px;padding:0 16px;border-radius:var(--radius-sm,10px);font-size:12.5px;font-weight:600;
   transition:all .12s;border:1px solid transparent;
 }
-.cw-btn.ghost{background:transparent;color:var(--text-2,#3E5A4C)}
-.cw-btn.ghost:hover{background:var(--surface-2,#EDF3EF);color:var(--text,#14281E)}
-.cw-btn.primary{background:linear-gradient(135deg,var(--primary,#0E9F6E),var(--primary-hover,#0A7A55));
-  color:#fff;border-color:transparent;box-shadow:0 2px 8px rgba(14,159,110,.18)}
-.cw-btn.primary:hover{background:linear-gradient(135deg,var(--primary-hover,#0A7A55),var(--primary-hover,#0A7A55));
+.cw-btn.ghost{background:transparent;color:var(--text-2,var(--color-ink-2))}
+.cw-btn.ghost:hover{background:var(--surface-2,var(--color-surface-2));color:var(--text,var(--color-ink))}
+.cw-btn.primary{background:linear-gradient(135deg,var(--primary,var(--color-brand)),var(--primary-hover,var(--color-brand-hover)));
+  color:var(--color-surface);border-color:transparent;box-shadow:0 2px 8px rgba(14,159,110,.18)}
+.cw-btn.primary:hover{background:linear-gradient(135deg,var(--primary-hover,var(--color-brand-hover)),var(--primary-hover,var(--color-brand-hover)));
   box-shadow:0 4px 14px rgba(14,159,110,.24);transform:translateY(-1px)}
 .cw-btn.small{height:28px;padding:0 12px;font-size:12px}
 .cw-btn:disabled{opacity:0.45;cursor:not-allowed}
 .cw-empty{
   display:flex;flex-direction:column;align-items:center;gap:10px;
-  padding:34px 16px;color:var(--muted,#6E8578);font-size:12.5px;text-align:center;
+  padding:34px 16px;color:var(--muted,var(--color-muted));font-size:12.5px;text-align:center;
 }
 .cw-empty-icon{
-  width:44px;height:44px;border-radius:12px;background:var(--surface-2,#EDF3EF);
-  color:var(--text-2,#3E5A4C);display:grid;place-items:center;
+  width:44px;height:44px;border-radius:12px;background:var(--surface-2,var(--color-surface-2));
+  color:var(--text-2,var(--color-ink-2));display:grid;place-items:center;
 }
 .cw-empty-icon svg{width:20px;height:20px}
 .cw-foot{
@@ -26097,7 +26097,7 @@ body.is-terminal-resizing {
   z-index: var(--z-tour);
   pointer-events: none;
   max-width: 300px;
-  background: #ffffff;
+  background: var(--color-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   box-shadow: 0 4px 16px rgba(20, 40, 30, 0.08);
@@ -26168,7 +26168,7 @@ body.is-terminal-resizing {
   padding: 0 12px;
   border: 1px solid var(--border-strong);
   border-radius: 7px;
-  background: #ffffff;
+  background: var(--color-surface);
   color: var(--text-2);
   font-size: 12px;
   font-weight: 600;
@@ -26184,12 +26184,12 @@ body.is-terminal-resizing {
 .tour-tooltip-btn.primary {
   background: var(--primary);
   border-color: var(--primary);
-  color: #ffffff;
+  color: var(--color-surface);
 }
 
 .tour-tooltip-btn.primary:hover {
   filter: brightness(1.05);
-  color: #ffffff;
+  color: var(--color-surface);
 }
 
 /* 弱化的"跳过"：纯文字链接，不强占视线。 */
@@ -26213,7 +26213,7 @@ body.is-terminal-resizing {
   position: absolute;
   width: 12px;
   height: 12px;
-  background: #ffffff;
+  background: var(--color-surface);
   border: 1px solid var(--border-strong);
   transform: rotate(45deg);
 }
@@ -26488,7 +26488,7 @@ body.is-terminal-resizing {
 .touchpoint-step strong { color: var(--text); font-size: 12px; }
 .touchpoint-step div > span { margin-top: 2px; color: var(--muted); font-size: var(--font-size-1); }
 .touchpoint-step.is-current .touchpoint-step-index {
-  color: #fff;
+  color: var(--color-surface);
   border-color: var(--primary);
   background: var(--primary);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--primary) 12%, transparent);
@@ -26682,11 +26682,11 @@ body.is-terminal-resizing {
   font-size: 12px;
 }
 
-.touchpoint-template-config { margin: 18px 0 22px; padding: 18px; border: 1px solid var(--border-color, #dfe3e8); border-radius: 8px; background: var(--bg-primary, #fff); }
+.touchpoint-template-config { margin: 18px 0 22px; padding: 18px; border: 1px solid var(--border-color, #dfe3e8); border-radius: 8px; background: var(--bg-primary, var(--color-surface)); }
 .touchpoint-template-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .touchpoint-template-grid label { display: flex; flex-direction: column; gap: 5px; color: var(--text-secondary, #646e7b); font-size: 12px; }
 .touchpoint-template-grid .span-2 { grid-column: span 2; }
-.touchpoint-template-grid input, .touchpoint-template-grid textarea, .touchpoint-template-grid select { width: 100%; border: 1px solid var(--border-color, #d9dde3); border-radius: 6px; padding: 8px 9px; color: var(--text-primary, #1f2329); background: var(--bg-primary, #fff); font: inherit; font-size: 12px; }
+.touchpoint-template-grid input, .touchpoint-template-grid textarea, .touchpoint-template-grid select { width: 100%; border: 1px solid var(--border-color, #d9dde3); border-radius: 6px; padding: 8px 9px; color: var(--text-primary, #1f2329); background: var(--bg-primary, var(--color-surface)); font: inherit; font-size: 12px; }
 .touchpoint-template-grid textarea { min-height: 90px; resize: vertical; line-height: 1.5; }
 .touchpoint-template-hint { margin-top: 12px; color: var(--text-tertiary, #7a8491); font-size: 11px; }
 .touchpoint-template-hint code { padding: 2px 4px; border-radius: 3px; color: var(--brand-color, #245bdb); background: var(--brand-bg, #eaf1ff); }
@@ -26835,7 +26835,7 @@ body.is-terminal-resizing {
 .touchpoint-template-card-note { margin-top: 14px; padding-top: 11px; border-top: 1px solid var(--border); color: var(--muted); font-size: var(--font-size-1); }
 .touchpoint-template-card-actions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 16px; }
 .touchpoint-template-card-actions button { min-height: 34px; border: 1px solid var(--border-strong); border-radius: 8px; background: var(--surface); color: var(--text); font: inherit; font-size: 11.5px; font-weight: 650; }
-.touchpoint-template-card-actions button.is-primary { border-color: var(--primary); background: var(--primary); color: #fff; }
+.touchpoint-template-card-actions button.is-primary { border-color: var(--primary); background: var(--primary); color: var(--color-surface); }
 .touchpoint-template-help { display: flex; align-items: flex-start; gap: 10px; padding: 14px 16px; border: 1px solid color-mix(in srgb, var(--success) 24%, var(--border)); border-radius: 12px; background: color-mix(in srgb, var(--success) 5%, var(--surface)); }
 .touchpoint-template-help > div:first-child { display: flex; align-items: center; justify-content: center; width: 26px; height: 26px; flex: 0 0 auto; border-radius: 8px; color: var(--success); background: color-mix(in srgb, var(--success) 11%, var(--surface)); }
 .touchpoint-template-help strong { display: block; margin: 2px 0 4px; font-size: 12px; }
@@ -26896,7 +26896,7 @@ body.is-terminal-resizing {
   font-size: 13px; color: #374151; line-height: 1.65;
 }
 .auto-time-adjust-card .auto-time-adjust-body .time-highlight {
-  font-weight: 600; background: #dcfce7; color: #166534;
+  font-weight: 600; background: var(--color-success-soft); color: #166534;
   padding: 1px 6px; border-radius: 4px; white-space: nowrap;
 }
 .auto-time-adjust-card .auto-time-adjust-body .time-highlight.new-time {
@@ -26914,19 +26914,19 @@ body.is-terminal-resizing {
   opacity: 0.5; cursor: not-allowed; transform: none !important;
 }
 .auto-time-adjust-card .auto-time-adjust-actions .btn-confirm {
-  background: #22c55e; color: #fff;
+  background: #22c55e; color: var(--color-surface);
 }
 .auto-time-adjust-card .auto-time-adjust-actions .btn-confirm:hover:not(:disabled) {
-  background: #16a34a; transform: translateY(-1px); box-shadow: 0 2px 8px rgba(22,163,74,0.3);
+  background: var(--color-success); transform: translateY(-1px); box-shadow: 0 2px 8px rgba(22,163,74,0.3);
 }
 .auto-time-adjust-card .auto-time-adjust-actions .btn-keep {
-  background: #dcfce7; color: #166534;
+  background: var(--color-success-soft); color: #166534;
 }
 .auto-time-adjust-card .auto-time-adjust-actions .btn-keep:hover:not(:disabled) {
   background: #bbf7d0; transform: translateY(-1px);
 }
 .auto-time-adjust-card.is-confirmed {
-  border-left-color: #16a34a;
+  border-left-color: var(--color-success);
 }
 .auto-time-adjust-card.is-dismissed {
   border-left-color: #9ca3af; background: #f9fafb;
@@ -26935,7 +26935,7 @@ body.is-terminal-resizing {
   font-size: 12.5px; padding: 6px 10px; border-radius: 6px; display: none;
 }
 .auto-time-adjust-card.is-confirmed .auto-time-adjust-result {
-  display: block; background: #dcfce7; color: #166534;
+  display: block; background: var(--color-success-soft); color: #166534;
   animation: autoTimeAdjustResultFadeIn 0.3s ease-out;
 }
 .auto-time-adjust-card.is-dismissed .auto-time-adjust-result {
@@ -26951,7 +26951,7 @@ body.is-terminal-resizing {
 /* Hero */
 .sec-hero {
   display: flex; gap: 16px; align-items: flex-start;
-  background: var(--panel, #fff); border: 1px solid var(--border);
+  background: var(--panel, var(--color-surface)); border: 1px solid var(--border);
   border-radius: 14px; padding: 18px 20px; margin-bottom: 16px;
 }
 .sec-hero-icon {
@@ -26959,10 +26959,10 @@ body.is-terminal-resizing {
   display: flex; align-items: center; justify-content: center;
   background: var(--success-soft); border: 1px solid transparent;
 }
-.sec-hero-icon.warn { background: #fef3c7; }
+.sec-hero-icon.warn { background: var(--color-warning-soft); }
 .sec-hero-icon.bad { background: var(--danger-soft, #fee2e2); }
 .sec-hero-dot { width: 14px; height: 14px; border-radius: 50%; background: var(--success); }
-.sec-hero-icon.warn .sec-hero-dot { background: #d97706; }
+.sec-hero-icon.warn .sec-hero-dot { background: var(--color-warning); }
 .sec-hero-icon.bad .sec-hero-dot { background: var(--danger); }
 .sec-hero-main { flex: 1; min-width: 0; }
 .sec-hero-title { font-size: 15.5px; font-weight: 650; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
@@ -26975,7 +26975,7 @@ body.is-terminal-resizing {
   font-size: 11px; font-weight: 500; padding: 2px 9px; border-radius: 999px; white-space: nowrap;
 }
 .sec-tag.ok, .sec-pill.ok { background: var(--success-soft); color: var(--success); }
-.sec-tag.warn, .sec-pill.warn { background: #fef3c7; color: #b45309; }
+.sec-tag.warn, .sec-pill.warn { background: var(--color-warning-soft); color: #b45309; }
 .sec-tag.bad, .sec-pill.bad { background: var(--danger-soft, #fee2e2); color: var(--danger); }
 .sec-pill.muted { background: #f1f5f3; color: var(--text-3); }
 
@@ -26983,7 +26983,7 @@ body.is-terminal-resizing {
 .sec-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
 @media (max-width: 760px) { .sec-grid { grid-template-columns: 1fr; } }
 .sec-card {
-  background: var(--panel, #fff); border: 1px solid var(--border);
+  background: var(--panel, var(--color-surface)); border: 1px solid var(--border);
   border-radius: 14px; padding: 14px 15px 12px;
 }
 .sec-card-head { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
@@ -26996,7 +26996,7 @@ body.is-terminal-resizing {
 .sec-section-head { display: flex; justify-content: space-between; align-items: flex-end; margin: 20px 0 10px; flex-wrap: wrap; gap: 6px; }
 .sec-section-title { font-size: 14.5px; font-weight: 650; }
 .sec-section-sub { font-size: 12px; color: var(--text-3); margin-top: 2px; }
-.sec-table-wrap { background: var(--panel, #fff); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; }
+.sec-table-wrap { background: var(--panel, var(--color-surface)); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; }
 .sec-table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .sec-table th {
   text-align: left; font-weight: 500; color: var(--text-3); font-size: 12px;
@@ -27015,7 +27015,7 @@ body.is-terminal-resizing {
 .sec-score { display: flex; align-items: center; gap: 8px; }
 .sec-score-bar { width: 60px; height: 5px; border-radius: 999px; background: #edf2ef; overflow: hidden; }
 .sec-score-bar i { display: block; height: 100%; border-radius: 999px; background: var(--primary); }
-.sec-score-bar i.mid { background: #d97706; }
+.sec-score-bar i.mid { background: var(--color-warning); }
 .sec-score-bar i.low { background: var(--danger); }
 .sec-score-num { color: var(--text-2); font-size: 12px; font-variant-numeric: tabular-nums; }
 .sec-time { color: var(--text-3); font-size: 12.5px; font-variant-numeric: tabular-nums; }
@@ -27027,8 +27027,8 @@ body.is-terminal-resizing {
 
 /* 操作 + 选择器 + 保护说明 */
 .sec-actions { display: flex; gap: 10px; margin-top: 14px; flex-wrap: wrap; }
-.sec-btn-primary { background: var(--primary); border-color: var(--primary); color: #fff; }
-.sec-btn-primary:hover { background: #0a7a55; }
+.sec-btn-primary { background: var(--primary); border-color: var(--primary); color: var(--color-surface); }
+.sec-btn-primary:hover { background: var(--color-brand-hover); }
 .sec-link {
   background: none; border: none; cursor: pointer; font-family: inherit;
   font-size: 12.5px; color: var(--primary-text); padding: 4px 2px;
@@ -27036,7 +27036,7 @@ body.is-terminal-resizing {
 .sec-link:hover { text-decoration: underline; }
 .sec-link:disabled { color: var(--text-3); cursor: default; text-decoration: none; }
 .sec-picker {
-  display: none; margin-top: 12px; background: var(--panel, #fff);
+  display: none; margin-top: 12px; background: var(--panel, var(--color-surface));
   border: 1px solid var(--border); border-radius: 14px; padding: 12px;
 }
 .sec-picker.open { display: block; }
@@ -27071,24 +27071,24 @@ body.is-terminal-resizing {
 .imp-close { margin-left: 8px; }
 .imp-status { display: flex; gap: 12px; align-items: flex-start; border-radius: 14px; padding: 14px 16px; margin-bottom: 14px; }
 .imp-status.ok { background: var(--success-soft); }
-.imp-status.warn { background: #fef3c7; }
+.imp-status.warn { background: var(--color-warning-soft); }
 .imp-status.bad { background: var(--danger-soft, #fee2e2); }
 .imp-status.muted { background: #F1F5F3; }
 .imp-status-icon { width: 34px; height: 34px; border-radius: 50%; background: #fff; display: flex; align-items: center; justify-content: center; flex: none; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
 .imp-status.ok .imp-status-icon { color: var(--success); }
-.imp-status.warn .imp-status-icon { color: #d97706; }
+.imp-status.warn .imp-status-icon { color: var(--color-warning); }
 .imp-status.bad .imp-status-icon { color: var(--danger); }
 .imp-status.muted .imp-status-icon { color: var(--text-3); }
 .imp-status-icon svg { width: 17px; height: 17px; }
 .imp-status-main { flex: 1; min-width: 0; }
 .imp-status-title { font-size: 14px; font-weight: 650; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.imp-score-chip { font-size: 12px; font-weight: 600; padding: 1px 9px; border-radius: 999px; background: #fff; }
+.imp-score-chip { font-size: 12px; font-weight: 600; padding: 1px 9px; border-radius: 999px; background: var(--color-surface); }
 .imp-status.ok .imp-score-chip { color: var(--success); }
-.imp-status.warn .imp-score-chip { color: #d97706; }
+.imp-status.warn .imp-score-chip { color: var(--color-warning); }
 .imp-status.bad .imp-score-chip { color: var(--danger); }
 .imp-status-desc { font-size: 12.5px; margin-top: 4px; }
 .imp-status.ok .imp-status-desc { color: #14532d; }
-.imp-status.warn .imp-status-desc { color: #92400e; }
+.imp-status.warn .imp-status-desc { color: var(--color-warning-text); }
 .imp-status.bad .imp-status-desc { color: #7f1d1d; }
 .imp-status.muted .imp-status-desc { color: var(--text-2); }
 .imp-surface { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
@@ -27100,15 +27100,15 @@ body.is-terminal-resizing {
 .imp-finding:last-child { border-bottom: none; }
 .imp-finding-dot { width: 7px; height: 7px; border-radius: 50%; margin-top: 6px; flex: none; }
 .imp-finding-dot.extreme { background: var(--danger); }
-.imp-finding-dot.medium { background: #d97706; }
+.imp-finding-dot.medium { background: var(--color-warning); }
 .imp-finding-dot.low { background: var(--text-3); }
 .imp-finding-text { flex: 1; color: var(--text-2); }
 .imp-finding-loc { color: var(--text-3); font-size: 11.5px; flex: none; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .imp-findings-more { padding: 8px 12px; font-size: 12px; color: var(--text-3); background: #FAFCFB; }
 .imp-foot { display: flex; align-items: center; gap: 10px; }
 .imp-spacer { flex: 1; }
-.imp-btn-primary { background: var(--primary); border-color: var(--primary); color: #fff; }
-.imp-btn-primary:hover { background: #0A7A55; color: #fff; }
+.imp-btn-primary { background: var(--primary); border-color: var(--primary); color: var(--color-surface); }
+.imp-btn-primary:hover { background: var(--color-brand-hover); color: var(--color-surface); }
 .imp-btn-danger { color: var(--danger); border-color: rgba(220,38,38,.25); }
 .imp-btn-danger:hover { border-color: var(--danger); color: var(--danger); }
 .imp-btn-ghost { border-color: transparent; background: none; color: var(--text-3); }
@@ -27119,87 +27119,87 @@ body.is-terminal-resizing {
  * （今天/昨天）、source-pill、进度 X/N、导入行状态、成功面板。业务逻辑不变。 */
 
 /* 头部副标题 */
-.cw-subtitle{font-size:12px;color:var(--muted,#6E8578);margin-top:2px;line-height:1.5}
+.cw-subtitle{font-size:12px;color:var(--muted,var(--color-muted));margin-top:2px;line-height:1.5}
 
 /* 隐私提示 */
-.cw-privacy-note{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;color:var(--muted,#6E8578);
-  padding:4px 9px;border-radius:6px;background:var(--surface-2,#EDF3EF);margin-top:2px}
+.cw-privacy-note{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;color:var(--muted,var(--color-muted));
+  padding:4px 9px;border-radius:6px;background:var(--surface-2,var(--color-surface-2));margin-top:2px}
 .cw-privacy-note svg{width:13px;height:13px;flex:none}
 
 /* ── Step 1 来源卡片（原型：agent-mark 圆标 + 状态点 + 计数）── */
 .cw-source-card{position:relative;display:flex;flex-direction:column;align-items:flex-start;gap:12px;padding:14px 13px;text-align:left;
-  border:1px solid var(--border,#E3EAE6);border-radius:11px;background:var(--surface,#fff);cursor:pointer;
+  border:1px solid var(--border,#E3EAE6);border-radius:11px;background:var(--surface,var(--color-surface));cursor:pointer;
   transition:border-color .16s,box-shadow .16s,background .16s,transform .16s;font-family:inherit}
 .cw-source-card:hover{border-color:#9ec9b7;box-shadow:0 5px 16px rgba(14,159,110,.08);transform:translateY(-1px)}
-.cw-source-card.is-selected{border-color:color-mix(in srgb,var(--primary,#0E9F6E) 45%,transparent);
-  background:color-mix(in srgb,var(--primary,#0E9F6E) 5%,var(--surface,#fff));
+.cw-source-card.is-selected{border-color:color-mix(in srgb,var(--primary,var(--color-brand)) 45%,transparent);
+  background:color-mix(in srgb,var(--primary,var(--color-brand)) 5%,var(--surface,var(--color-surface)));
   box-shadow:0 0 0 1px rgba(15,155,108,.08)}
 .cw-source-card.is-disabled{cursor:not-allowed;opacity:.58;background:#f6f8f7}
 .cw-source-check{position:absolute;top:10px;right:10px;width:18px;height:18px;border:1.5px solid var(--border-strong,#C8D5CE);
   border-radius:50%;display:inline-flex;align-items:center;justify-content:center;color:#fff;background:var(--surface,#fff);
   transition:background .12s,border-color .12s}
-.cw-source-card.is-selected .cw-source-check{border-color:var(--primary,#0E9F6E);background:var(--primary,#0E9F6E)}
+.cw-source-card.is-selected .cw-source-check{border-color:var(--primary,var(--color-brand));background:var(--primary,var(--color-brand))}
 .cw-source-check svg{width:11px;height:11px;opacity:0}
 .cw-source-card.is-selected .cw-source-check svg{opacity:1}
 .cw-source-main{display:flex;align-items:center;gap:11px;min-width:0}
 .cw-agent-mark{width:34px;height:34px;border-radius:9px;flex:none;display:inline-flex;align-items:center;justify-content:center;
-  background:var(--primary-soft,#E2F5EC);color:var(--primary-text,#0A7A55);font-size:12px;font-weight:750;letter-spacing:.02em}
-.cw-source-main h4{margin:0;font-size:14px;font-weight:650;color:var(--text,#14281E)}
-.cw-source-main .cw-source-meta{margin-top:3px;color:var(--muted,#6E8578);font-size:11.5px}
-.cw-source-foot{display:flex;align-items:center;gap:7px;color:var(--text-2,#3E5A4C);font-size:11.5px}
-.cw-status-dot{width:7px;height:7px;border-radius:50%;background:var(--primary,#0E9F6E);flex:none}
+  background:var(--primary-soft,var(--color-brand-soft));color:var(--primary-text,var(--color-brand-hover));font-size:12px;font-weight:750;letter-spacing:.02em}
+.cw-source-main h4{margin:0;font-size:14px;font-weight:650;color:var(--text,var(--color-ink))}
+.cw-source-main .cw-source-meta{margin-top:3px;color:var(--muted,var(--color-muted));font-size:11.5px}
+.cw-source-foot{display:flex;align-items:center;gap:7px;color:var(--text-2,var(--color-ink-2));font-size:11.5px}
+.cw-status-dot{width:7px;height:7px;border-radius:50%;background:var(--primary,var(--color-brand));flex:none}
 .cw-status-dot.is-off{background:#a9b4ae}
 
 /* ── Step 2 会话分组 + source-pill ── */
 .cw-session-group{margin-bottom:14px}
-.cw-group-label{margin-bottom:7px;color:var(--muted,#6E8578);font-size:12px;font-weight:650}
-.cw-session-list-inner{border:1px solid var(--border,#E3EAE6);border-radius:10px;overflow:hidden;background:var(--surface,#fff)}
+.cw-group-label{margin-bottom:7px;color:var(--muted,var(--color-muted));font-size:12px;font-weight:650}
+.cw-session-list-inner{border:1px solid var(--border,#E3EAE6);border-radius:10px;overflow:hidden;background:var(--surface,var(--color-surface))}
 .cw-session-row{display:grid;grid-template-columns:24px minmax(0,1fr) auto auto;gap:12px;align-items:center;
   padding:11px 13px;border-bottom:1px solid var(--border,#E3EAE6);cursor:pointer;transition:background .15s}
 .cw-session-row:last-child{border-bottom:0}
 .cw-session-row:hover{background:#fafcfb}
-.cw-session-row.is-selected{background:var(--surface-2,#EDF3EF)}
-.cw-session-row.is-selected .cw-check{background:var(--primary,#0E9F6E);border-color:var(--primary,#0E9F6E)}
+.cw-session-row.is-selected{background:var(--surface-2,var(--color-surface-2))}
+.cw-session-row.is-selected .cw-check{background:var(--primary,var(--color-brand));border-color:var(--primary,var(--color-brand))}
 .cw-session-row.is-selected .cw-check svg{opacity:1}
 .cw-session-body{min-width:0;display:flex;flex-direction:column;gap:3px}
-.cw-session-title{font-size:13px;font-weight:600;color:var(--text,#14281E);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.cw-session-meta{font-size:11px;color:var(--muted,#6E8578);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.cw-source-pill{padding:3px 8px;border-radius:5px;color:var(--primary-text,#0A7A55);background:var(--primary-soft,#E2F5EC);
+.cw-session-title{font-size:13px;font-weight:600;color:var(--text,var(--color-ink));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cw-session-meta{font-size:11px;color:var(--muted,var(--color-muted));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cw-source-pill{padding:3px 8px;border-radius:5px;color:var(--primary-text,var(--color-brand-hover));background:var(--primary-soft,var(--color-brand-soft));
   font-size: var(--font-size-1);font-weight:700;white-space:nowrap}
-.cw-session-time{color:var(--muted,#6E8578);font-size:11.5px;text-align:right;white-space:nowrap}
+.cw-session-time{color:var(--muted,var(--color-muted));font-size:11.5px;text-align:right;white-space:nowrap}
 
 /* ── Step 3 进度 + 导入行 + 成功面板 ── */
 .cw-progress-summary{display:flex;flex-direction:column;gap:7px;margin:4px 0 14px}
-.cw-progress-count{align-self:flex-end;font-size:12px;font-weight:650;color:var(--text-2,#3E5A4C);font-variant-numeric:tabular-nums}
+.cw-progress-count{align-self:flex-end;font-size:12px;font-weight:650;color:var(--text-2,var(--color-ink-2));font-variant-numeric:tabular-nums}
 .cw-import-row{display:grid;grid-template-columns:28px minmax(0,1fr) auto;gap:12px;align-items:center;
-  padding:11px 13px;border:1px solid var(--border,#E3EAE6);border-radius:10px;margin-bottom:8px;background:var(--surface,#fff)}
+  padding:11px 13px;border:1px solid var(--border,#E3EAE6);border-radius:10px;margin-bottom:8px;background:var(--surface,var(--color-surface))}
 .cw-import-state{width:26px;height:26px;border-radius:7px;display:inline-flex;align-items:center;justify-content:center;
-  background:var(--surface-2,#EDF3EF);color:var(--muted,#6E8578)}
+  background:var(--surface-2,var(--color-surface-2));color:var(--muted,var(--color-muted))}
 .cw-import-state svg{width:14px;height:14px}
-.cw-import-row.is-running .cw-import-state{background:var(--primary-soft,#E2F5EC);color:var(--primary-text,#0A7A55)}
+.cw-import-row.is-running .cw-import-state{background:var(--primary-soft,var(--color-brand-soft));color:var(--primary-text,var(--color-brand-hover))}
 .cw-import-row.is-running .cw-import-state svg{animation:cw-spin 1s linear infinite}
-.cw-import-row.is-ok .cw-import-state,.cw-import-row.is-exists .cw-import-state{background:var(--primary-soft,#E2F5EC);color:var(--primary-text,#0A7A55)}
-.cw-import-row.is-degraded .cw-import-state{background:var(--surface-2,#EDF3EF);color:var(--muted,#6E8578)}
-.cw-import-row.is-fail .cw-import-state{background:color-mix(in srgb,var(--danger,#DE5B45) 12%,#fff);color:var(--danger,#DE5B45)}
+.cw-import-row.is-ok .cw-import-state,.cw-import-row.is-exists .cw-import-state{background:var(--primary-soft,var(--color-brand-soft));color:var(--primary-text,var(--color-brand-hover))}
+.cw-import-row.is-degraded .cw-import-state{background:var(--surface-2,var(--color-surface-2));color:var(--muted,var(--color-muted))}
+.cw-import-row.is-fail .cw-import-state{background:color-mix(in srgb,var(--danger,#DE5B45) 12%,var(--color-surface));color:var(--danger,#DE5B45)}
 @keyframes cw-spin{to{transform:rotate(360deg)}}
 .cw-import-copy{min-width:0}
-.cw-import-copy b{display:block;font-size:12.5px;font-weight:600;color:var(--text,#14281E);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.cw-import-copy small{display:block;margin-top:3px;color:var(--muted,#6E8578);font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.cw-state-label{justify-self:end;color:var(--muted,#6E8578);font-size:11.5px;white-space:nowrap}
-.cw-import-row.is-ok .cw-state-label,.cw-import-row.is-exists .cw-state-label{color:var(--primary-text,#0A7A55)}
-.cw-import-row.is-running .cw-state-label{color:var(--primary,#0E9F6E)}
+.cw-import-copy b{display:block;font-size:12.5px;font-weight:600;color:var(--text,var(--color-ink));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cw-import-copy small{display:block;margin-top:3px;color:var(--muted,var(--color-muted));font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cw-state-label{justify-self:end;color:var(--muted,var(--color-muted));font-size:11.5px;white-space:nowrap}
+.cw-import-row.is-ok .cw-state-label,.cw-import-row.is-exists .cw-state-label{color:var(--primary-text,var(--color-brand-hover))}
+.cw-import-row.is-running .cw-state-label{color:var(--primary,var(--color-brand))}
 
 /* 成功面板 */
 .cw-success-panel{display:none;align-items:flex-start;gap:12px;margin-top:6px;padding:15px 16px;
-  border:1px solid color-mix(in srgb,var(--primary,#0E9F6E) 30%,var(--border,#E3EAE6));border-radius:12px;
-  background:var(--primary-soft,#E2F5EC)}
+  border:1px solid color-mix(in srgb,var(--primary,var(--color-brand)) 30%,var(--border,#E3EAE6));border-radius:12px;
+  background:var(--primary-soft,var(--color-brand-soft))}
 .cw-success-panel.show{display:flex}
-.cw-success-panel svg{width:22px;height:22px;color:var(--primary-text,#0A7A55);flex:none;margin-top:1px}
-.cw-success-panel h4{margin:0 0 4px;font-size:14.5px;font-weight:650;color:var(--text,#14281E)}
-.cw-success-panel p{margin:0;color:var(--text-2,#3E5A4C);line-height:1.55;font-size:12.5px}
+.cw-success-panel svg{width:22px;height:22px;color:var(--primary-text,var(--color-brand-hover));flex:none;margin-top:1px}
+.cw-success-panel h4{margin:0 0 4px;font-size:14.5px;font-weight:650;color:var(--text,var(--color-ink))}
+.cw-success-panel p{margin:0;color:var(--text-2,var(--color-ink-2));line-height:1.55;font-size:12.5px}
 
 /* footer 摘要 */
-.cw-selection-summary{color:var(--muted,#6E8578);font-size:12px}
+.cw-selection-summary{color:var(--muted,var(--color-muted));font-size:12px}
 
 /* ── 结果块（恢复自 e88275e1「Evidence/Receipt 结果块」）──────────────
    9.1 统一框架 · 中间区：来源引用/教学回执收进「证据 Evidence」块、产物
@@ -27349,7 +27349,7 @@ body.is-terminal-resizing {
 .conversation-info-files-repick:hover {
   background: var(--surface-2);
   border-color: var(--primary);
-  color: var(--primary-text, #0a7a55);
+  color: var(--primary-text, var(--color-brand-hover));
 }
 
 /* 工作区区块：当前工作区路径行（让用户一眼知道实际用的是哪个目录）。 */
@@ -27502,7 +27502,7 @@ body.is-terminal-resizing {
 .run-center-view-tabs { align-self: stretch; gap: 18px; }
 .run-center-navigation { display: flex; min-width: 0; align-items: center; gap: 18px; }
 .run-center-task-scopes { display: inline-flex; align-items: center; gap: 2px; padding: 2px; border: 1px solid var(--border); border-radius: var(--radius-1); background: var(--surface-2); }
-.run-center-task-scopes button { min-height: 24px; padding: 3px 8px; border: 0; border-radius: 3px; color: var(--muted); background: transparent; font: inherit; font-size: 11px; cursor: pointer; }
+.run-center-task-scopes button { min-height: 24px; padding: 3px 8px; border: 0; border-radius: var(--radius-1); color: var(--muted); background: transparent; font: inherit; font-size: 11px; cursor: pointer; }
 .run-center-task-scopes button.is-active { color: var(--text); background: var(--surface); box-shadow: 0 1px 2px rgba(15, 23, 42, .08); }
 .run-center-task-summary { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); flex: 0 0 auto; border: 1px solid var(--border); background: var(--surface); }
 .run-center-task-summary button { display: flex; min-width: 0; min-height: 42px; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 12px; border: 0; border-right: 1px solid var(--border); color: var(--text-2); background: transparent; font: inherit; font-size: 11px; cursor: pointer; }
@@ -29909,7 +29909,7 @@ body.kb-wb-resizing .kb-wb-divider { z-index: var(--z-popover); }
   cursor: pointer; color: var(--kb-text); font: inherit;
 }
 .kb-qa-model-item:hover { background: var(--kb-hover); }
-.kb-qa-model-item-check { flex: none; width: 18px; color: var(--kb-green, #0E9F6E); font-weight: 700; font-size: 14px; }
+.kb-qa-model-item-check { flex: none; width: 18px; color: var(--kb-green, var(--color-brand)); font-weight: 700; font-size: 14px; }
 .kb-qa-model-item-main { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
 .kb-qa-model-item-name {
   font-size: 13px; font-weight: 550; color: var(--kb-text);
@@ -29922,10 +29922,10 @@ body.kb-wb-resizing .kb-wb-divider { z-index: var(--z-popover); }
 .kb-qa-model-pop-foot { padding: 8px 16px 14px; border-top: 1px solid var(--kb-border); }
 .kb-qa-model-pop-manage {
   width: 100%; border: 1px solid var(--kb-border); background: transparent;
-  border-radius: 8px; padding: 8px; font-size: 13px; color: var(--kb-green, #0E9F6E);
+  border-radius: 8px; padding: 8px; font-size: 13px; color: var(--kb-green, var(--color-brand));
   cursor: pointer;
 }
-.kb-qa-model-pop-manage:hover { background: var(--kb-brand-soft, #E2F5EC); }
+.kb-qa-model-pop-manage:hover { background: var(--kb-brand-soft, var(--color-brand-soft)); }
 .kb-qa-input {
   flex: 1; min-width: 0; resize: none; font-size: var(--font-size-4); line-height: 1.6;
   height: 26px; max-height: 120px; padding: 4px 4px; color: var(--kb-text);
@@ -29956,7 +29956,7 @@ body.kb-wb-resizing .kb-wb-divider { z-index: var(--z-popover); }
 .kb-qa-attach-ico {
   flex: none; width: 30px; height: 30px; border-radius: 7px;
   display: grid; place-items: center; font-size: 9px; font-weight: 700;
-  background: var(--kb-brand-soft, #E2F5EC); color: var(--kb-green, #0E9F6E);
+  background: var(--kb-brand-soft, var(--color-brand-soft)); color: var(--kb-green, var(--color-brand));
 }
 .kb-qa-attach-ico.is-pdf { background: #FDEBE7; color: #C0392B; }
 .kb-qa-attach-ico.is-md, .kb-qa-attach-ico.is-txt { background: #E8F1FB; color: #2F5FA8; }
@@ -30002,16 +30002,16 @@ body.kb-wb-resizing .kb-wb-divider { z-index: var(--z-popover); }
 }
 .kb-qa-history-close:hover { background: var(--kb-hover); }
 .kb-qa-history-new {
-  margin: 10px 12px 4px; padding: 9px 12px; border-radius: 9px; border: 1px dashed var(--kb-green, #0E9F6E);
-  color: var(--kb-green, #0E9F6E); font-size: 13px; font-weight: 600; text-align: center; cursor: pointer;
+  margin: 10px 12px 4px; padding: 9px 12px; border-radius: 9px; border: 1px dashed var(--kb-green, var(--color-brand));
+  color: var(--kb-green, var(--color-brand)); font-size: 13px; font-weight: 600; text-align: center; cursor: pointer;
 }
-.kb-qa-history-new:hover { background: var(--kb-brand-soft, #E2F5EC); }
+.kb-qa-history-new:hover { background: var(--kb-brand-soft, var(--color-brand-soft)); }
 .kb-qa-history-list { flex: 1; overflow: auto; padding: 4px 8px 10px; }
 .kb-qa-history-item {
   display: flex; align-items: center; gap: 8px; padding: 9px 10px; border-radius: 9px; cursor: pointer;
 }
 .kb-qa-history-item:hover { background: var(--kb-hover); }
-.kb-qa-history-item.is-active { background: var(--kb-brand-soft, #E2F5EC); }
+.kb-qa-history-item.is-active { background: var(--kb-brand-soft, var(--color-brand-soft)); }
 .kb-qa-history-title { flex: 1; min-width: 0; font-size: 13px; color: var(--kb-text2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .kb-qa-history-meta { flex: none; font-size: 11px; color: var(--kb-text3); }
 .kb-qa-history-del {
@@ -30047,7 +30047,7 @@ body.kb-wb-resizing .kb-wb-divider { z-index: var(--z-popover); }
 .kb-qa-hint { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; color: var(--kb-text3); }
 .kb-qa-hint-ico {
   width: 64px; height: 64px; border-radius: 20px; display: grid; place-items: center;
-  background: var(--kb-brand-soft, #E2F5EC); color: var(--kb-green, #0E9F6E); margin-bottom: 6px;
+  background: var(--kb-brand-soft, var(--color-brand-soft)); color: var(--kb-green, var(--color-brand)); margin-bottom: 6px;
 }
 .kb-qa-hint-ico .kb-ico-svg { width: 30px; height: 30px; }
 .kb-qa-hint-title { font-size: 15px; font-weight: 600; color: var(--kb-text); }
@@ -30088,14 +30088,14 @@ body.kb-wb-resizing .kb-wb-divider { z-index: var(--z-popover); }
 /* 对话回答「生成脑图」按钮 + 内嵌预览 */
 .kb-qa-mm-action { margin-top: 12px; }
 .kb-qa-mm-btn {
-  font-size: 12px; color: var(--kb-green, #0E9F6E);
-  background: var(--kb-brand-soft, #E2F5EC); border: 1px solid rgba(14, 159, 110, .35);
+  font-size: 12px; color: var(--kb-green, var(--color-brand));
+  background: var(--kb-brand-soft, var(--color-brand-soft)); border: 1px solid rgba(14, 159, 110, .35);
   border-radius: 8px; padding: 5px 14px; cursor: pointer; transition: background .15s;
 }
 .kb-qa-mm-btn:hover:not(:disabled) { background: #D3EEE1; }
 .kb-qa-mm-btn:disabled { opacity: .55; cursor: default; }
 .kb-qa-mm-action .kb-mm-msg { margin-top: 10px; }
-.kb-qa-mm-action .kb-wb-mm-canvas { border: 1px solid var(--kb-border); border-radius: 10px; background: #fff; min-height: 90px; cursor: pointer; }
+.kb-qa-mm-action .kb-wb-mm-canvas { border: 1px solid var(--kb-border); border-radius: 10px; background: var(--color-surface); min-height: 90px; cursor: pointer; }
 .kb-qa-mm-action .kb-mm-loading { color: var(--kb-muted, #9DB4A6); font-size: 12px; padding: 26px 16px; text-align: center; }
 .kb-qa-mm-action .kb-mm-fail { color: var(--kb-danger, #C0392B); font-size: 12px; padding: 26px 16px; text-align: center; }
 /* 未找到时的跨库引导卡片（前往对应个人库目录并自动重问） */
@@ -30109,10 +30109,10 @@ body.kb-wb-resizing .kb-wb-divider { z-index: var(--z-popover); }
 .kb-qa-suggest-txt b { color: var(--kb-fg-2, #35513F); }
 .kb-qa-suggest-txt code {
   font-size: 11px; color: var(--kb-fg-2, #35513F);
-  background: rgba(14, 159, 110, .08); border-radius: 4px; padding: 0 4px;
+  background: rgba(14, 159, 110, .08); border-radius: var(--radius-1); padding: 0 4px;
 }
 .kb-qa-suggest-btn {
-  font-size: 12px; color: #fff; background: var(--kb-green, #0E9F6E);
+  font-size: 12px; color: var(--color-surface); background: var(--kb-green, var(--color-brand));
   border: 1px solid transparent; border-radius: 8px; padding: 4px 14px; cursor: pointer;
   transition: background .15s;
 }
@@ -30372,7 +30372,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   border-right: 2px solid color-mix(in srgb, var(--kb-text3, #9DB4A6) 65%, transparent);
   border-bottom: 2px solid color-mix(in srgb, var(--kb-text3, #9DB4A6) 65%, transparent);
 }
-.kb-mm-resize:hover::after { border-color: var(--kb-green, #0E9F6E); }
+.kb-mm-resize:hover::after { border-color: var(--kb-green, var(--color-brand)); }
 .kb-mm-overlay-toolbar {
   display: flex; align-items: center; gap: 10px; padding: 12px 18px;
   background: var(--color-white); border-bottom: 1px solid var(--kb-border);
@@ -30393,10 +30393,10 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   background: transparent; padding: 3px 8px; outline: none; cursor: text;
 }
 .kb-mm-title-input:hover { border-color: var(--kb-border); background: var(--kb-hover); }
-.kb-mm-title-input:focus { border-color: var(--kb-green, #0E9F6E); background: #fff; }
+.kb-mm-title-input:focus { border-color: var(--kb-green, var(--color-brand)); background: var(--color-surface); }
 .kb-mm-save-state { font-size: 11.5px; white-space: nowrap; }
-.kb-mm-save-state.is-saved { color: var(--kb-green, #0E9F6E); }
-.kb-mm-save-state.is-dirty { color: #D97706; font-weight: 600; }
+.kb-mm-save-state.is-saved { color: var(--kb-green, var(--color-brand)); }
+.kb-mm-save-state.is-dirty { color: var(--color-warning); font-weight: 600; }
 .kb-mm-titlebar-actions { display: flex; align-items: center; gap: 6px; }
 .kb-mm-titlebar-actions button, .kb-mm-overlay-close {
   height: 28px; padding: 0 10px; border-radius: 7px; border: 1px solid var(--kb-border);
@@ -30426,11 +30426,11 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-mm-tb-group > button:hover, .kb-mm-tb-group .kb-mm-layout > button:hover,
 .kb-mm-tb-group .kb-mm-export > button:hover, .kb-mm-tb-group .kb-mm-open > button:hover,
 .kb-mm-tb-group .kb-mm-overlay-zoom button:hover { background: var(--kb-hover); color: var(--kb-text); }
-.kb-mm-tb-group > button.is-active { color: var(--kb-green, #0E9F6E); background: var(--kb-brand-soft, #E2F5EC); }
+.kb-mm-tb-group > button.is-active { color: var(--kb-green, var(--color-brand)); background: var(--kb-brand-soft, var(--color-brand-soft)); }
 .kb-mm-tb-group .kb-mm-overlay-zoom { display: inline-flex; align-items: center; gap: 2px; }
 .kb-mm-tb-group .kb-mm-overlay-zoom span { font-size: 11.5px; color: var(--kb-text3); min-width: 38px; text-align: center; }
-.kb-mm-search { height: 28px; width: 130px; padding: 0 10px; border: 1px solid var(--kb-border); border-radius: 7px; font-size: 12px; color: var(--kb-text); background: #fff; outline: none; }
-.kb-mm-search:focus { border-color: var(--kb-green, #0E9F6E); }
+.kb-mm-search { height: 28px; width: 130px; padding: 0 10px; border: 1px solid var(--kb-border); border-radius: 7px; font-size: 12px; color: var(--kb-text); background: var(--color-surface); outline: none; }
+.kb-mm-search:focus { border-color: var(--kb-green, var(--color-brand)); }
 .kb-mm-more { position: relative; }
 .kb-mm-more-menu {
   position: absolute; top: 32px; right: 0; z-index: var(--z-popover); min-width: 140px;
@@ -31158,7 +31158,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-share-pop {
   position: relative;
   width: min(380px, 92vw);
-  background: #fff; border-radius: 14px;
+  background: var(--color-surface); border-radius: 14px;
   box-shadow: 0 18px 60px rgba(10, 32, 20, .26);
   padding: 20px 20px 18px;
 }
@@ -31170,7 +31170,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-share-pop-close:hover { background: #EFF2EE; }
 .kb-share-pop-head {
   display: flex; align-items: center; gap: 8px;
-  font-size: 16px; font-weight: 700; color: #14281E; margin-bottom: 16px;
+  font-size: 16px; font-weight: 700; color: var(--color-ink); margin-bottom: 16px;
 }
 .kb-share-pop-head-ico { display: flex; color: #22302A; }
 .kb-share-pop-head-ico .kb-ico-svg { width: 17px; height: 17px; }
@@ -31183,18 +31183,18 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-share-pop-folder {
   width: 42px; height: 42px; flex: none; border-radius: 10px;
   display: grid; place-items: center;
-  background: #D9F2E7; color: #0E9F6E;
+  background: #D9F2E7; color: var(--color-brand);
 }
 .kb-share-pop-folder .kb-ico-svg { width: 22px; height: 22px; }
 .kb-share-pop-card-meta { min-width: 0; }
-.kb-share-pop-count { font-size: 14px; font-weight: 600; color: #14281E; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kb-share-pop-count { font-size: 14px; font-weight: 600; color: var(--color-ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .kb-share-pop-creator {
   display: flex; align-items: center; gap: 5px; margin-top: 3px;
   font-size: 12px; color: #7C8F84;
 }
 .kb-share-pop-avatar {
   width: 18px; height: 18px; border-radius: 50%; display: inline-grid; place-items: center;
-  background: #0E9F6E; color: #fff; font-size: 10px;
+  background: var(--color-brand); color: var(--color-surface); font-size: 10px;
 }
 /* 分享方式行 */
 .kb-share-pop-row {
@@ -31202,7 +31202,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   padding: 11px 4px; cursor: pointer; border-radius: 8px;
 }
 .kb-share-pop-row:hover { background: #F4F7F4; }
-.kb-share-pop-row-label { font-size: 13px; color: #14281E; font-weight: 600; }
+.kb-share-pop-row-label { font-size: 13px; color: var(--color-ink); font-weight: 600; }
 .kb-share-pop-row-hint { font-size: 12px; color: #9DB4A6; display: flex; align-items: center; gap: 4px; }
 .kb-share-pop-row-arrow { color: #B7C4BB; font-size: 14px; }
 /* 操作按钮 */
@@ -31211,16 +31211,16 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-share-pop-btn {
   flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px;
   padding: 9px 14px; border-radius: 9px; border: 1px solid #DDE4DD;
-  background: #fff; color: #33423A; font-size: 13px; cursor: pointer;
+  background: var(--color-surface); color: #33423A; font-size: 13px; cursor: pointer;
 }
 .kb-share-pop-btn .kb-ico-svg { width: 15px; height: 15px; }
 .kb-share-pop-btn:hover { background: #F4F6F4; }
 .kb-share-pop-btn.is-code { background: #F2F5F2; }
 .kb-share-pop-btn.is-primary {
   flex: none; min-width: 88px; border: 0;
-  background: #C9D6CE; color: #fff; font-weight: 600;
+  background: #C9D6CE; color: var(--color-surface); font-weight: 600;
 }
-.kb-share-pop-btn.is-primary:not(:disabled) { background: var(--color-brand, #0E9F6E); }
+.kb-share-pop-btn.is-primary:not(:disabled) { background: var(--color-brand, var(--color-brand)); }
 .kb-share-pop-btn.is-primary:not(:disabled):hover { background: #0C8A5F; }
 .kb-share-pop-btn.is-primary:disabled { cursor: default; }
 /* 权限设置弹窗（图 1） */
@@ -31232,7 +31232,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   padding: 10px 2px; gap: 12px;
 }
 .kb-share-perm-texts { min-width: 0; }
-.kb-share-perm-title { font-size: 13.5px; font-weight: 700; color: #14281E; }
+.kb-share-perm-title { font-size: 13.5px; font-weight: 700; color: var(--color-ink); }
 .kb-share-perm-desc { font-size: 12px; color: #9DB4A6; margin-top: 2px; }
 /* 开关 */
 .kb-share-toggle {
@@ -31242,10 +31242,10 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 }
 .kb-share-toggle-dot {
   position: absolute; top: 3px; left: 3px;
-  width: 16px; height: 16px; border-radius: 50%; background: #fff;
+  width: 16px; height: 16px; border-radius: 50%; background: var(--color-surface);
   transition: left .15s;
 }
-.kb-share-toggle.is-on { background: var(--color-brand, #0E9F6E); }
+.kb-share-toggle.is-on { background: var(--color-brand, var(--color-brand)); }
 .kb-share-toggle.is-on .kb-share-toggle-dot { left: 21px; }
 /* 下拉 */
 .kb-share-select-wrap { flex: none; min-width: 168px; position: relative; }
@@ -31256,9 +31256,9 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   background: #F7F9F7 url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='%239DB4A6' stroke-width='1.6' fill='none' stroke-linecap='round'/></svg>") no-repeat right 12px center;
   font-size: 12.5px; color: #1F2A24; cursor: pointer; outline: none;
 }
-.kb-share-select:focus { border-color: var(--color-brand, #0E9F6E); }
+.kb-share-select:focus { border-color: var(--color-brand, var(--color-brand)); }
 /* ── 分享到飞书（方案 A/B）：状态行 / 管理面板 / 知识码 ── */
-.kb-share-pop-status-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-brand, #0E9F6E); display: inline-block; }
+.kb-share-pop-status-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-brand, var(--color-brand)); display: inline-block; }
 .kb-share-pop-btn.is-manage { flex: none; min-width: 76px; }
 .kb-share-pop-btn:disabled { opacity: 0.6; cursor: default; }
 /* 知识码弹窗 */
@@ -31267,7 +31267,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-share-qr-img { width: 160px; height: 160px; border: 1px solid #E4EAE5; border-radius: 12px; display: flex; align-items: center; justify-content: center; background: #fff; }
 .kb-share-qr-img svg { width: 160px; height: 160px; }
 .kb-share-qr-fallback { font-size: 12px; color: #9DB4A6; }
-.kb-share-qr-name { font-size: 14px; font-weight: 700; color: #14281E; }
+.kb-share-qr-name { font-size: 14px; font-weight: 700; color: var(--color-ink); }
 .kb-share-qr-url { font-size: 11.5px; color: #9DB4A6; word-break: break-all; text-align: center; max-width: 260px; line-height: 1.5; }
 /* 分享管理面板 */
 .kb-share-pop--manage .kb-share-pop-head { margin-bottom: 10px; }
@@ -31276,16 +31276,16 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-share-manage-empty { text-align: center; color: #9DB4A6; font-size: 12.5px; padding: 26px 0 18px; line-height: 1.9; }
 /* CogSeed 问答分享管理（方案 C）：成员申请列表 */
 .kb-share-cogseed-members { margin-top: 14px; border-top: 1px solid #EEF1EE; padding-top: 12px; }
-.kb-share-cogseed-members-title { font-size: 13px; font-weight: 700; color: #14281E; margin-bottom: 10px; }
+.kb-share-cogseed-members-title { font-size: 13px; font-weight: 700; color: var(--color-ink); margin-bottom: 10px; }
 .kb-share-cogseed-members-empty { text-align: center; color: #9DB4A6; font-size: 12px; padding: 14px 0; }
-.kb-share-manage-item { border: 1px solid #E4EAE5; border-radius: 12px; padding: 12px 14px; background: #fff; }
+.kb-share-manage-item { border: 1px solid #E4EAE5; border-radius: 12px; padding: 12px 14px; background: var(--color-surface); }
 .kb-share-manage-item-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.kb-share-manage-item-name { font-size: 13.5px; font-weight: 700; color: #14281E; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kb-share-manage-item-name { font-size: 13.5px; font-weight: 700; color: var(--color-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .kb-share-manage-item-badge {
   flex: none; font-size: 11px; padding: 2px 8px; border-radius: 10px;
   background: #F2F5F2; color: #6B7F73;
 }
-.kb-share-manage-item-badge.is-anyone { background: #E2F5EC; color: #0B7A52; }
+.kb-share-manage-item-badge.is-anyone { background: var(--color-brand-soft); color: #0B7A52; }
 .kb-share-manage-item-badge.is-tenant { background: #EEF1EE; color: #55675C; }
 .kb-share-manage-item-badge.is-private { background: #F4F0EC; color: #8A6B4A; }
 .kb-share-manage-item-meta {
@@ -31307,7 +31307,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-share-config-tip {
   font-size: 12px; color: #6B7F73; line-height: 1.7; margin: 4px 0 10px;
 }
-.kb-share-config-tip a { color: var(--color-brand, #0E9F6E); text-decoration: underline; }
+.kb-share-config-tip a { color: var(--color-brand, var(--color-brand)); text-decoration: underline; }
 .kb-share-config-tip.is-warn { color: #B07A2A; background: #FBF3E5; border-radius: 8px; padding: 8px 10px; }
 .kb-share-config-field { margin-bottom: 10px; }
 .kb-share-config-label { display: block; font-size: 12.5px; font-weight: 600; color: #33423A; margin-bottom: 5px; }
@@ -31315,7 +31315,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   width: 100%; padding: 8px 12px; border: 1px solid #DDE4DD; border-radius: 8px;
   background: #F7F9F7; font-size: 13px; color: #1F2A24; outline: none; box-sizing: border-box;
 }
-.kb-share-config-input:focus { border-color: var(--color-brand, #0E9F6E); background: #fff; }
+.kb-share-config-input:focus { border-color: var(--color-brand, var(--color-brand)); background: var(--color-surface); }
 
 /* ── KB 问答回答卡视觉分层（评审改版：正文给人看，引用给溯源，操作主按钮化）── */
 /* 正文阅读：加大行高，降低密度 */
@@ -31346,12 +31346,12 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px; color: #666; text-align: left;
-  background: transparent; border: none; padding: 1px 2px; cursor: pointer; border-radius: 4px;
+  background: transparent; border: none; padding: 1px 2px; cursor: pointer; border-radius: var(--radius-1);
 }
 .kb-qa-src-path:hover { color: var(--kb-accent, #2F6FED); background: rgba(47, 111, 237, .06); }
 .kb-qa-src-copy {
   flex: none; width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center;
-  font-size: 11px; color: #999; background: transparent; border: none; cursor: pointer; border-radius: 4px;
+  font-size: 11px; color: #999; background: transparent; border: none; cursor: pointer; border-radius: var(--radius-1);
   opacity: 0; transition: opacity .12s, color .12s;
 }
 .kb-qa-src-row:hover .kb-qa-src-copy { opacity: 1; }
@@ -31359,11 +31359,11 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 
 /* 「生成脑图」主操作按钮：主题色填充，与引用区拉开间距 */
 .kb-qa-mm-btn {
-  background: var(--kb-green, #0E9F6E); border-color: transparent; color: #fff;
+  background: var(--kb-green, var(--color-brand)); border-color: transparent; color: var(--color-surface);
   box-shadow: 0 1px 3px rgba(14, 159, 110, .25);
 }
-.kb-qa-mm-btn:hover:not(:disabled) { background: #0C8A5F; color: #fff; }
-.kb-qa-mm-btn:disabled { background: #B9D8C9; color: #fff; box-shadow: none; }
+.kb-qa-mm-btn:hover:not(:disabled) { background: #0C8A5F; color: var(--color-surface); }
+.kb-qa-mm-btn:disabled { background: #B9D8C9; color: var(--color-surface); box-shadow: none; }
 .kb-qa-mm-action { margin-top: 14px; padding-top: 10px; border-top: 1px solid var(--kb-border, #E4EAE4); }
 .kb-qa-mm-action .kb-mm-msg { margin-top: 12px; }
 
@@ -31371,17 +31371,17 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-wb-one-liner {
   display: flex; gap: 8px; align-items: flex-start; padding: 10px 12px;
   background: #f7f8fa; border: 1px solid var(--kb-border, #E4EAE4);
-  border-radius: 10px; margin-bottom: 14px; line-height: 1.6;
+  border-radius: var(--radius-3); margin-bottom: 14px; line-height: 1.6;
 }
 .kb-wb-one-liner-tag {
   flex: none; font-size: 11.5px; padding: 2px 8px; border-radius: 999px;
-  background: rgba(14, 159, 110, .12); color: var(--kb-green, #0E9F6E);
+  background: rgba(14, 159, 110, .12); color: var(--kb-green, var(--color-brand));
   white-space: nowrap; align-self: flex-start;
 }
 .kb-wb-one-liner-text { font-size: 13px; color: #44554C; }
 .kb-wb-doc {
-  background: #fff; border: 1px solid var(--kb-border, #E4EAE4);
-  border-radius: 10px; padding: 10px 12px; margin-bottom: 8px;
+  background: var(--color-surface); border: 1px solid var(--kb-border, #E4EAE4);
+  border-radius: var(--radius-3); padding: 10px 12px; margin-bottom: 8px;
 }
 .kb-wb-doc-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
 .kb-wb-doc-name { font-weight: 600; font-size: 13px; color: var(--kb-text, #22372B); }
@@ -31400,7 +31400,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
 .kb-qa-msg.is-ai .kb-qa-msg-body code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: .92em; color: #35513F;
-  background: rgba(14, 159, 110, .1); border-radius: 4px; padding: 0 4px;
+  background: rgba(14, 159, 110, .1); border-radius: var(--radius-1); padding: 0 4px;
 }
 .kb-qa-msg.is-ai .kb-qa-msg-body .kb-a-block { margin: 7px 0; }
 .kb-qa-msg.is-ai .kb-qa-msg-body .kb-a-line { line-height: 1.6; margin: 2px 0; }
@@ -31428,7 +31428,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   padding: 18px;
   border: 1px solid var(--border, #e5e7eb);
   border-radius: 12px;
-  background: var(--surface, #fff);
+  background: var(--surface, var(--color-surface));
   scroll-margin-top: 12px;
   outline: none;
 }
@@ -31441,7 +31441,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   min-width: 0;
   min-height: 520px;
   border: 1px solid var(--border, #e5e7eb);
-  border-radius: 10px;
+  border-radius: var(--radius-3);
   overflow: hidden;
 }
 .settings-embedded-touchpoints {
@@ -31487,8 +31487,8 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   min-width: 0;
   padding: 12px;
   border: 1px solid var(--border, #e5e7eb);
-  border-radius: 9px;
-  background: color-mix(in srgb, var(--surface, #fff) 97%, var(--text) 3%);
+  border-radius: var(--radius-2);
+  background: color-mix(in srgb, var(--surface, var(--color-surface)) 97%, var(--text) 3%);
 }
 .run-center-settings-runtime-row {
   display: grid;
@@ -31555,7 +31555,7 @@ section.kb-wb-right { display: flex; flex-direction: column; min-width: 0; min-h
   margin-bottom: 14px;
   padding: 14px;
   border: 1px solid var(--border, #e5e7eb);
-  border-radius: 9px;
+  border-radius: var(--radius-2);
 }
 .run-center-settings-worktree-heading {
   display: grid;


### PR DESCRIPTION
## 动机
develop→cicd 同步（#202）首测被 macOS verify 的 `tokens:check` 拦截：#189/#191 合入的 UI CSS 引入字面量债务（基线 2026-09-03 后 color literals +64、off-scale radius +12），develop 无 CI 静默累积至今。
## 改动
- `src/renderer/style.css`：与 tokens.css **值相等**的颜色字面量全部换为对应 `var(--token)`（同值替换，视觉零变化，739 处）；修正基线后新增的 12 处非白名单 `border-radius`（2/3/4→--radius-1、9→--radius-2、10→--radius-3）。
- `scripts/design-tokens-baseline.json`：债务降低后按规范 `tokens:update` 刷新基线。
## 验证
`npm run tokens:check` ✅ pass（findings −937）；改动为同值 token 化 + 12 处就近 radius，无视觉变化。
