### PR TITLE
fix(connections): keep Agent tab in Connections

### DIFF
--- a/docs/superpowers/plans/2026-09-09-connections-agent-tab-navigation.md
+++ b/docs/superpowers/plans/2026-09-09-connections-agent-tab-navigation.md
@@ -1,0 +1,104 @@
+# Connections Agent Tab Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Connections > Agent inside the Connections page and restore its existing lazy Agent refresh.
+
+**Architecture:** Exercise the classic renderer script in a VM-backed fake DOM, then remove only the Agent-to-Settings redirect while preserving the Touchpoints and Models redirects. Re-enable the pre-existing `loadAgents(false)` refresh when the Agent pane becomes active.
+
+**Tech Stack:** Electron renderer classic JavaScript, Vitest, Node `vm`.
+
+---
+
+### Task 1: Add the navigation regression test
+
+**Files:**
+- Create: `test/renderer/connections-navigation.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create a VM harness with Agent and MCP tabs/panes. Load `src/renderer/modules/connections.js`, invoke `activateConnectionsTab('agents')`, and assert:
+
+```ts
+expect(setView).not.toHaveBeenCalled();
+expect(tabs[0].classList.contains('is-active')).toBe(true);
+expect(panes[0].hidden).toBe(false);
+expect(panes[1].hidden).toBe(true);
+expect(loadAgents).toHaveBeenCalledWith(false);
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```powershell
+npm run test:js -- test/renderer/connections-navigation.test.ts
+```
+
+Expected: FAIL because current code calls `setView('settings', ...)`, leaves the Agent pane hidden, and does not call `loadAgents(false)`.
+
+### Task 2: Restore Agent as a real Connections tab
+
+**Files:**
+- Modify: `src/renderer/modules/connections.js:55-80`
+- Modify: `src/renderer/modules/connections.js:145-148`
+
+- [ ] **Step 1: Remove Agent from the Settings redirect**
+
+Keep only Touchpoints in the redirect conditions:
+
+```js
+function _connectionsOpenTarget(target) {
+  if (target === 'touchpoints') {
+    _connectionsOpenConfiguration('gateways');
+    return;
+  }
+  if (target === 'models' && typeof setView === 'function') {
+    _connectionsOpenConfiguration('models');
+  }
+}
+
+// In activateConnectionsTab:
+if (name === 'touchpoints') {
+  _connectionsOpenTarget(name);
+  return;
+}
+```
+
+- [ ] **Step 2: Restore the Agent refresh on tab activation**
+
+Before the Sources branch, restore:
+
+```js
+if (target === 'agents' && typeof loadAgents === 'function') {
+  Promise.resolve(loadAgents(false)).catch(() => {});
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+npm run test:js -- test/renderer/connections-navigation.test.ts test/renderer/settings-tabs.test.ts
+```
+
+Expected: both files pass.
+
+- [ ] **Step 4: Run renderer safety and type gates**
+
+Run:
+
+```powershell
+npm run test:js -- test/renderer/shared-ui-adoption-guard.test.ts test/renderer/top-drag-regions.test.ts
+npm run typecheck
+```
+
+Expected: all tests and typecheck pass.
+
+- [ ] **Step 5: Commit the fix**
+
+```powershell
+git add -- src/renderer/modules/connections.js test/renderer/connections-navigation.test.ts
+git commit -m "fix(connections): keep Agent tab in connections"
+```

--- a/docs/superpowers/specs/2026-09-09-connections-agent-tab-navigation-design.md
+++ b/docs/superpowers/specs/2026-09-09-connections-agent-tab-navigation-design.md
@@ -1,0 +1,20 @@
+# Connections Agent Tab Navigation Fix
+
+## Problem
+
+The Connections page still renders an Agent tab and an embedded Agent pane, but clicking the tab redirects to Settings > Configuration. This conflicts with the visible navigation and leaves the embedded pane unreachable.
+
+## Decision
+
+Restore the Agent tab as a real Connections tab. Settings > Configuration remains available as a separate place for executor configuration; it is not the destination of the Connections Agent tab.
+
+## Behavior
+
+- Clicking Connections > Agent activates `connections-pane-agents` without changing the top-level view.
+- Entering the Agent tab lazily refreshes the full Agent list through the existing `loadAgents(false)` path.
+- Existing MCP, plugins, skills, sources, touchpoints, and models behavior remains unchanged.
+- The fix adds renderer regression coverage proving that Agent activation does not call `setView('settings')` and reveals the Agent pane.
+
+## Scope
+
+Only Connections navigation logic and its focused renderer test are changed. No settings layout, Agent data model, IPC contract, or enterprise model-governance behavior is changed.

--- a/src/renderer/modules/connections.js
+++ b/src/renderer/modules/connections.js
@@ -53,8 +53,8 @@ let _connectionsMcpPrimed = false;
 let _connectionsSkillsPrimed = false;
 
 function _connectionsOpenTarget(target) {
-  if (target === 'agents' || target === 'touchpoints') {
-    _connectionsOpenConfiguration(target === 'agents' ? 'agents' : 'gateways');
+  if (target === 'touchpoints') {
+    _connectionsOpenConfiguration('gateways');
     return;
   }
   if (target === 'models' && typeof setView === 'function') {
@@ -74,7 +74,7 @@ function _connectionsOpenConfiguration(anchor) {
 function activateConnectionsTab(name) {
   const tabs = Array.from(document.querySelectorAll('.connections-tab'));
   if (!tabs.length) return;
-  if (name === 'agents' || name === 'touchpoints') {
+  if (name === 'touchpoints') {
     _connectionsOpenTarget(name);
     return;
   }
@@ -151,7 +151,12 @@ function activateConnectionsTab(name) {
       });
   }
 
-  // 数据源 tab 内嵌资料库；Agent 与触点已归入设置—配置。
+  // Agent tab 内嵌了 AI 团队：进入时加载完整列表，升级 boot 的摘要缓存。
+  if (target === 'agents' && typeof loadAgents === 'function') {
+    Promise.resolve(loadAgents(false)).catch(() => {});
+  }
+
+  // 数据源 tab 内嵌资料库；触点已归入设置—配置。
   if (target === 'sources') {
     // 资料库（contexts）是懒加载模块：从「连接」视图进入时 boot 只初始化
     // tab 壳，不会加载 contexts.js。这里先加载模块再渲染，否则面板永远

--- a/test/renderer/connections-navigation.test.ts
+++ b/test/renderer/connections-navigation.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
+
+const root = path.join(__dirname, '../..');
+
+class FakeClassList {
+  classes = new Set<string>();
+
+  constructor(initial: string[] = []) {
+    initial.forEach((name) => this.classes.add(name));
+  }
+
+  contains(name: string) {
+    return this.classes.has(name);
+  }
+
+  toggle(name: string, force?: boolean) {
+    const enabled = force === undefined ? !this.classes.has(name) : force;
+    if (enabled) this.classes.add(name);
+    else this.classes.delete(name);
+    return enabled;
+  }
+}
+
+class FakeElement {
+  classList: FakeClassList;
+  hidden: boolean;
+
+  constructor(
+    public dataset: Record<string, string>,
+    classes: string[] = [],
+    hidden = false,
+  ) {
+    this.classList = new FakeClassList(classes);
+    this.hidden = hidden;
+  }
+}
+
+function loadConnectionsModule() {
+  const tabs = [
+    new FakeElement({ connectionsTab: 'agents' }, ['connections-tab']),
+    new FakeElement({ connectionsTab: 'mcp' }, ['connections-tab', 'is-active']),
+  ];
+  const panes = [
+    new FakeElement({ connectionsPane: 'agents' }, ['connections-tab-pane'], true),
+    new FakeElement({ connectionsPane: 'mcp' }, ['connections-tab-pane']),
+  ];
+  const setView = vi.fn();
+  const loadAgents = vi.fn();
+  const document = {
+    querySelectorAll(selector: string) {
+      if (selector === '.connections-tab') return tabs;
+      if (selector === '.connections-tab-pane') return panes;
+      return [];
+    },
+  };
+  const context: any = { document, loadAgents, Promise, setView, window: {} };
+  context.window.window = context.window;
+  vm.createContext(context);
+  const source = fs.readFileSync(path.join(root, 'src/renderer/modules/connections.js'), 'utf8');
+  vm.runInContext(source, context, { filename: 'connections.js' });
+  return { loadAgents, panes, setView, tabs, window: context.window };
+}
+
+describe('connections navigation', () => {
+  it('keeps the Agent tab inside Connections', () => {
+    const { panes, setView, tabs, window } = loadConnectionsModule();
+
+    window.activateConnectionsTab('agents');
+
+    expect(setView).not.toHaveBeenCalled();
+    expect(tabs[0].classList.contains('is-active')).toBe(true);
+    expect(tabs[1].classList.contains('is-active')).toBe(false);
+    expect(panes[0].hidden).toBe(false);
+    expect(panes[1].hidden).toBe(true);
+  });
+
+  it('refreshes the full Agent list when the tab becomes active', () => {
+    const { loadAgents, window } = loadConnectionsModule();
+
+    window.activateConnectionsTab('agents');
+
+    expect(loadAgents).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary
- keep **Connections > Agent** inside the Connections page instead of redirecting to **Settings > Configuration**
- preserve the existing Settings redirects for Touchpoints and Models
- restore lazy loading of the complete Agent list and add renderer regression coverage

## Verification
- `npm run test:js -- test/renderer/connections-navigation.test.ts test/renderer/settings-tabs.test.ts test/renderer/shared-ui-adoption-guard.test.ts test/renderer/top-drag-regions.test.ts` — 45 passed
- `npm run typecheck` — passed
- Pre-rebase full suite: 10,663 passed, 4 failed. The same four Windows process/temp-directory failures reproduced on the unmodified then-current `origin/develop@4991c338`, so they are unrelated to this renderer-only change.

## Manual verification
Source startup was attempted twice. It was blocked before Electron launch by the runtime dependency downloader (`uv`: `ECONNRESET`, then timeout), so GUI click-through verification could not be completed in this environment.