### PR TITLE
过程 UI 修复 + CLI 常驻运行时 + 外接智能体模型枚举 + CLI 用量统计下线

### DIFF
--- a/p3394-gateway/gateway.cjs
+++ b/p3394-gateway/gateway.cjs
@@ -252,6 +252,9 @@ const PRESETS = {
   codex:    { cli: 'codex',   args: 'exec {message}',           id: 'codex',
               // 模型经 app-server thread/start 的 model 参数下发（专有通道）。
               modelControllable: true,
+              // 清单：常驻通道探 app-server 枚举 RPC，失败回落 config.toml
+              // profiles（configModels 声明，2026-09-09 全量补全）。
+              configModels: 'codex',
               // 强度专有通道：low/high → thread/start 的
               // model_reasoning_effort config（失败降级重试）。
               effortChannel: 'model-reasoning-effort' },
@@ -264,9 +267,13 @@ const PRESETS = {
               effortArgs: '--variant {effort}', effortLevels: { off: 'minimal' },
               resumeArgs: '--session {cli_session_id}', sessionIdPattern: '"sessionID"\\s*:\\s*"([^"]+)"' },
   gemini:   { cli: 'gemini',  args: '-p {message}',             id: 'gemini',
-              modelArgs: '-m {model}' },
+              // 模型清单读 ~/.gemini/settings.json（当前）+ 官方常规系
+              //（configModels 声明式枚举，2026-09-09 全量补全）。
+              modelArgs: '-m {model}', configModels: 'gemini' },
   aider:    { cli: 'aider',   args: '--message {message} --yes', id: 'aider',
-              modelArgs: '--model {model}' },
+              // 模型清单读 ~/.aider.model.settings.yml 条目 + conf 的当前
+              //（configModels 声明式枚举，2026-09-09 全量补全）。
+              modelArgs: '--model {model}', configModels: 'aider' },
   openclaw: { cli: 'openclaw', args: 'agent --local --json --agent main --message {message}', id: 'openclaw',
               // --model 单次覆盖（agent --help 实测）；模型绑定在配置的
               // agents/models 段——configModels 声明式枚举读取。
@@ -947,6 +954,59 @@ function probePresetInspect() {
   if (!preset || !preset.inspect) return null;
   return probeInspectCommand({ cli: CLI, args: preset.inspect.args, parser: preset.inspect.parser, spawnFn: spawnCli, killTreeFn: killProcessTree });
 }
+
+/** 预设级模型发现（oneshot 与 sscli 通道共用，Hermes 模型枚举修复
+ *  2026-09-09）：网关与 CLI 同机，探测与消息通道无关——预设表声明了
+ *  枚举通道（inspect）就走通用探测；声明了 initProbeArgs（claude 兼容
+ *  CLI）再并行抓 init 帧的当前模型；claude 落 oneshot 时保留专用探测，
+ *  其列表探测拿不到清单（自定义模型网关只披露 current）时回落读
+ *  ~/.claude/settings.json 槽位变量取完整清单；声明 configModels
+ *  （hermes/openclaw/gemini/aider/codex）读 CLI 自身配置文件枚举；其余
+ *  明确 unavailable，宿主回落静态目录+手输。 */
+async function inspectPresetModels(fallbackReason) {
+  if (PRESET_NAME === 'claude') {
+    const probed = await probeClaudeModels();
+    if (probed.status === 'ready' && Array.isArray(probed.models) && probed.models.length) {
+      return probed;
+    }
+    // claude 自定义模型网关（DeepSeek 等的 anthropic 兼容端点）下列表
+    // 探测/init 帧只披露 current 一个——回落读 ~/.claude/settings.json
+    // env 段的槽位变量取完整清单（2026-09-09 实机：/model 五条目只扫
+    // 出默认一条）。专用探测的 current（CLI 运行态事实）优先于配置。
+    const viaCfg = probeConfigModels({ configModels: 'claude', env: process.env, readFileSync: fs.readFileSync });
+    if (viaCfg.status === 'ready') {
+      return { ...viaCfg, ...(probed.current ? { current: probed.current } : {}) };
+    }
+    return probed;
+  }
+  const viaPreset = probePresetInspect();
+  const viaConfig = (preset && preset.configModels)
+    ? probeConfigModels({ configModels: preset.configModels, env: process.env, readFileSync: fs.readFileSync })
+    : null;
+  const viaInit = (preset && preset.initProbeArgs)
+    ? probeStreamJsonInitModel({ cli: CLI, args: preset.initProbeArgs, spawnFn: spawnCli, killTreeFn: killProcessTree })
+    : null;
+  const [listResult, initResult] = await Promise.all([viaPreset || Promise.resolve(null), viaInit || Promise.resolve(null)]);
+  if (listResult && listResult.status === 'ready') {
+    return {
+      ...listResult,
+      ...(initResult && initResult.current ? { current: initResult.current } : {}),
+    };
+  }
+  // 清单没拿到但 init 帧披露了清单（未来 claude 版本恢复 models 数组）。
+  if (initResult && initResult.models && initResult.models.length) {
+    return { status: 'ready', models: initResult.models, ...(initResult.current ? { current: initResult.current } : {}) };
+  }
+  if (initResult && initResult.current) {
+    // 只有当前模型、无清单——unavailable 附 current（宿主静态目录兜底清单）。
+    return { status: 'unavailable', reason: 'no_model_list', current: initResult.current };
+  }
+  // 配置声明式枚举（hermes/openclaw/gemini/aider/codex）：子命令探测缺失/
+  // 失败时接管——读 CLI 自身配置的模型绑定，永远比"无枚举命令"多一步。
+  if (viaConfig && viaConfig.status === 'ready') return viaConfig;
+  if (listResult) return listResult;
+  return { status: 'unavailable', reason: fallbackReason || 'preset_no_inspect' };
+}
 // 本网关的模型参数模板（env 覆盖 > 预设声明；null=无通道，信封 model 被忽略）。
 function modelArgTemplate() {
   return modelArgsFor(preset, process.env);
@@ -1124,39 +1184,10 @@ const oneshotRuntime = {
     return reply;
   },
   cancel(taskId) { return cancelTask(taskId); },
-  /** 模型发现：预设表声明了枚举通道（inspect）就走通用探测；声明了
-   *  initProbeArgs（claude 兼容 CLI）再并行抓 init 帧的当前模型；claude
-   *  落 oneshot 时保留专用探测；声明 configModels（hermes/openclaw）读
-   *  CLI 自身配置文件枚举；其余明确 unavailable。 */
+  /** 模型发现：与 sscli 通道共用 inspectPresetModels（Hermes 模型枚举
+   *  修复 2026-09-09：探测与消息通道无关，见该函数头注释）。 */
   async inspectModels() {
-    if (PRESET_NAME === 'claude') return probeClaudeModels();
-    const viaPreset = probePresetInspect();
-    const viaConfig = (preset && preset.configModels)
-      ? probeConfigModels({ configModels: preset.configModels, env: process.env, readFileSync: fs.readFileSync })
-      : null;
-    const viaInit = (preset && preset.initProbeArgs)
-      ? probeStreamJsonInitModel({ cli: CLI, args: preset.initProbeArgs, spawnFn: spawnCli, killTreeFn: killProcessTree })
-      : null;
-    const [listResult, initResult] = await Promise.all([viaPreset || Promise.resolve(null), viaInit || Promise.resolve(null)]);
-    if (listResult && listResult.status === 'ready') {
-      return {
-        ...listResult,
-        ...(initResult && initResult.current ? { current: initResult.current } : {}),
-      };
-    }
-    // 清单没拿到但 init 帧披露了清单（未来 claude 版本恢复 models 数组）。
-    if (initResult && initResult.models && initResult.models.length) {
-      return { status: 'ready', models: initResult.models, ...(initResult.current ? { current: initResult.current } : {}) };
-    }
-    if (initResult && initResult.current) {
-      // 只有当前模型、无清单——unavailable 附 current（宿主静态目录兜底清单）。
-      return { status: 'unavailable', reason: 'no_model_list', current: initResult.current };
-    }
-    // 配置声明式枚举（hermes/openclaw）：子命令探测缺失/失败时接管——
-    // 读 CLI 自身配置的模型绑定，永远比"无枚举命令"多一步。
-    if (viaConfig && viaConfig.status === 'ready') return viaConfig;
-    if (listResult) return listResult;
-    return { status: 'unavailable', reason: 'oneshot_no_inspect' };
+    return inspectPresetModels('oneshot_no_inspect');
   },
   close() {
     for (const child of activeTasks.values()) killProcessTree(child, 'SIGTERM');
@@ -1661,10 +1692,14 @@ class SscliRuntime {
     this._send({ op: 'cancel', task_id: taskId });
     return true;
   }
-  /** 模型发现：p3394-sscli/1.0 协议尚无模型枚举操作（hermes 侧 ACP 广播是
-   *  后续增强）——明确 unavailable，宿主回落静态目录+手输。 */
+  /** 模型发现（Hermes 模型枚举修复 2026-09-09）：不再因「协议无枚举 op」
+   *  直接 unavailable——网关与 CLI 同机，预设级探测（子命令/init 帧/
+   *  配置文件声明式枚举，hermes 走 ~/.hermes 配置）与消息通道无关，
+   *  sscli 通道与 oneshot 共用 inspectPresetModels。shim 的 p3394-sscli
+   *  协议侧无需新 op；探测失败的兜底语义不变（unavailable，宿主回落
+   *  静态目录+手输）。 */
   async inspectModels() {
-    return { status: 'unavailable', reason: 'sscli_no_inspect_op' };
+    return inspectPresetModels('sscli_no_inspect');
   }
   close() {
     this.closing = true;
@@ -2305,6 +2340,57 @@ class OpencodeRuntime {
       req.write(data);
       req.end();
     });
+  }
+  _getJson(base, pathName) {
+    return new Promise((resolve, reject) => {
+      const req = http.get(base + pathName, (res) => {
+        let buf = '';
+        res.on('data', (c) => { buf += c; });
+        res.on('end', () => {
+          if (res.statusCode >= 400) { reject(new Error('p3394_opencode_http_' + res.statusCode + ': ' + buf.slice(0, 200))); return; }
+          try { resolve(buf ? JSON.parse(buf) : {}); } catch { resolve({ raw: buf }); }
+        });
+      });
+      req.on('error', reject);
+    });
+  }
+  /** 模型发现（2026-09-09 全量补全）：常驻 serve 的 GET /api/model 是权威
+   *  事实源（进程已在跑、零 spawn、天然含自定义 provider——实机实测
+   *  {location, data:[{id, providerID, name}]}）。清单 id 拼 providerID/id
+   *  （与 --model 传参同口径，子命令输出同格式）；端点不披露 current，
+   *  留空（UI 选中态由宿主处理）。无活跃 server 时按默认 cwd 起一个
+   *  （首查需等 serve 冷启动，之后复用）；端点失败回落 models 子命令
+   *  探测。此前本 runtime 无 inspectModels，端点一律 runtime_no_inspect
+   *  → 界面扫描不到模型。 */
+  async inspectModels() {
+    try {
+      let entry = null;
+      for (const [, hitEntry] of this.servers) { entry = hitEntry; break; }
+      if (!entry) entry = await this._serverFor(process.cwd());
+      else await entry.ready;
+      const body = await this._getJson(entry.base, '/api/model');
+      const rawModels = body && Array.isArray(body.data)
+        ? body.data
+        : (body && Array.isArray(body.models) ? body.models : null);
+      const models = [];
+      const seen = new Set();
+      if (rawModels) {
+        for (const m of rawModels) {
+          if (!m || typeof m !== 'object') continue;
+          const bareId = String(m.id || m.modelID || '').trim();
+          if (!bareId) continue;
+          const provider = String(m.providerID || '').trim();
+          const id = provider ? `${provider}/${bareId}` : bareId;
+          if (seen.has(id)) continue;
+          seen.add(id);
+          models.push({ id, label: String(m.name || m.displayName || id).trim() || id });
+        }
+      }
+      if (models.length) return { status: 'ready', models };
+    } catch (error) {
+      console.log('[p3394-gateway] opencode /api/model inspect failed: ' + (error && error.message ? error.message : String(error)));
+    }
+    return inspectPresetModels('opencode_no_inspect');
   }
   async deliver(sessionId, messageId, text, opts, onDelta, onProgress) {
     const note = (opts && opts.artifactNote) || '';

--- a/p3394-gateway/models-probe.cjs
+++ b/p3394-gateway/models-probe.cjs
@@ -528,9 +528,123 @@ function openclawConfigModels(fsMod, pathMod, env, readFileSync) {
   return { status: 'ready', models, ...(current ? { current } : {}) };
 }
 
+// ── 其余 CLI 的配置枚举（2026-09-09 全量补全：模型清单以 CLI 自身配置
+//    为事实源——外接 CLI 普遍接自定义网关，官方静态目录猜不出网关模型）──
+
+/** claude settings.json env 段的槽位枚举：清单取 _NAME 变量（CLI 自己
+ *  的显示名，无 [ctx] 上下文标记后缀），缺 _NAME 时剥后缀；同模型多
+ *  槽位去重（Opus/Sonnet/Fable 可映射同一模型）；默认槽位排最前。 */
+function claudeConfigModels(fsMod, pathMod, env, readFileSync) {
+  const home = (env && env.HOME) || require('node:os').homedir();
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(pathMod.join(home, '.claude', 'settings.json'), 'utf8'));
+  } catch { return { status: 'unavailable', reason: 'config_read_failed' }; }
+  const cfgEnv = (settings && typeof settings.env === 'object' && settings.env) || {};
+  const clean = (v) => String(v || '').trim().replace(/\[[^\]]*\]\s*$/, '').trim();
+  const ids = [];
+  const push = (id) => { const c = clean(id); if (c && !ids.includes(c)) ids.push(c); };
+  // 默认槽位最前（即菜单绿勾项），其余按 opus→sonnet→fable→haiku 顺序。
+  const current = clean(cfgEnv.ANTHROPIC_MODEL) || null;
+  push(current);
+  for (const slot of ['opus', 'sonnet', 'fable', 'haiku']) {
+    const upper = `ANTHROPIC_DEFAULT_${slot.toUpperCase()}_MODEL`;
+    push(cfgEnv[`${upper}_NAME`] || cfgEnv[upper]);
+  }
+  if (!ids.length) return { status: 'unavailable', reason: 'config_no_models' };
+  return { status: 'ready', models: ids.map((id) => ({ id, label: id })), ...(current ? { current } : {}) };
+}
+
+/** gemini ~/.gemini/settings.json：当前模型（新版 model.name / 旧版
+ *  selectedModel）+ 官方常规模型系（公开事实，与配置去重后置底——网关
+ *  部署时 -m 传任意 id，静态项仅作常用候选，不宣称穷举）。 */
+const GEMINI_KNOWN_MODELS = Object.freeze([
+  'gemini-2.5-pro',
+  'gemini-2.5-flash',
+  'gemini-2.5-flash-lite',
+]);
+function geminiConfigModels(fsMod, pathMod, env, readFileSync) {
+  const home = (env && env.HOME) || require('node:os').homedir();
+  let cfg;
+  try {
+    cfg = JSON.parse(readFileSync(pathMod.join(home, '.gemini', 'settings.json'), 'utf8'));
+  } catch { return { status: 'unavailable', reason: 'config_read_failed' }; }
+  const raw = (cfg && (
+    (cfg.model && (cfg.model.name || cfg.model.id))
+    || cfg.selectedModel
+    || cfg.defaultModel
+  )) || '';
+  const current = String(raw).trim();
+  const ids = [];
+  if (current) ids.push(current);
+  for (const id of GEMINI_KNOWN_MODELS) if (!ids.includes(id)) ids.push(id);
+  if (!ids.length) return { status: 'unavailable', reason: 'config_no_models' };
+  return { status: 'ready', models: ids.map((id) => ({ id, label: id })), ...(current ? { current } : {}) };
+}
+
+/** aider：~/.aider.model.settings.yml 的模型条目（- name: xxx 行级提取，
+ *  不引 yaml 依赖）+ ~/.aider.conf.yml / .aider.conf.yaml 的 model: 当前。 */
+function aiderConfigModels(fsMod, pathMod, env, readFileSync) {
+  const home = (env && env.HOME) || require('node:os').homedir();
+  const ids = [];
+  let current = '';
+  try {
+    const text = readFileSync(pathMod.join(home, '.aider.model.settings.yml'), 'utf8');
+    for (const m of String(text || '').matchAll(/^\s*-\s*name:\s*(\S+)\s*$/gm)) {
+      const id = m[1].trim();
+      if (id && !ids.includes(id)) ids.push(id);
+    }
+  } catch { /* 无文件：清单交给已知常量/手输 */ }
+  for (const conf of ['.aider.conf.yml', '.aider.conf.yaml']) {
+    try {
+      const text = String(readFileSync(pathMod.join(home, conf), 'utf8') || '');
+      const m = /^\s*model:\s*(\S+)\s*$/m.exec(text);
+      if (m) { current = m[1].trim(); break; }
+    } catch { /* next */ }
+  }
+  if (current && !ids.includes(current)) ids.unshift(current);
+  if (!ids.length) return { status: 'unavailable', reason: 'config_no_models' };
+  return { status: 'ready', models: ids.map((id) => ({ id, label: id })), ...(current ? { current } : {}) };
+}
+
+/** codex ~/.codex/config.toml：顶层 `model = "..."`（当前）+
+ *  [profiles.<name>] 段下的 `model = "..."`（各 profile 绑定，枚举成
+ *  清单）。行级状态机解析，不引 toml 依赖。 */
+function codexConfigModels(fsMod, pathMod, env, readFileSync) {
+  const home = (env && (env.CODEX_HOME || env.HOME)) || require('node:os').homedir();
+  const codexHome = env && env.CODEX_HOME ? home : pathMod.join(home, '.codex');
+  let text;
+  try {
+    text = String(readFileSync(pathMod.join(codexHome, 'config.toml'), 'utf8') || '');
+  } catch { return { status: 'unavailable', reason: 'config_read_failed' }; }
+  let current = '';
+  const ids = [];
+  let section = '';
+  for (const line of text.split('\n')) {
+    const sec = /^\s*\[([^\]]+)\]\s*$/.exec(line);
+    if (sec) { section = sec[1].trim(); continue; }
+    const kv = /^\s*model\s*=\s*"([^"]+)"/.exec(line);
+    if (!kv) continue;
+    const id = kv[1].trim();
+    if (!id) continue;
+    if (!section) {
+      current = id; // 顶层 model = 当前默认
+      if (!ids.includes(id)) ids.unshift(id);
+    } else if (section.startsWith('profiles.') && !ids.includes(id)) {
+      ids.push(id);
+    }
+  }
+  if (!ids.length) return { status: 'unavailable', reason: 'config_no_models' };
+  return { status: 'ready', models: ids.map((id) => ({ id, label: id })), ...(current ? { current } : {}) };
+}
+
 const CONFIG_MODEL_PARSERS = {
   hermes: hermesConfigModels,
   openclaw: openclawConfigModels,
+  claude: claudeConfigModels,
+  gemini: geminiConfigModels,
+  aider: aiderConfigModels,
+  codex: codexConfigModels,
 };
 
 /** 声明式配置枚举入口。deps: { configModels（解析器键）, env, readFileSync }。

--- a/src/main/features/chat_events/process-persist.ts
+++ b/src/main/features/chat_events/process-persist.ts
@@ -58,6 +58,11 @@ export function createProcessCollector(input: {
       try {
         for (const chatEvent of projectUpstreamEvent(state, event as never)) {
           if (entries.length >= MAX_CHAT_ENTRIES) break;
+          // 实时流式专用形状不落盘（子安 2026-09-09 思考实时外发）：
+          // inProgress reasoning 增量逐 delta 产出，落盘会刷爆条目上限
+          // 并与截断冲刷的 completed 整段重复——重放只消费 completed。
+          const shape = chatEvent as { kind?: string; status?: string };
+          if (shape.kind === 'reasoning' && shape.status === 'inProgress') continue;
           entries.push({ type: 'chatItem', item: chatEvent });
         }
       } catch {

--- a/src/main/features/chat_events/project-upstream.ts
+++ b/src/main/features/chat_events/project-upstream.ts
@@ -201,6 +201,18 @@ export function projectUpstreamEvent(
       ensureTurnStarted(state, out);
     }
     state.openReasoningText += event.text;
+    // 实时流式外发（子安 2026-09-09 需求）：思考进行中就逐段可见，不再
+    // 等截断冲刷的 completed 整段。inProgress 增量只走实时链路——持久
+    // 化收集器按状态过滤（process-persist：inProgress reasoning 不落
+    // 盘），重放仍只消费 completed 整段，无重复。
+    out.push({
+      type: 'chat.item',
+      turnId: state.turnId,
+      itemId: state.openReasoningItemId,
+      kind: 'reasoning',
+      status: 'inProgress',
+      payload: { delta: event.text },
+    });
   } else if (etype === 'event' && event.event) {
     const inner = event.event as { stream?: unknown; data?: unknown };
     if (inner.stream === 'tool' && inner.data && typeof inner.data === 'object') {

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -5647,7 +5647,16 @@ async function runActorTurnBody(
         }
         // Stream events → process channel.
         if (ev.type === "final") {
-          finalText = ev.text || "";
+          // 消息正文只承载「最终段」（实机反馈 2026-09-09：展开执行过程
+          // 只见工具调用，AI 的中间叙述无处可见）。中间段已在被工具/
+          // 思考截断时经 flushTextSegmentForPersist 落盘为 completed text
+          // 条目、进过程轨迹（时间序交错展示）；此前正文=全文聚合，中间
+          // 段在过程区又被收尾清理，等于彻底不可见。final 段不触发 flush，
+          // 此刻 segmentText 恰为最终段；纯文本轮（无截断）segmentText=
+          // 全文、行为不变；中间有叙述但收尾无文本的轮次回退全文（保全
+          // 旧语义）。abort salvage（下方 streamingText 兜底）仍取全文。
+          const finalSeg = segmentText;
+          finalText = finalSeg.trim() ? finalSeg : (ev.text || "");
         } else if (ev.type === "delta") {
           // Pulled out of the generic branch below so we can mirror the text
           // into `streamingText` for abort-time salvage. The activity++ +
@@ -5765,7 +5774,12 @@ async function runActorTurnBody(
             const event = processEventForPersistence(
               (ev as { event?: unknown }).event,
             );
-            if (event && event.stream !== "assistant") {
+            // CLI 回合剥除 usage（子安 2026-09-09：外接 CLI 的 token 输入/
+            // 输出/缓存命中先不显示——CLI 自报口径不可靠，计费输出≠可见
+            // 输出、可见输出无真值，缓存命中更是无从核对）。时间线 usage
+            // 行与持久化条目一并不产；时长/首 token（本地墙钟）不受影响。
+            const suppressCliUsage = !!cliAgent && event?.stream === "usage";
+            if (event && event.stream !== "assistant" && !suppressCliUsage) {
               appendProcessItem(processItems, { type: "event", event });
             }
             // 喂入的是脱敏后形状：持久化的 chatItem 与老条目同源同隐私口径。
@@ -5773,7 +5787,7 @@ async function runActorTurnBody(
             // 中间段，flush；usage/runtime 等非工具事件不 flush（防最终段
             // 被误落盘）。
             if (event && event.stream === "tool") flushTextSegmentForPersist();
-            if (event) chatCollector.feed({ type: "event", event });
+            if (event && !suppressCliUsage) chatCollector.feed({ type: "event", event });
           }
           // See the delta branch: anonymous workers don't surface to the UI.
           if (actor.kind !== "worker") {
@@ -6459,7 +6473,12 @@ async function runActorTurnBody(
     // didn't report are omitted, never fabricated.
     let replyMetrics: GroupMessageMetrics | undefined;
     if (cliTurnMetrics) {
-      replyMetrics = cliTurnMetrics;
+      // CLI 回合同上剥 usage：消息 metrics 只保留本地计时（时长/首
+      // token/模型名），token 与缓存字段不落——消息头小字与页脚会话
+      // 统计据此不再显示 CLI 回合的 token/缓存读数（历史消息不受
+      // 影响，如实保留当时记录）。
+      const { usage: _cliUsage, ...timingOnly } = cliTurnMetrics;
+      replyMetrics = timingOnly as GroupMessageMetrics;
     } else if (agentRunTimingData) {
       const durationMs = Number(agentRunTimingData.duration_ms);
       const completedAt = agentRunResultAt ?? Date.now();

--- a/src/main/features/local_agents/backends/claude.ts
+++ b/src/main/features/local_agents/backends/claude.ts
@@ -27,8 +27,16 @@ import {
   levelOrInfo,
   FileChangeFallbackTracker,
 } from './base.js';
+import { wrapPersistentBackend, registerPersistentAdapter } from '../persistent/index.js';
+import { createClaudeAdapter } from './claude_persistent.js';
 
 const log = createLogger('local-agents:claude');
+
+// Persistent wiring: stream-json duplex adapter (one resident process
+// per conversation window; see claude_persistent.ts). The one-shot
+// backend below stays the fallback path and the reference for event
+// parity.
+registerPersistentAdapter(createClaudeAdapter());
 
 /**
  * Claude Code reads its thinking budget from the documented
@@ -36,13 +44,15 @@ const log = createLogger('local-agents:claude');
  * not tiered presets, so these budgets are our heuristic mapping: unset
  * ('off') keeps the CLI's own default (usually no extended thinking), the
  * tiers raise the budget without touching anything else in the session.
+ * Exported for the persistent adapter (process-lifetime env, applied at
+ * spawn time).
  */
-const CLAUDE_THINKING_TOKENS: Record<'low' | 'high', string> = {
+export const CLAUDE_THINKING_TOKENS: Record<'low' | 'high', string> = {
   low: '8192',
   high: '32000',
 };
 
-export const claudeBackend: LocalBackend = {
+const claudeOneShotBackend: LocalBackend = {
   async run(opts: BackendRunOptions): Promise<void> {
     const args = buildClaudeArgs(opts);
     // 'off' → unset: claude has no hard "disable thinking" switch, so the
@@ -525,3 +535,18 @@ function mergeUsage(
   if (typeof inc.model === 'string' && inc.model) out.model = inc.model;
   return out;
 }
+
+// Exported backend: persistent duplex by default. Dispatches carrying
+// a bridge MCP config or customArgs stay one-shot — the bridge server
+// is per-run (fresh socket each dispatch), so a resident process
+// would hold stale MCP endpoints by turn 2; user flags are
+// spawn-time only. See claude_persistent.ts header notes.
+const wrapped = wrapPersistentBackend('claude', claudeOneShotBackend);
+export const claudeBackend: LocalBackend = {
+  async run(opts: BackendRunOptions): Promise<void> {
+    if ((opts.bridge) || (opts.customArgs && opts.customArgs.length)) {
+      return claudeOneShotBackend.run(opts);
+    }
+    return wrapped.run(opts);
+  },
+};

--- a/src/main/features/local_agents/backends/claude_persistent.ts
+++ b/src/main/features/local_agents/backends/claude_persistent.ts
@@ -1,0 +1,356 @@
+/**
+ * Claude persistent adapter — stream-json duplex on one process.
+ *
+ * Verified live in the phase-0 probe (see design/CLI常驻运行时-
+ * 探测报告-20260903.md): `claude -p --input-format stream-json
+ * --output-format stream-json` stays resident while stdin remains
+ * open; each user line triggers one conversation turn terminated by
+ * a `result` record, and context carries across turns inside the
+ * process (same session id, no --resume needed).
+ *
+ * Shape (per f076c0c's ClaudePersistentRuntime, re-anchored onto
+ * the LocalBackend contracts):
+ *
+ *   - ONE claude process per CogSeed conversation window (process
+ *     isolation — the prototype measured in-process session
+ *     switching as unreliable, and one process per conversation
+ *     sidesteps it entirely).
+ *   - stdin stays OPEN for the window's lifetime (the one-shot path
+ *     ends stdin at the terminal result so the CLI can exit — here
+ *     that same record only resolves the turn).
+ *   - turns: write one {"type":"user"} line, stream stdout events
+ *     through the SAME mapClaudeEvent the one-shot backend uses,
+ *     resolve on the `result` record. `control_request` is answered
+ *     with an allow response exactly like the one-shot path.
+ *   - crash recovery is the manager's: process death rejects the
+ *     in-flight turn, the manager re-acquires with the last known
+ *     session id, and acquire passes `--resume <id>` so the new
+ *     process restores the conversation (same mechanism as the
+ *     one-shot resume path, equally reliable).
+ *   - cancel/timeout: claude's stream-json input has no interrupt
+ *     message, so cancelTurn kills the process — the next dispatch
+ *     rebuilds the window from the bound session id.
+ *
+ * Known gap (deliberate): dispatches carrying a cogseed-bridge MCP
+ * config stay on the one-shot path — the bridge server is per-run
+ * (fresh socket each dispatch, closed in the runner's finally), so a
+ * resident process would hold stale MCP endpoints by turn 2. Routing
+ * those runs one-shot is the honest behavior; making the bridge
+ * itself resident is separate work. Same for customArgs (user flags
+ * are spawn-time only).
+ */
+
+import { createLogger } from '../../../logger.js';
+import { logErrorSummary } from '../../../util/log-redact.js';
+import {
+  spawnCli,
+  LineSplitter,
+} from './base.js';
+import {
+  mapClaudeEvent,
+  extractClaudeUsage,
+  CLAUDE_THINKING_TOKENS,
+} from './claude.js';
+import {
+  WindowDiedError,
+  type PersistentAdapter,
+  type PersistentCancelReason,
+  type PersistentSendOpts,
+  type PersistentTurnResult,
+  type PersistentWindow,
+} from '../persistent/types.js';
+
+const log = createLogger('local-agents:claude-persistent');
+
+/** Stream-json duplex args — mirrors the one-shot buildClaudeArgs
+ *  base (same permission posture, same partial-message streaming);
+ *  --resume/--model are appended per acquire. */
+function persistentArgs(resumeSessionId: string | undefined, model: string | undefined): string[] {
+  const args = [
+    '-p',
+    '--output-format', 'stream-json',
+    '--input-format', 'stream-json',
+    '--include-partial-messages',
+    '--verbose',
+    '--permission-mode', 'bypassPermissions',
+    '--dangerously-skip-permissions',
+  ];
+  if (model) args.push('--model', model);
+  if (resumeSessionId) args.push('--resume', resumeSessionId);
+  return args;
+}
+
+/** Per-turn translation state — mirrors the one-shot locals. */
+interface TurnState {
+  onEvent: (e: import('./base.js').LocalEvent) => void;
+  partialState: { sawTextStreamEvent: boolean };
+  resolve: (r: PersistentTurnResult) => void;
+  resultText: string;
+  resultStatus: 'completed' | 'failed' | undefined;
+  resultError: string | undefined;
+  resultUsage: Record<string, number | string> | undefined;
+  accUsage: Record<string, number | string> | undefined;
+  settled: boolean;
+}
+
+class ClaudeWindow implements PersistentWindow {
+  readonly cli = 'claude' as const;
+  /** Latest CLI-reported session id (updated every turn; --resume
+   *  forks a new id per claude's own semantics). */
+  private sid: string | undefined;
+  private aliveFlag = true;
+  private readonly splitter = new LineSplitter();
+  private turn: TurnState | null = null;
+  private cancelReason: PersistentCancelReason | null = null;
+  private readonly stderrTail: string[] = [];
+  lastActiveAt = Date.now();
+
+  constructor(
+    private readonly child: import('node:child_process').ChildProcessWithoutNullStreams,
+    initialSid: string | undefined,
+  ) {
+    this.sid = initialSid;
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      this.splitter.push(chunk, line => this.onLine(line));
+    });
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      // Collected for crash diagnostics AND surfaced per line during
+      // a turn — same event parity as the one-shot backend (its
+      // stderr lines render in the process rail).
+      if (this.stderrTail.join('').length < 8 * 1024) this.stderrTail.push(chunk);
+      const turn = this.turn;
+      if (turn && !turn.settled) {
+        for (const line of chunk.split(/\r?\n/)) {
+          if (line) turn.onEvent({ type: 'stderr-line', line });
+        }
+      }
+    });
+    // Liveness is OUR flag: a signal-killed child keeps exitCode
+    // null forever (Node only sets it on normal exits) — the same
+    // lesson the opencode adapter learned live.
+    child.on('close', () => {
+      this.aliveFlag = false;
+      const turn = this.turn;
+      this.turn = null;
+      if (turn && !turn.settled) {
+        turn.settled = true;
+        // A cancel-initiated kill resolves as cancelled/timeout, not
+        // failed — cancelTurn kills the process (no interrupt input
+        // exists), so the close event is the cancel landing.
+        if (this.cancelReason) {
+          const status = this.cancelReason === 'user' ? 'cancelled' : 'timeout';
+          this.cancelReason = null;
+          turn.resolve({ status, ...(this.sid ? { sessionId: this.sid } : {}) });
+          return;
+        }
+        turn.resolve({
+          status: 'failed',
+          error: `claude process exited${this.stderrTail.length ? `: ${this.stderrTail.join('').slice(-300)}` : ''}`,
+          ...(this.sid ? { sessionId: this.sid } : {}),
+        });
+      }
+    });
+  }
+
+  get sessionId(): string | undefined {
+    return this.sid;
+  }
+
+  alive(): boolean {
+    return this.aliveFlag && this.child.stdin.writable;
+  }
+
+  async send(opts: PersistentSendOpts): Promise<PersistentTurnResult> {
+    if (!this.alive()) throw new WindowDiedError('claude process is gone');
+    this.lastActiveAt = Date.now();
+    this.cancelReason = null;
+    const turn: TurnState = {
+      onEvent: opts.onEvent,
+      partialState: { sawTextStreamEvent: false },
+      resolve: () => undefined,
+      resultText: '',
+      resultStatus: undefined,
+      resultError: undefined,
+      resultUsage: undefined,
+      accUsage: undefined,
+      settled: false,
+    };
+    this.turn = turn;
+    const finished = new Promise<PersistentTurnResult>(resolve => { turn.resolve = resolve; });
+    const inputLine = JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: opts.prompt }] },
+    }) + '\n';
+    try {
+      this.child.stdin.write(inputLine);
+    } catch (err) {
+      this.turn = null;
+      throw new WindowDiedError(`claude stdin write failed: ${(err as Error).message}`);
+    }
+    const result = await finished;
+    this.lastActiveAt = Date.now();
+    return result;
+  }
+
+  /** One stdout line — same translation pipeline as the one-shot
+   *  backend (mapClaudeEvent + the control/usage side channels), the
+   *  only behavioral differences being: stdin is NEVER ended at the
+   *  terminal record (the window continues), and the terminal record
+   *  resolves the in-flight turn instead of arming process exit. */
+  private onLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    // Pre-parse lines (banners before the first system/init) are
+    // surfaced as text so a startup failure is visible — same rule
+    // as the one-shot path.
+    let obj: any;
+    try { obj = JSON.parse(trimmed); }
+    catch {
+      this.emitRaw(trimmed);
+      return;
+    }
+    if (obj?.type === 'control_request') {
+      this.respondToControlRequest(obj);
+      this.turn?.onEvent({
+        type: 'permission-request',
+        id: String(obj.request_id || ''),
+        tool: String(obj?.request?.tool_name || ''),
+        input: obj?.request?.input ?? {},
+        autoDecided: 'allow',
+        reason: 'bypass',
+      });
+      return;
+    }
+    if (obj?.type === 'assistant' && obj?.message?.usage && this.turn) {
+      const inc = extractClaudeUsage({ usage: obj.message.usage, message: { model: obj.message.model } });
+      if (inc) {
+        const acc = mergeUsage(this.turn.accUsage, inc);
+        this.turn.accUsage = acc;
+        this.turn.onEvent({ type: 'status', status: 'usage', usage: acc });
+      }
+    }
+    const turn = this.turn;
+    const ev = mapClaudeEvent(obj, this.sid, turn ? turn.partialState : { sawTextStreamEvent: false });
+    if (obj?.session_id && typeof obj.session_id === 'string') this.sid = obj.session_id;
+    if (!turn || turn.settled) return;
+    if (ev?.event) turn.onEvent(ev.event);
+    if (ev?.terminal) {
+      turn.resultStatus = ev.terminal.status;
+      turn.resultText = ev.terminal.text;
+      turn.resultError = ev.terminal.error;
+      turn.resultUsage = ev.terminal.usage as typeof turn.resultUsage;
+      turn.settled = true;
+      this.turn = null;
+      turn.resolve({
+        status: this.cancelReason
+          ? (this.cancelReason === 'user' ? 'cancelled' : 'timeout')
+          : ev.terminal.status,
+        output: turn.resultText || undefined,
+        error: turn.resultError,
+        ...(this.sid ? { sessionId: this.sid } : {}),
+        ...(turn.resultUsage ?? turn.accUsage ? { usage: (turn.resultUsage ?? turn.accUsage)! } : {}),
+      });
+    }
+  }
+
+  private emitRaw(trimmed: string): void {
+    const turn = this.turn;
+    if (turn && !turn.settled) {
+      if (!this.sid) turn.onEvent({ type: 'text-delta', text: trimmed + '\n' });
+      else turn.onEvent({ type: 'raw-line', line: trimmed });
+    }
+  }
+
+  /** Auto-allow control_request — identical schema to the one-shot
+   *  backend's responder. */
+  private respondToControlRequest(msg: any): void {
+    const req = msg?.request || {};
+    const inputMap = (req.input && typeof req.input === 'object') ? req.input : {};
+    const response = {
+      type: 'control_response',
+      response: {
+        subtype: 'success',
+        request_id: msg.request_id,
+        response: { behavior: 'allow', updatedInput: inputMap },
+      },
+    };
+    try {
+      this.child.stdin.write(JSON.stringify(response) + '\n');
+    } catch (err) {
+      log.warn('claude control_response write failed', { error: logErrorSummary(err) });
+    }
+  }
+
+  cancelTurn(reason: PersistentCancelReason): void {
+    this.cancelReason = reason;
+    // No interrupt input exists for stream-json duplex — killing the
+    // process is the reliable stop. The turn's result is attributed
+    // to the cancel reason; the window dies and the next dispatch
+    // rebuilds via --resume.
+    try { this.child.kill('SIGTERM'); } catch { /* already gone */ }
+    const turn = this.turn;
+    if (turn && !turn.settled) {
+      const grace = setTimeout(() => {
+        if (this.turn === turn && !turn.settled) {
+          try { this.child.kill('SIGKILL'); } catch { /* already gone */ }
+        }
+      }, 10_000);
+      grace.unref?.();
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.aliveFlag = false;
+    const turn = this.turn;
+    this.turn = null;
+    if (turn && !turn.settled) {
+      turn.settled = true;
+      turn.resolve({ status: 'cancelled' });
+    }
+    try { this.child.stdin.end(); } catch { /* already gone */ }
+    try { this.child.kill('SIGTERM'); } catch { /* already gone */ }
+  }
+}
+
+/** Sum two normalized usage records — same merge as the one-shot
+ *  claude backend's running counter. */
+function mergeUsage(
+  acc: Record<string, number | string> | undefined,
+  inc: Record<string, number | string>,
+): Record<string, number | string> {
+  const out: Record<string, number | string> = { ...(acc || {}) };
+  for (const k of ['input', 'output', 'cacheRead', 'cacheCreate']) {
+    const a = typeof out[k] === 'number' ? (out[k] as number) : 0;
+    const i = typeof inc[k] === 'number' ? (inc[k] as number) : 0;
+    if (a || i) out[k] = a + i;
+  }
+  if (typeof inc.model === 'string' && inc.model) out.model = inc.model;
+  return out;
+}
+
+export function createClaudeAdapter(): PersistentAdapter {
+  return {
+    cli: 'claude',
+    supported: true,
+    async acquire(opts): Promise<PersistentWindow> {
+      const args = persistentArgs(opts.resumeSessionId, opts.model);
+      // thinkingLevel is process-lifetime env in duplex mode; applied
+      // at spawn like model. ('off' → leave the CLI default alone.)
+      const effortEnv = opts.thinkingLevel === 'low' || opts.thinkingLevel === 'high'
+        ? { MAX_THINKING_TOKENS: CLAUDE_THINKING_TOKENS[opts.thinkingLevel] }
+        : undefined;
+      const child = spawnCli(opts.binPath, args, opts.cwd, undefined, opts.providerEnv, effortEnv);
+      opts.onEvent({
+        type: 'process-info',
+        pid: child.pid ?? -1,
+        cwd: opts.cwd,
+        cmd: opts.binPath,
+        args,
+        persistent: true,
+      });
+      return new ClaudeWindow(child, opts.resumeSessionId);
+    },
+  };
+}

--- a/src/main/features/local_agents/backends/codex.ts
+++ b/src/main/features/local_agents/backends/codex.ts
@@ -3,6 +3,17 @@
  * JSON-RPC 2.0 protocol. Modelled after multica's `codex.go`, distilled
  * to what we need for one-shot agent dispatch:
  *
+ * PERSISTENT-RUNTIME STATUS (phase-0 probe, 2026-09-03): NO adapter
+ * registered — the codex CLI is not installed on the probe machine,
+ * so a resident adapter could not be live-verified and the
+ * no-unverified-implementations rule applies. The protocol itself is
+ * resident-shaped (this file already speaks it: one app-server
+ * process multiplexes threads; `thread/resume` restores a known
+ * conversation), so the future adapter is: acquire = spawn
+ * app-server + initialize (per cwd), send = turn/start on the bound
+ * threadId, reusing this file's notification parsing verbatim.
+ *
+ *
  *  1. Spawn `codex app-server --listen stdio://`.
  *  2. RPC `initialize` (clientInfo + experimentalApi capability).
  *  3. Notify `initialized`.

--- a/src/main/features/local_agents/backends/opencode.ts
+++ b/src/main/features/local_agents/backends/opencode.ts
@@ -30,10 +30,21 @@ import {
   LineSplitter,
   FileChangeFallbackTracker,
 } from './base.js';
+import { wrapPersistentBackend, registerPersistentAdapter } from '../persistent/index.js';
+import { createOpencodeAdapter } from './opencode_persistent.js';
 
 const log = createLogger('local-agents:opencode');
 
-export const opencodeBackend: LocalBackend = {
+// Persistent wiring: register the serve-based adapter (acquire +
+// event translation live in opencode_persistent.ts; the translation
+// reuses mapOpencodeEvent below for stream parity), then expose the
+// backend through the persistent wrapper. runner.ts and the bus are
+// untouched — the wrapper is an ordinary LocalBackend.
+registerPersistentAdapter(createOpencodeAdapter({
+  mapEvent: mapOpencodeEvent,
+}));
+
+const opencodeOneShotBackend: LocalBackend = {
   async run(opts: BackendRunOptions): Promise<void> {
     const args = buildOpencodeArgs(opts);
     const child = spawnCli(opts.binPath, args, opts.cwd);
@@ -296,3 +307,16 @@ function numOrUndef(...vals: any[]): number | undefined {
   }
   return undefined;
 }
+
+// Exported backend: persistent path by default. Dispatches carrying
+// customArgs fall back to the one-shot spawn — user-supplied CLI
+// flags can't be applied per-turn to an already-running server.
+const wrapped = wrapPersistentBackend('opencode', opencodeOneShotBackend);
+export const opencodeBackend: LocalBackend = {
+  async run(opts: BackendRunOptions): Promise<void> {
+    if (opts.customArgs && opts.customArgs.length) {
+      return opencodeOneShotBackend.run(opts);
+    }
+    return wrapped.run(opts);
+  },
+};

--- a/src/main/features/local_agents/backends/opencode_persistent.ts
+++ b/src/main/features/local_agents/backends/opencode_persistent.ts
@@ -1,0 +1,635 @@
+/**
+ * OpenCode persistent adapter — `opencode serve` (HTTP + SSE).
+ *
+ * Design lifted from the f076c0c prototype (p3394-gateway's
+ * OpencodeRuntime), re-anchored onto the LocalAgent contracts:
+ *
+ *   - one `opencode serve` process per (cwd, provider-env
+ *     fingerprint), spawned lazily on first use, port parsed from
+ *     the "listening on http://127.0.0.1:<port>" stdout line.
+ *     Multiple CogSeed conversations in the same project share the
+ *     server; opencode keeps per-session state server-side.
+ *   - turns: POST /session/:id/message (suspends until the whole
+ *     turn completes, body {info, parts}) for the terminal state +
+ *     GET /event (SSE) for live deltas/tool progress.
+ *   - unattended permissions: a headless server waits forever on
+ *     permission.asked with nobody to approve it, so the serve env
+ *     gets OPENCODE_CONFIG_CONTENT with allow rules — env-only,
+ *     never written to the user's config files. The one-shot path
+ *     runs the same CLI with --dangerously-skip-permissions, so
+ *     this is parity, not a loosening. Opt out with
+ *     COGSEED_PERSISTENT_OPENCODE_AUTO_APPROVE=0.
+ *   - event parity: terminal parts are translated through the SAME
+ *     mapOpencodeEvent the one-shot NDJSON path uses (the shapes
+ *     are isomorphic: tool→tool_use, step-finish→step_finish),
+ *     with dedup against the SSE stream so nothing double-emits,
+ *     and SSE-loss fallback so a dropped event stream still yields
+ *     the identical terminal events the one-shot run produces.
+ *   - turn teardown grace 250ms: the SSE feed and the synchronous
+ *     HTTP response are two connections with no ordering guarantee;
+ *     dropping the turn eagerly right at terminal-state time would
+ *     discard the trailing frames (instance-compared delete).
+ *
+ * Recovery semantics: sessions live in opencode's own storage, so a
+ * crashed server is restarted and the SAME session id is reused
+ * (POST straight to /session/:id/message). A 404 there falls back
+ * to a fresh session — the turn still runs, the window just loses
+ * prior context. Verified live for the in-memory case; the
+ * restart-resume case is flagged for real-machine verification.
+ */
+
+import * as http from 'node:http';
+import { createLogger } from '../../../logger.js';
+import { logErrorRef, logErrorSummary } from '../../../util/log-redact.js';
+import { spawnCli } from './base.js';
+import type { LocalEvent } from './base.js';
+import {
+  WindowDiedError,
+  type PersistentAdapter,
+  type PersistentCancelReason,
+  type PersistentSendOpts,
+  type PersistentTurnResult,
+  type PersistentWindow,
+} from '../persistent/types.js';
+import type { mapOpencodeEvent } from './opencode.js';
+
+const log = createLogger('local-agents:opencode-persistent');
+
+/** Serve startup timeout — includes plugin/config load. */
+const SERVE_TIMEOUT_MS = 30_000;
+/** Terminal-state grace before detaching the SSE turn (see header). */
+const TURN_GRACE_MS = 250;
+/** Delay before killing a server whose last session detached. */
+const SERVE_DRAIN_MS = 5_000;
+/** Reconnect backoff for the SSE subscription. */
+const SSE_RECONNECT_MS = 2_000;
+
+function autoApproveEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return String(env.COGSEED_PERSISTENT_OPENCODE_AUTO_APPROVE ?? '1').trim() !== '0';
+}
+
+/** The allow-rules blob injected via OPENCODE_CONFIG_CONTENT. */
+const OPENCODE_ALLOW_CONFIG = JSON.stringify({
+  permission: { bash: 'allow', edit: 'allow', webfetch: 'allow', websearch: 'allow' },
+});
+
+/** Stable fingerprint for provider env (credential switches must
+ *  not reuse a server spawned under different env). */
+function providerEnvFingerprint(env: Record<string, string> | undefined): string {
+  if (!env || Object.keys(env).length === 0) return '';
+  const keys = Object.keys(env).sort();
+  return keys.map(k => `${k}=${env[k]}`).join('\u0000');
+}
+
+/** Loopback connection failures that mean "the server process is
+ *  gone": refused (nothing listening), reset, or the stream died
+ *  mid-response. Everything else (HTTP 4xx/5xx bodies, timeouts we
+ *  raised ourselves) is an ordinary turn failure. */
+function isConnectionDeath(err: unknown): boolean {
+  const msg = String((err as Error)?.message || err);
+  return /ECONNREFUSED|ECONNRESET|EPIPE|socket hang up/i.test(msg);
+}
+
+// ── tiny HTTP helpers (node:http, loopback only) ────────────────────────
+
+function requestJson(
+  base: string,
+  method: 'GET' | 'POST',
+  pathName: string,
+  body: unknown | undefined,
+  timeoutMs?: number,
+): Promise<{ status: number; json: any; text: string }> {
+  return new Promise((resolve, reject) => {
+    const data = body === undefined ? null : JSON.stringify(body);
+    const req = http.request(base + pathName, {
+      method,
+      headers: {
+        ...(data ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(data) } : {}),
+      },
+    }, res => {
+      let buf = '';
+      res.setEncoding('utf8');
+      res.on('data', (c: string) => { buf += c; });
+      res.on('end', () => {
+        let json: any;
+        try { json = buf ? JSON.parse(buf) : undefined; } catch { json = undefined; }
+        resolve({ status: res.statusCode ?? 0, json, text: buf });
+      });
+    });
+    req.on('error', reject);
+    if (timeoutMs) {
+      const t = setTimeout(() => req.destroy(new Error(`opencode http timeout after ${timeoutMs}ms`)), timeoutMs);
+      t.unref?.();
+    }
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+// ── SSE turn routing state ───────────────────────────────────────────────
+
+/** Per-turn SSE view — attached to the server's event feed while a
+ *  message POST is in flight (+grace). */
+interface TurnState {
+  onEvent: (e: LocalEvent) => void;
+  /** partID → part type, to tell reasoning deltas from body text
+   *  (both arrive as field:'text'). */
+  partTypes: Map<string, string>;
+  /** part ids whose tool-result event already went out (SSE and
+   *  terminal-parts dedup share this set). */
+  sentToolEvents: Set<string>;
+  /** Body text accumulated from SSE deltas (drives the "did SSE
+   *  stream anything" decision for terminal-part emission). */
+  deltaText: string;
+  /** Last full text part seen (no-delta fallback). */
+  lastText: string;
+  settled: boolean;
+}
+
+// ── server entries ──────────────────────────────────────────────────────
+
+interface ServeEntry {
+  child: import('node:child_process').ChildProcessWithoutNullStreams;
+  base: string;
+  port: number;
+  /** Liveness flag we own. child.exitCode stays null even after a
+   *  signal kill (Node only sets exitCode on normal exits), so it
+   *  can NEVER be the liveness oracle here. */
+  dead: boolean;
+  /** Session ids this adapter tracks on the server (refcount for
+   *  drain-kill). */
+  sessions: Set<string>;
+  /** The in-flight (or in-grace) turn per session id. */
+  turns: Map<string, TurnState>;
+  closing: boolean;
+  drainTimer: NodeJS.Timeout | null;
+}
+
+/** Shape the terminal parts share with the one-shot NDJSON events —
+ *  lets us reuse mapOpencodeEvent verbatim for parity. */
+function terminalPartToNdjson(ocSid: string, part: any): any | undefined {
+  switch (part?.type) {
+    case 'text':
+      return { type: 'text', part, sessionID: ocSid };
+    case 'tool':
+      // NDJSON tool_use parts carry callID; SSE/HTTP parts use id.
+      return { type: 'tool_use', part: { ...part, callID: part.callID ?? part.id }, sessionID: ocSid };
+    case 'step-finish':
+      return { type: 'step_finish', part, sessionID: ocSid };
+    case 'step-start':
+      return { type: 'step_start', part, sessionID: ocSid };
+    default:
+      return { type: String(part?.type || 'unknown'), part, sessionID: ocSid };
+  }
+}
+
+class OpencodeWindow implements PersistentWindow {
+  readonly cli = 'opencode' as const;
+  private aliveFlag = true;
+  lastActiveAt = Date.now();
+  private pendingSend: ((r: PersistentTurnResult) => void) | null = null;
+  private pendingReason: PersistentCancelReason | null = null;
+
+  constructor(
+    private readonly serve: ServeEntry,
+    private readonly adapter: OpencodePersistentAdapter,
+    private readonly ocSid: string,
+  ) {
+    serve.sessions.add(ocSid);
+  }
+
+  get sessionId(): string | undefined {
+    return this.ocSid;
+  }
+
+  alive(): boolean {
+    return this.aliveFlag && !this.serve.dead;
+  }
+
+  async send(opts: PersistentSendOpts): Promise<PersistentTurnResult> {
+    if (!this.alive()) throw new WindowDiedError('opencode server exited');
+    this.lastActiveAt = Date.now();
+    const turn: TurnState = {
+      onEvent: opts.onEvent,
+      partTypes: new Map(),
+      sentToolEvents: new Set(),
+      deltaText: '',
+      lastText: '',
+      settled: false,
+    };
+    this.serve.turns.set(this.ocSid, turn);
+    // Provider env drift on reuse: the server runs with the env it
+    // was spawned with; a per-turn change can't be applied. Warn and
+    // continue — credentials rarely change mid-conversation, and the
+    // acquire path already separates servers per fingerprint.
+    if (opts.providerEnv && Object.keys(opts.providerEnv).length) {
+      opts.onEvent({
+        type: 'log', level: 'warn',
+        message: 'persistent opencode server ignores per-turn provider env (spawn-time env)',
+        source: 'opencode',
+      });
+    }
+    try {
+      const body = await this.postMessage(opts, turn);
+      return this.finishFromTerminal(opts, turn, body);
+    } catch (err) {
+      if (this.pendingReason) {
+        // cancelTurn raced the HTTP failure — the cancel status wins
+        return this.cancelledResult();
+      }
+      // A refused/reset connection means the server is gone even if
+      // the close event hasn't landed yet — treat as a dead window so
+      // the manager's recovery path (re-acquire → retry) takes over.
+      if (!this.alive() || isConnectionDeath(err)) {
+        this.serve.dead = true;
+        throw new WindowDiedError(`opencode turn failed: ${(err as Error).message}`);
+      }
+      return {
+        status: 'failed',
+        error: `opencode turn failed: ${(err as Error).message}`,
+        sessionId: this.ocSid,
+      };
+    }
+  }
+
+  /** POST /session/:id/message, suspended to terminal state; the
+   *  SSE feed streams into `turn` while we wait. */
+  private postMessage(opts: PersistentSendOpts, turn: TurnState): Promise<any> {
+    return new Promise<any>((resolve, reject) => {
+      const data = JSON.stringify({ parts: [{ type: 'text', text: opts.prompt }] });
+      const req = http.request(
+        `${this.serve.base}/session/${encodeURIComponent(this.ocSid)}/message`,
+        { method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(data) } },
+        res => {
+          let buf = '';
+          res.setEncoding('utf8');
+          res.on('data', (c: string) => { buf += c; });
+          res.on('end', () => {
+            if (res.statusCode && res.statusCode >= 400) {
+              reject(new Error(`HTTP ${res.statusCode}: ${buf.slice(0, 200)}`));
+              return;
+            }
+            try { resolve(buf ? JSON.parse(buf) : {}); }
+            catch { resolve({ parts: [] }); }
+          });
+        },
+      );
+      req.on('error', reject);
+      this.pendingSend = (r) => {
+        req.destroy(new Error('turn cancelled'));
+        resolve(undefined as any);
+        void r;
+      };
+      req.write(data);
+      req.end();
+    });
+  }
+
+  /** Translate the terminal parts through the shared one-shot
+   *  mapper, deduped against what the SSE stream already emitted. */
+  private finishFromTerminal(
+    opts: PersistentSendOpts,
+    turn: TurnState,
+    body: any,
+  ): PersistentTurnResult {
+    turn.settled = true;
+    const parts: any[] = Array.isArray(body?.parts) ? body.parts : [];
+    let output = '';
+    let usage: Record<string, number | string> | undefined;
+    let failure: string | undefined;
+    const sawSseDeltas = turn.deltaText.length > 0;
+    for (const part of parts) {
+      const nd = terminalPartToNdjson(this.ocSid, part);
+      if (!nd) continue;
+      // text: SSE already streamed the body → skip re-emitting, just
+      // accumulate output. No SSE (dropped feed) → emit the whole
+      // part exactly like the one-shot path so the event stream the
+      // runner persists stays complete.
+      if (nd.type === 'text' && typeof part?.text === 'string') {
+        output += part.text;
+        if (!sawSseDeltas) {
+          const mapped = this.adapter.deps.mapEvent(nd);
+          if (mapped?.event) opts.onEvent(mapped.event);
+        }
+        continue;
+      }
+      if (nd.type === 'tool_use') {
+        // SSE emitted running→use and completed→result already; only
+        // backfill the terminal result when the feed went quiet.
+        const pid = String(part?.id ?? part?.callID ?? '');
+        const state = part?.state ?? {};
+        const done = ['completed', 'success', 'done'].includes(String(state.status || ''));
+        if (pid && done && !turn.sentToolEvents.has(pid)) {
+          const mapped = this.adapter.deps.mapEvent(nd);
+          if (mapped?.event) {
+            turn.sentToolEvents.add(pid);
+            opts.onEvent(mapped.event);
+          }
+        }
+        continue;
+      }
+      const mapped = this.adapter.deps.mapEvent(nd);
+      if (mapped?.event) opts.onEvent(mapped.event);
+      if (mapped?.terminal?.status === 'failed') failure = mapped.terminal.error;
+      if (mapped?.event?.type === 'status' && (mapped.event as any).status === 'usage') {
+        const u = (mapped.event as any).usage;
+        if (u && typeof u === 'object') usage = u;
+      }
+    }
+    const finalOutput = (output.trim() || turn.deltaText.trim() || turn.lastText.trim());
+    return failure
+      ? { status: 'failed', error: failure, output: finalOutput, sessionId: this.ocSid }
+      : { status: 'completed', output: finalOutput, sessionId: this.ocSid, ...(usage ? { usage } : {}) };
+  }
+
+  cancelTurn(reason: PersistentCancelReason): void {
+    this.pendingReason = reason;
+    // Best-effort server-side turn abort (endpoint verified in the
+    // OpenAPI spec; effectiveness flagged for real-machine checks).
+    const req = http.request(
+      `${this.serve.base}/session/${encodeURIComponent(this.ocSid)}/abort`,
+      { method: 'POST' },
+      () => undefined,
+    );
+    req.on('error', () => undefined);
+    req.end();
+    if (this.pendingSend) {
+      const settle = this.pendingSend;
+      this.pendingSend = null;
+      settle(this.cancelledResult());
+    }
+  }
+
+  private cancelledResult(): PersistentTurnResult {
+    const status = this.pendingReason === 'user' ? 'cancelled' : 'timeout';
+    this.pendingReason = null;
+    this.detachTurn();
+    return { status, sessionId: this.ocSid };
+  }
+
+  private detachTurn(): void {
+    const turn = this.serve.turns.get(this.ocSid);
+    if (turn) {
+      // Grace detach: trailing SSE frames still route for a moment.
+      setTimeout(() => {
+        if (this.serve.turns.get(this.ocSid) === turn) this.serve.turns.delete(this.ocSid);
+      }, TURN_GRACE_MS).unref?.();
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.aliveFlag = false;
+    this.serve.sessions.delete(this.ocSid);
+    this.serve.turns.delete(this.ocSid);
+    this.adapter.maybeDrainServe(this.serve);
+  }
+}
+
+// ── adapter ──────────────────────────────────────────────────────────────
+
+/** The one-shot translation helpers, injected by opencode.ts (keeps
+ *  this module free of a circular import on the backend file). */
+export interface OpencodeAdapterDeps {
+  mapEvent: typeof mapOpencodeEvent;
+}
+
+export function createOpencodeAdapter(deps: OpencodeAdapterDeps): PersistentAdapter {
+  return new OpencodePersistentAdapter(deps);
+}
+
+class OpencodePersistentAdapter implements PersistentAdapter {
+  readonly cli = 'opencode' as const;
+  readonly supported = true;
+  /** cwd + env fingerprint → server. */
+  private readonly serves = new Map<string, ServeEntry>();
+
+  constructor(readonly deps: OpencodeAdapterDeps) {}
+
+  async acquire(opts: import('../persistent/types.js').PersistentAcquireOpts): Promise<PersistentWindow> {
+    const serve = await this.serverFor(opts);
+    let ocSid = opts.resumeSessionId;
+    if (ocSid) {
+      const check = await requestJson(serve.base, 'GET', `/session/${encodeURIComponent(ocSid)}`, undefined, 10_000)
+        .catch(err => { throw new WindowDiedError(`opencode session check failed: ${(err as Error).message}`); });
+      if (check.status === 404) {
+        // Session gone (server restarted + storage miss) — continue
+        // fresh; the turn runs, prior context is lost.
+        opts.onEvent({
+          type: 'log', level: 'warn',
+          message: `opencode session ${ocSid} not found on server — starting a fresh session`,
+          source: 'opencode',
+        });
+        ocSid = undefined;
+      } else if (check.status >= 400) {
+        throw new WindowDiedError(`opencode session check HTTP ${check.status}`);
+      }
+    }
+    if (!ocSid) {
+      const created = await requestJson(serve.base, 'POST', '/session', {
+        ...(opts.model && opts.model.includes('/')
+          ? { model: { providerID: opts.model.split('/')[0], id: opts.model.split('/').slice(1).join('/') } }
+          : {}),
+      }, 10_000).catch(err => { throw new WindowDiedError(`opencode session create failed: ${(err as Error).message}`); });
+      ocSid = typeof created.json?.id === 'string' ? created.json.id : undefined;
+      if (!ocSid) throw new WindowDiedError('opencode session create returned no id');
+    }
+    return new OpencodeWindow(serve, this, ocSid);
+  }
+
+  /** Lazy per-(cwd, envFingerprint) server with in-flight dedup. */
+  private readonly serverInflight = new Map<string, Promise<ServeEntry>>();
+
+  private async serverFor(opts: { binPath: string; cwd: string; providerEnv?: Record<string, string>; onEvent: (e: LocalEvent) => void }): Promise<ServeEntry> {
+    const envKey = providerEnvFingerprint(opts.providerEnv);
+    const key = `${opts.cwd}\u0000${envKey}`;
+    const hit = this.serves.get(key);
+    if (hit && !hit.dead) return hit;
+    if (hit) this.serves.delete(key);
+    const pending = this.serverInflight.get(key);
+    if (pending) return pending;
+    const p = this.spawnServer(key, opts.binPath, opts.cwd, opts.providerEnv, opts.onEvent)
+      .finally(() => this.serverInflight.delete(key));
+    this.serverInflight.set(key, p);
+    return p;
+  }
+
+  private async spawnServer(
+    key: string,
+    binPath: string,
+    cwd: string,
+    providerEnv: Record<string, string> | undefined,
+    onEvent: (e: LocalEvent) => void,
+  ): Promise<ServeEntry> {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (autoApproveEnabled() && !env.OPENCODE_CONFIG_CONTENT) {
+      env.OPENCODE_CONFIG_CONTENT = OPENCODE_ALLOW_CONFIG;
+    }
+    const args = ['serve', '--port', '0', '--hostname', '127.0.0.1'];
+    const child = spawnCli(binPath, args, cwd, env, providerEnv);
+    let stderrLog = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (c: string) => { if (stderrLog.length < 8 * 1024) stderrLog += c; });
+    try {
+      const port = await new Promise<number>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`opencode serve startup timeout${stderrLog ? `: ${stderrLog.slice(-300)}` : ''}`)),
+          SERVE_TIMEOUT_MS,
+        );
+        timer.unref?.();
+        child.on('error', err => { clearTimeout(timer); reject(err); });
+        let buf = '';
+        child.stdout.setEncoding('utf8');
+        child.stdout.on('data', (c: string) => {
+          buf += c;
+          const m = buf.match(/listening on http:\/\/127\.0\.0\.1:(\d+)/);
+          if (m) { clearTimeout(timer); resolve(Number(m[1])); }
+        });
+      });
+      const entry: ServeEntry = {
+        child,
+        base: `http://127.0.0.1:${port}`,
+        port,
+        dead: false,
+        sessions: new Set(),
+        turns: new Map(),
+        closing: false,
+        drainTimer: null,
+      };
+      child.on('close', code => {
+        // Server died: every window on it is dead. In-flight turns
+        // reject through their HTTP error path → WindowDiedError.
+        entry.dead = true;
+        this.serves.delete(key);
+        entry.turns.clear();
+        log.warn('opencode serve exited', { code, port });
+      });
+      this.serves.set(key, entry);
+      onEvent({
+        type: 'process-info',
+        pid: child.pid ?? -1,
+        cwd,
+        cmd: binPath,
+        args,
+        persistent: true,
+      });
+      this.subscribeEvents(entry);
+      log.info('opencode serve started', { port, cwd });
+      return entry;
+    } catch (err) {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+      log.warn('opencode serve spawn failed', { error: logErrorSummary(err) });
+      throw new WindowDiedError(`opencode serve failed to start: ${(err as Error).message}`);
+    }
+  }
+
+  /** One SSE subscription per server, routing events to the
+   *  per-session turn state; auto-reconnects while the server lives. */
+  private subscribeEvents(entry: ServeEntry): void {
+    const connect = (): void => {
+      if (entry.closing || entry.dead) return;
+      const req = http.get(`${entry.base}/event`, res => {
+        let buf = '';
+        res.setEncoding('utf8');
+        res.on('data', (c: string) => {
+          buf += c;
+          let idx: number;
+          while ((idx = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, idx).trim();
+            buf = buf.slice(idx + 1);
+            if (!line.startsWith('data:')) continue;
+            try { this.onSseEvent(entry, JSON.parse(line.slice(5).trim())); }
+            catch { /* non-JSON keepalive line */ }
+          }
+        });
+        res.on('end', () => { setTimeout(connect, SSE_RECONNECT_MS).unref?.(); });
+      });
+      req.on('error', () => { setTimeout(connect, SSE_RECONNECT_MS).unref?.(); });
+    };
+    connect();
+  }
+
+  private onSseEvent(entry: ServeEntry, ev: any): void {
+    const props = ev?.properties;
+    if (!props || typeof props.sessionID !== 'string') return;
+    const turn = entry.turns.get(props.sessionID);
+    if (!turn || turn.settled) return;
+    if (ev.type === 'message.part.updated' && props.part && typeof props.part.id === 'string') {
+      const part = props.part;
+      turn.partTypes.set(part.id, String(part.type || ''));
+      if (part.type === 'text' && typeof part.text === 'string') {
+        turn.lastText = part.text;
+      } else if (part.type === 'tool' && part.state) {
+        this.emitToolEvent(turn, part);
+      }
+      return;
+    }
+    if (ev.type === 'message.part.delta' && props.field === 'text' && typeof props.delta === 'string' && props.delta) {
+      // reasoning parts stream their text with field:'text' too —
+      // only body parts pass the partID→type filter.
+      if (turn.partTypes.get(props.partID) === 'text') {
+        turn.deltaText += props.delta;
+        turn.onEvent({ type: 'text-delta', text: props.delta });
+      }
+    }
+  }
+
+  private emitToolEvent(turn: TurnState, part: any): void {
+    const pid = String(part.id ?? part.callID ?? '');
+    const status = String(part.state?.status || '');
+    // running → phase 'use' fires every update while running (the
+    // server may re-emit with growing input); only the first per
+    // part goes out to keep the rail clean. completed → 'result',
+    // deduped against terminal-part backfill through the same set.
+    if (status === 'running') {
+      if (pid && turn.sentToolEvents.has(`${pid}#use`)) return;
+      if (pid) turn.sentToolEvents.add(`${pid}#use`);
+      turn.onEvent({
+        type: 'tool-event',
+        tool: String(part.tool || 'tool'),
+        callId: String(part.callID || pid),
+        phase: 'use',
+        input: part.state?.input ?? {},
+      });
+      return;
+    }
+    if (['completed', 'success', 'done', 'error'].includes(status)) {
+      if (pid && turn.sentToolEvents.has(pid)) return;
+      if (pid) turn.sentToolEvents.add(pid);
+      const output = typeof part.state?.output === 'string'
+        ? part.state.output
+        : (part.state?.output != null ? JSON.stringify(part.state.output) : '');
+      turn.onEvent({
+        type: 'tool-event',
+        tool: String(part.tool || 'tool'),
+        callId: String(part.callID || pid),
+        phase: 'result',
+        output,
+      });
+    }
+  }
+
+  /** Kill a server once its last session detached (drain-delayed so
+   *  a follow-up acquire in the same conversation reuses it). */
+  maybeDrainServe(entry: ServeEntry): void {
+    if (entry.sessions.size > 0 || entry.drainTimer) return;
+    entry.drainTimer = setTimeout(() => {
+      entry.drainTimer = null;
+      if (entry.sessions.size === 0 && entry.child.exitCode === null) {
+        entry.closing = true;
+        try { entry.child.kill('SIGTERM'); } catch { /* already gone */ }
+        log.info('opencode serve drained and stopped', { port: entry.port });
+      }
+    }, SERVE_DRAIN_MS);
+    entry.drainTimer.unref?.();
+  }
+
+  /** Stop every server (app exit / test teardown). */
+  stopAll(): void {
+    for (const [, entry] of this.serves) {
+      entry.closing = true;
+      if (entry.drainTimer) { clearTimeout(entry.drainTimer); entry.drainTimer = null; }
+      try { entry.child.kill('SIGTERM'); } catch ( /* already gone */ err) { void err; }
+    }
+    this.serves.clear();
+  }
+}

--- a/src/main/features/local_agents/persistent/index.ts
+++ b/src/main/features/local_agents/persistent/index.ts
@@ -1,0 +1,71 @@
+/**
+ * Persistent runtime — adapter registry + backend wrapper.
+ *
+ * Wiring rule: the ONE-SHOT backend modules wrap themselves:
+ *
+ *   export const opencodeBackend = wrapPersistentBackend(
+ *     'opencode', opencodeOneShotBackend);
+ *
+ * That keeps runner.ts and the bus untouched (zero contract change):
+ * the wrapper is an ordinary LocalBackend that routes each `run`
+ * through the manager when persistent mode is on and an adapter is
+ * registered, and transparently delegates to the one-shot backend
+ * otherwise (COGSEED_PERSISTENT=0, adapter unsupported, or shutdown).
+ */
+
+import type { LocalBackend, LocalEvent } from '../backends/base.js';
+import type { LocalCliType } from '../registry.js';
+import { getPersistentRuntimeManager } from './manager.js';
+import type { PersistentAdapter } from './types.js';
+
+export {
+  persistentEnabled,
+  resolveIdleReclaimMs,
+  PersistentRuntimeManager,
+  getPersistentRuntimeManager,
+} from './manager.js';
+export type {
+  PersistentAdapter,
+  PersistentWindow,
+  PersistentAcquireOpts,
+  PersistentSendOpts,
+  PersistentTurnResult,
+  PersistentCancelReason,
+} from './types.js';
+export { WindowDiedError } from './types.js';
+
+/**
+ * Adapter registry. Populated by the adapter modules themselves
+ * (registerPersistentAdapter at import time) — importing a backend
+ * file is what activates its persistent path. CLIs with no entry
+ * (hermes, gemini, codex today — see the phase-0 probe report) stay
+ * on the one-shot path with zero overhead.
+ */
+const ADAPTERS: Partial<Record<LocalCliType, PersistentAdapter>> = {};
+
+export function registerPersistentAdapter(adapter: PersistentAdapter): void {
+  ADAPTERS[adapter.cli] = adapter;
+}
+
+/** Test hook — clear registrations between suites. */
+export function _clearPersistentAdaptersForTest(): void {
+  for (const k of Object.keys(ADAPTERS)) delete ADAPTERS[k as LocalCliType];
+}
+
+/** Route marker so the log line "persistent window reused" can be
+ *  attributed; also the single place that knows the manager exists. */
+export function wrapPersistentBackend(cli: LocalCliType, oneShot: LocalBackend): LocalBackend {
+  return {
+    async run(opts): Promise<void> {
+      const adapter = ADAPTERS[cli];
+      if (!adapter || !adapter.supported) return oneShot.run(opts);
+      return getPersistentRuntimeManager().run(opts, adapter, oneShot);
+    },
+  };
+}
+
+/** Re-exported for adapters that want to emit the same shape of
+ *  reuse/process log events the manager does. */
+export function persistentLogEvent(message: string, level: 'debug' | 'info' | 'warn' | 'error' = 'debug'): LocalEvent {
+  return { type: 'log', level, message, source: 'persistent' };
+}

--- a/src/main/features/local_agents/persistent/manager.ts
+++ b/src/main/features/local_agents/persistent/manager.ts
@@ -1,0 +1,401 @@
+/**
+ * PersistentRuntimeManager — the shared lifecycle brain.
+ *
+ * Responsibilities (everything EXCEPT the per-CLI wiring, which
+ * lives in adapters):
+ *
+ *   - lazy start: a window is only acquired on the first dispatch
+ *     that needs it; nothing pre-spawns.
+ *   - reuse: a dispatch with resumeSessionId R reuses the live
+ *     window whose sessionId === R. A first turn (no resumeSessionId)
+ *     ALWAYS opens a fresh window — two different agents in one
+ *     conversation both dispatch without a binding on their first
+ *     turn, and reusing one agent's window there would cross-wire
+ *     their contexts. The cost is one extra short-lived window when
+ *     an idle one could have been reused; correctness wins.
+ *   - idle reclaim: a sweeper stops windows whose last turn ended
+ *     more than COGSEED_PERSISTENT_IDLE_MS ago (default 10 min).
+ *   - crash recovery: a window that dies mid-turn is dropped, the
+ *     turn is retried ONCE on a freshly acquired window restored
+ *     from the last known session id (resume demoted to a recovery
+ *     mechanism); if that also fails the turn falls back to the
+ *     one-shot backend so the dispatch still completes.
+ *   - exit cleanup: shutdownAll() on process exit signals.
+ *
+ * Turn semantics: the manager owns the terminal `done` event and the
+ * turn watchdogs (wall-clock + idle, mirroring armKillWatchdog),
+ * adapters own translation events and must resolve send() once
+ * cancelTurn() fires.
+ */
+
+import { createLogger } from '../../../logger.js';
+import { logErrorRef, logErrorSummary } from '../../../util/log-redact.js';
+import type { LocalBackend, BackendRunOptions } from '../backends/base.js';
+import type {
+  PersistentAdapter,
+  PersistentWindow,
+  PersistentSendOpts,
+  PersistentTurnResult,
+  PersistentCancelReason,
+} from './types.js';
+
+const log = createLogger('local-agents:persistent');
+
+/** Master switch. Default ON; COGSEED_PERSISTENT=0 runs every CLI
+ *  through the existing one-shot path (byte-for-byte behavior). */
+export function persistentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return String(env.COGSEED_PERSISTENT ?? '1').trim() !== '0';
+}
+
+/** Idle reclaim window (ms). 0/negative disables reclaim. */
+export function resolveIdleReclaimMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number(env.COGSEED_PERSISTENT_IDLE_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 10 * 60 * 1000;
+}
+
+/** Sweeper cadence — coarse; only wakes to check timestamps. */
+const SWEEP_INTERVAL_MS = 30 * 1000;
+/** How long the watchdog keeps waiting for send() to resolve after
+ *  cancelTurn before treating the window as dead. Adapters contract
+ *  to resolve promptly; this is zombie insurance. */
+const CANCEL_GRACE_MS = 15_000;
+
+function windowKey(cli: string, cwd: string, sessionId: string): string {
+  return `${cli}::${cwd}::${sessionId}`;
+}
+
+export class PersistentRuntimeManager {
+  private readonly windows = new Map<string, PersistentWindow>();
+  /** Per-key acquire dedup — concurrent dispatches for the same key
+   *  (e.g. two turns racing on a cold cwd) must not double-spawn. */
+  private readonly inflight = new Map<string, Promise<PersistentWindow>>();
+  /** Windows with an in-flight turn — exempt from idle reclaim. */
+  private readonly busy = new Set<PersistentWindow>();
+  private freshSeq = 0;
+  private sweeper: NodeJS.Timeout | null = null;
+  private shutDown = false;
+
+  constructor(
+    private readonly env: NodeJS.ProcessEnv = process.env,
+    private readonly sweepIntervalMs = SWEEP_INTERVAL_MS,
+  ) {}
+
+  /** Live window count — test/diagnostics hook. */
+  get size(): number {
+    return this.windows.size;
+  }
+
+  /** Entry point used by the backend wrapper. */
+  async run(opts: BackendRunOptions, adapter: PersistentAdapter, fallback: LocalBackend): Promise<void> {
+    if (!persistentEnabled(this.env) || !adapter.supported || this.shutDown) {
+      return fallback.run(opts);
+    }
+    const startedAt = Date.now();
+    const sid = opts.resumeSessionId;
+    const key = sid
+      ? windowKey(adapter.cli, opts.cwd, sid)
+      : windowKey(adapter.cli, opts.cwd, `@fresh-${++this.freshSeq}`);
+
+    // Reuse: only an ALIVE window whose sessionId matches the
+    // binding qualifies. Stale/dead hits are dropped eagerly.
+    const cached = sid ? this.windows.get(key) : undefined;
+    if (cached) {
+      if (cached.alive() && cached.sessionId === sid) {
+        opts.onEvent({
+          type: 'log',
+          level: 'debug',
+          message: `persistent window reused (cli=${adapter.cli})`,
+          source: 'persistent',
+        });
+        return this.deliverTurn(cached, key, opts, adapter, fallback, startedAt);
+      }
+      this.windows.delete(key);
+    }
+
+    const win = await this.acquireWindow(key, adapter, opts);
+    return this.deliverTurn(win, key, opts, adapter, fallback, startedAt);
+  }
+
+  /** Acquire with per-key dedup; on failure the placeholder is
+   *  removed so a later dispatch can retry. */
+  private async acquireWindow(
+    key: string,
+    adapter: PersistentAdapter,
+    opts: BackendRunOptions,
+  ): Promise<PersistentWindow> {
+    const pending = this.inflight.get(key);
+    if (pending) return pending;
+    const p = adapter
+      .acquire({
+        binPath: opts.binPath,
+        cwd: opts.cwd,
+        ...(opts.model ? { model: opts.model } : {}),
+        ...(opts.thinkingLevel ? { thinkingLevel: opts.thinkingLevel } : {}),
+        ...(opts.resumeSessionId ? { resumeSessionId: opts.resumeSessionId } : {}),
+        ...(opts.providerEnv ? { providerEnv: opts.providerEnv } : {}),
+        onEvent: opts.onEvent,
+      })
+      .then(win => {
+        this.windows.set(key, win);
+        this.armSweeper();
+        return win;
+      })
+      .finally(() => {
+        this.inflight.delete(key);
+      });
+    this.inflight.set(key, p);
+    return p;
+  }
+
+  /** Deliver one turn with watchdogs, serialization, and crash
+   *  recovery. Always resolves after emitting exactly one terminal
+   *  `done` — or after the fallback backend emitted its own. */
+  private async deliverTurn(
+    win: PersistentWindow,
+    key: string,
+    opts: BackendRunOptions,
+    adapter: PersistentAdapter,
+    fallback: LocalBackend,
+    startedAt: number,
+  ): Promise<void> {
+    this.busy.add(win);
+    try {
+      let result: PersistentTurnResult;
+      try {
+        result = await this.sendWithWatchdogs(win, opts);
+      } catch (err) {
+        // Window died (or acquire-send failed hard). Drop it and try
+        // ONE recovery pass: re-acquire restored from the last known
+        // session id, re-deliver the same prompt. Re-executing a
+        // partially-run turn may repeat tool side effects — the same
+        // tradeoff the one-shot resume path already makes.
+        const deadSid = win.sessionId ?? opts.resumeSessionId;
+        log.warn('persistent window died mid-turn — recovering', {
+          cli: adapter.cli,
+          error: logErrorSummary(err),
+          ...(deadSid ? { resume: true } : {}),
+        });
+        this.dropWindow(key, win);
+        const recoveryKey = deadSid ? windowKey(adapter.cli, opts.cwd, deadSid) : key;
+        let revived: PersistentWindow | null = null;
+        try {
+          revived = await this.acquireWindow(
+            recoveryKey,
+            adapter,
+            { ...opts, ...(deadSid ? { resumeSessionId: deadSid } : {}) },
+          );
+          result = await this.sendWithWatchdogs(revived, opts);
+          this.rekey(adapter.cli, opts.cwd, revived, result, recoveryKey);
+        } catch (retryErr) {
+          // Recovery failed — drop the unusable revived window so no
+          // zombie entry lingers, then run the turn through the
+          // one-shot backend (which emits its own done) so the
+          // dispatch still completes.
+          log.warn('persistent recovery failed — falling back to one-shot', {
+            cli: adapter.cli,
+            error: logErrorSummary(retryErr),
+          });
+          if (revived) this.dropWindow(recoveryKey, revived);
+          await fallback.run(opts);
+          return;
+        }
+      }
+      this.rekey(adapter.cli, opts.cwd, win, result, key);
+      opts.onEvent({
+        type: 'done',
+        status: result.status,
+        durationMs: Date.now() - startedAt,
+        ...(result.output !== undefined ? { output: result.output } : {}),
+        ...(result.error !== undefined ? { error: result.error } : {}),
+        ...(result.sessionId !== undefined ? { sessionId: result.sessionId } : {}),
+        ...(result.usage !== undefined ? { usage: result.usage } : {}),
+      });
+    } finally {
+      this.busy.delete(win);
+    }
+  }
+
+  /** Serialize sends per window (a resident process handles one
+   *  turn at a time) and arm the turn watchdogs. */
+  private sendQueue = new WeakMap<PersistentWindow, Promise<unknown>>();
+
+  private sendWithWatchdogs(win: PersistentWindow, opts: BackendRunOptions): Promise<PersistentTurnResult> {
+    const prev = this.sendQueue.get(win) ?? Promise.resolve();
+    const task = prev.catch(() => undefined).then(() => this.sendTurn(win, opts));
+    this.sendQueue.set(win, task);
+    return task;
+  }
+
+  private async sendTurn(win: PersistentWindow, opts: BackendRunOptions): Promise<PersistentTurnResult> {
+    const sendOpts: PersistentSendOpts = {
+      prompt: opts.prompt,
+      cwd: opts.cwd,
+      ...(opts.model ? { model: opts.model } : {}),
+      ...(opts.customArgs && opts.customArgs.length ? { customArgs: opts.customArgs } : {}),
+      ...(opts.thinkingLevel ? { thinkingLevel: opts.thinkingLevel } : {}),
+      signal: opts.signal,
+      onEvent: opts.onEvent,
+      ...(opts.lastEventAt ? { lastEventAt: opts.lastEventAt } : {}),
+      ...(opts.providerEnv ? { providerEnv: opts.providerEnv } : {}),
+    };
+
+    // Watchdogs mirror armKillWatchdog's two limits, but instead of
+    // killing we ask the window to cancel the turn; adapters map the
+    // reason onto the terminal result status. The grace timer is
+    // zombie insurance for adapters that never resolve.
+    const minLimit = opts.idleKillMs && opts.idleKillMs > 0 && opts.lastEventAt
+      ? Math.min(opts.timeoutMs, opts.idleKillMs)
+      : opts.timeoutMs;
+    const tickMs = Math.max(25, Math.min(5_000, Math.floor(minLimit / 4)));
+    const startedAt = Date.now();
+    let fired: 'wall' | 'idle' | null = null;
+    let firedIdleMs = 0;
+    let graceTimer: NodeJS.Timeout | null = null;
+
+    const p = win.send(sendOpts);
+    const reasonOf = (): PersistentCancelReason =>
+      fired === 'wall' ? 'timeout' : fired === 'idle' ? 'idle' : 'user';
+    const ticker = setInterval(() => {
+      const now = Date.now();
+      if (now - startedAt >= opts.timeoutMs) fired = 'wall';
+      else if (opts.idleKillMs && opts.idleKillMs > 0 && opts.lastEventAt) {
+        const idleFor = now - opts.lastEventAt();
+        if (idleFor >= opts.idleKillMs) { fired = 'idle'; firedIdleMs = idleFor; }
+      }
+      if (fired) {
+        clearInterval(ticker);
+        win.cancelTurn(reasonOf());
+        // Adapter contract: resolve promptly after cancelTurn. If it
+        // doesn't, reject so the recovery path takes over.
+        graceTimer = setTimeout(() => {
+          const err = new Error(
+            fired === 'idle'
+              ? `persistent window unresponsive after idle cancel (idle ${firedIdleMs}ms)`
+              : 'persistent window unresponsive after wall-clock cancel',
+          );
+          (p as Promise<PersistentTurnResult>).catch(() => undefined);
+          rejectPending(err);
+        }, CANCEL_GRACE_MS);
+        if (typeof graceTimer.unref === 'function') graceTimer.unref();
+      }
+    }, tickMs);
+    if (typeof ticker.unref === 'function') ticker.unref();
+
+    let rejectPending: (e: Error) => void = () => undefined;
+    const guarded = new Promise<PersistentTurnResult>((resolve, reject) => {
+      rejectPending = reject;
+      p.then(resolve, reject);
+    });
+
+    const onAbort = () => {
+      fired = null; // user abort outranks watchdog reasons
+      win.cancelTurn('user');
+    };
+    if (opts.signal.aborted) onAbort();
+    else opts.signal.addEventListener('abort', onAbort, { once: true });
+
+    try {
+      return await guarded;
+    } finally {
+      clearInterval(ticker);
+      if (graceTimer) clearTimeout(graceTimer);
+      opts.signal.removeEventListener('abort', onAbort);
+    }
+  }
+
+  /** Move the window's map entry to the CLI-reported session id so
+   *  the next dispatch (resumeSessionId from the sessions.ts
+   *  binding) finds it. First turns start on a @fresh- key and get
+   *  re-keyed here. */
+  private rekey(
+    cli: string,
+    cwd: string,
+    win: PersistentWindow,
+    result: PersistentTurnResult,
+    oldKey: string,
+  ): void {
+    if (!result.sessionId) return;
+    const nextKey = windowKey(cli, cwd, result.sessionId);
+    if (nextKey === oldKey) return;
+    if (this.windows.get(oldKey) === win) this.windows.delete(oldKey);
+    this.windows.set(nextKey, win);
+  }
+
+  private dropWindow(key: string, win: PersistentWindow): void {
+    if (this.windows.get(key) === win) this.windows.delete(key);
+    for (const [k, w] of this.windows) {
+      if (w === win) this.windows.delete(k);
+    }
+    void win.stop().catch(() => undefined);
+  }
+
+  private armSweeper(): void {
+    if (this.sweeper || this.shutDown) return;
+    const idleMs = resolveIdleReclaimMs(this.env);
+    if (idleMs <= 0) return;
+    this.sweeper = setInterval(() => {
+      const now = Date.now();
+      for (const [key, win] of this.windows) {
+        if (this.busy.has(win)) continue;
+        if (now - win.lastActiveAt >= idleMs || !win.alive()) {
+          if (!win.alive()) {
+            this.windows.delete(key);
+            continue;
+          }
+          log.info('persistent window idle-reclaimed', { cli: win.cli });
+          this.windows.delete(key);
+          void win.stop().catch(() => undefined);
+        }
+      }
+      if (this.windows.size === 0 && this.sweeper) {
+        clearInterval(this.sweeper);
+        this.sweeper = null;
+      }
+    }, this.sweepIntervalMs);
+    if (typeof this.sweeper.unref === 'function') this.sweeper.unref();
+  }
+
+  /** Stop every window and disable the manager. Used on app exit
+   *  and by tests. */
+  shutdownAll(): void {
+    this.shutDown = true;
+    if (this.sweeper) {
+      clearInterval(this.sweeper);
+      this.sweeper = null;
+    }
+    for (const win of this.windows.values()) {
+      void win.stop().catch(err => {
+        log.warn('persistent window stop failed', { cli: win.cli, error: logErrorRef(err) });
+      });
+    }
+    this.windows.clear();
+  }
+
+  /** Test hook — inspect the live key set. */
+  _keysForTest(): string[] {
+    return [...this.windows.keys()];
+  }
+}
+
+/** Process-wide singleton. Registered lazily so importing the
+ *  module never installs exit handlers in isolation (tests construct
+ *  their own instances instead). */
+let defaultManager: PersistentRuntimeManager | null = null;
+
+export function getPersistentRuntimeManager(): PersistentRuntimeManager {
+  if (!defaultManager) {
+    defaultManager = new PersistentRuntimeManager();
+    const hooks: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+    const cleanup = () => defaultManager?.shutdownAll();
+    process.once('exit', cleanup);
+    for (const sig of hooks) {
+      process.once(sig, () => {
+        cleanup();
+        // Re-raise the default behavior after our stop pass so the
+        // process still terminates normally.
+        process.kill(process.pid, sig);
+      });
+    }
+  }
+  return defaultManager;
+}

--- a/src/main/features/local_agents/persistent/types.ts
+++ b/src/main/features/local_agents/persistent/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Persistent CLI runtime — shared contracts.
+ *
+ * Goal: keep one long-lived "chat window" per external CLI agent so
+ * consecutive turns reuse the same process/server instead of paying
+ * the ~50 s cold-start on every dispatch. The runner/bus contracts
+ * stay untouched: `wrapPersistentBackend` produces an ordinary
+ * `LocalBackend` whose `run()` is called once per dispatch — under
+ * the hood the turn is delivered to a reused window.
+ *
+ * Layering (see persistent/manager.ts for the lifecycle rules):
+ *
+ *   runner.ts ──run(opts)──▶ wrapPersistentBackend(cli, oneShot)
+ *                                │  COGSEED_PERSISTENT=0 or adapter
+ *                                │  unsupported → oneShot.run(opts)
+ *                                ▼
+ *                          PersistentRuntimeManager
+ *                                │ reuse-by-session-id, idle reclaim,
+ *                                │ crash recovery, exit cleanup
+ *                                ▼
+ *                          PersistentAdapter (one per CLI — the only
+ *                          per-CLI code): how to open a window and
+ *                          how to translate its native events into
+ *                          `LocalEvent`s.
+ *
+ * An adapter writes exactly two things:
+ *   1. `acquire` — how this CLI opens (or restores) a resident window;
+ *   2. the event translation inside the window's `send` — it must
+ *      produce the SAME `LocalEvent` stream the one-shot backend
+ *      emits, so runner parsing and the renderer rail stay identical.
+ */
+
+import type { LocalEvent } from '../backends/base.js';
+import type { LocalCliType } from '../registry.js';
+
+/** Terminal outcome of one delivered turn. The manager turns this
+ *  into the terminal `done` LocalEvent; adapters never emit `done`
+ *  themselves (single-owner rule — the one-shot backends own their
+ *  `done`, here the manager owns it). */
+export interface PersistentTurnResult {
+  status: 'completed' | 'failed' | 'cancelled' | 'timeout';
+  /** Final assistant text, when the CLI surfaced one. */
+  output?: string;
+  error?: string;
+  /** CLI-reported conversation id (claude session_id / opencode
+   *  session id). The manager re-keys the window on it so the NEXT
+   *  dispatch (whose resumeSessionId comes from the sessions.ts
+   *  binding fed by done.sessionId) finds this window again. */
+  sessionId?: string;
+  usage?: Record<string, number | string>;
+}
+
+/** Per-turn delivery options — a projection of BackendRunOptions;
+ *  fields the current persistent adapters can't act on (bridge,
+ *  executionContext, …) stay on the one-shot path. */
+export interface PersistentSendOpts {
+  prompt: string;
+  cwd: string;
+  model?: string;
+  customArgs?: string[];
+  thinkingLevel?: 'off' | 'low' | 'high';
+  signal: AbortSignal;
+  onEvent: (e: LocalEvent) => void;
+  /** Activity clock (ms epoch of last non-idle event) shared with
+   *  the runner's idle heartbeat — adapters touch it through their
+   *  emitted events; the manager reads it for the idle watchdog. */
+  lastEventAt?: () => number;
+  /** Extra env the CLI process needs (provider credentials etc.).
+   *  Only applied when the window is (re)spawned, not on reuse —
+   *  per-turn env changes require a restart in practice. */
+  providerEnv?: Record<string, string>;
+}
+
+/** Why the current turn is being cancelled (manager watchdog or
+ *  user abort). Maps onto the terminal `done` status. */
+export type PersistentCancelReason = 'user' | 'timeout' | 'idle';
+
+/** One resident conversation window. Implementation owns the
+ *  underlying process/server + event translation; the manager owns
+ *  bookkeeping (reuse keying, idle reclaim, exit cleanup) and the
+ *  terminal `done` event. */
+export interface PersistentWindow {
+  readonly cli: LocalCliType;
+  /** Last CLI-reported conversation id. Undefined until the first
+   *  turn reports one. Used for reuse matching and crash recovery. */
+  readonly sessionId: string | undefined;
+  /** Milliseconds since epoch of the last completed turn. Managed
+   *  by the implementation (it knows when a turn truly ends); the
+   *  manager's sweeper reads it for idle reclaim. */
+  readonly lastActiveAt: number;
+  /** Whether the underlying process/server still exists. A window
+   *  that died is never reused — the manager drops it and recovers
+   *  through acquire(resumeSessionId). */
+  alive(): boolean;
+  /** Deliver one turn: emit process/translation events through
+   *  `opts.onEvent`, resolve with the terminal result. Must resolve
+   *  (never hang) once `cancelTurn` fires. Concurrent sends on the
+   *  same window are serialized by the manager. */
+  send(opts: PersistentSendOpts): Promise<PersistentTurnResult>;
+  /** Best-effort interruption of the in-flight turn (user abort /
+   *  watchdog). Implementations resolve the pending send with the
+   *  matching cancelled/timeout status. Safe to call when no turn
+   *  is in flight. */
+  cancelTurn(reason: PersistentCancelReason): void;
+  /** Tear the window down (kill process / release server session).
+   *  Idempotent. */
+  stop(): Promise<void>;
+}
+
+/** Arguments for opening a window. `resumeSessionId` present =
+ *  restore a known conversation (crash recovery, or the CLI's own
+ *  persistent store outliving our process); absent = fresh window. */
+export interface PersistentAcquireOpts {
+  binPath: string;
+  cwd: string;
+  /** Model for NEW windows — session-level in most CLIs (applied at
+   *  creation; existing windows keep their creation-time model). */
+  model?: string;
+  /** Reasoning-effort hint — also process-lifetime for resident
+   *  windows (backends with a concrete switch consume it at spawn). */
+  thinkingLevel?: 'off' | 'low' | 'high';
+  resumeSessionId?: string;
+  /** Custom-provider env — servers spawned per provider fingerprint
+   *  so a switch to different credentials never reuses a process
+   *  launched with the old ones. */
+  providerEnv?: Record<string, string>;
+  /** Window-lifetime event sink (process-info on spawn, lifecycle
+   *  logs). Turn-time events flow through send's onEvent instead. */
+  onEvent: (e: LocalEvent) => void;
+}
+
+/** Per-CLI adapter — the ONLY per-CLI code in the persistent
+ *  framework. Registered in persistent/index.ts. */
+export interface PersistentAdapter {
+  readonly cli: LocalCliType;
+  /** Probing/probing-missed CLIs or unverified channels declare
+   *  false — the wrapper transparently runs the one-shot backend. */
+  readonly supported: boolean;
+  /** Open (or restore) a window. Called by the manager on cache
+   *  miss only — must be safe to call concurrently for different
+   *  keys (the manager serializes per key through in-flight
+   *  promises). */
+  acquire(opts: PersistentAcquireOpts): Promise<PersistentWindow>;
+}
+
+/** Sentinel: the window's process died mid-turn. Distinguishes
+ *  "retry through acquire(resumeSessionId)" from ordinary turn
+ *  failures (which surface as status:'failed' results, not
+ *  throws). */
+export class WindowDiedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WindowDiedError';
+  }
+}

--- a/src/main/features/local_agents/sessions.ts
+++ b/src/main/features/local_agents/sessions.ts
@@ -8,6 +8,17 @@
  * after prior visible turns (for example cwd changed), group_chat may
  * bridge that transcript once into the fresh CLI session.
  *
+ * Persistent-runtime semantics (local_agents/persistent/): while a
+ * resident window for this binding is alive, context continuity
+ * lives in the WINDOW — the runner delivers each turn to it directly
+ * and this table is not consulted for history purposes at all. The
+ * stored id still matters: it is the recovery handle when the window
+ * dies (the manager re-opens the CLI conversation from it) and the
+ * reuse key matching a live window to the next dispatch. In other
+ * words resume has been demoted from a per-turn mechanism to a
+ * crash-recovery mechanism; the on-disk shape and read/write paths
+ * are unchanged.
+ *
  * Storage: `<uid>/local/cli-sessions/<cid>.json`, shape:
  *   { "<aid>": { "cli": "claude", "sessionId": "...", "updatedAt": "..." } }
  *

--- a/src/renderer/modules/chat-stream.js
+++ b/src/renderer/modules/chat-stream.js
@@ -142,20 +142,19 @@ function _csFirstArg(args, keys) {
 }
 
 function _csFmtDur(ms) {
-  const total = Math.max(1, Math.round((Number(ms) || 0) / 1000));
+  const total = Math.max(0, Math.floor((Number(ms) || 0) / 1000));
   if (total < 60) return `${total} 秒`;
   return `${Math.floor(total / 60)} 分 ${total % 60} 秒`;
 }
 
-/** 任务总耗时格式（子安 2026-09-08 需求）：「X分X.X秒」——本地发送时刻
- *  到本地收尾时刻的纯本地差值；分位为 0 时省略分；秒保留 1 位小数。 */
+/** 任务总耗时格式（子安 2026-09-09 修订）：整秒计数（「1 秒」「2 秒」，
+ *  不带小数位）——本地发送时刻到本地收尾时刻的纯本地差值；分位为 0 时
+ *  省略分。发送瞬间即显示「0 秒」起跳。 */
 function _csFmtTaskDur(ms) {
   const v = Math.max(0, Number(ms) || 0);
-  const sec = v / 1000;
-  if (sec < 60) return `${sec.toFixed(1)} 秒`;
-  const m = Math.floor(sec / 60);
-  const s = sec - m * 60;
-  return `${m} 分 ${s.toFixed(1)} 秒`;
+  const sec = Math.floor(v / 1000);
+  if (sec < 60) return `${sec} 秒`;
+  return `${Math.floor(sec / 60)} 分 ${sec % 60} 秒`;
 }
 
 // ── 活动流骨架（每回合一个，无外框；计时/收起徽章挂消息头） ────────────────
@@ -341,8 +340,22 @@ function _csEnsureFlow(cid, anchor, turnId, opts) {
   if (flow && (flow.isConnected || !!(anchor && anchor.contains && anchor.contains(flow)))) {
     return { flow, body: flow.querySelector('.cs-flow-body') };
   }
+  // 发送即起计的 pending 流接管（子安 2026-09-09 需求：计时器在发送
+  // 那一刻出现，不等模型首事件）：prewarm 建的流挂在同一 anchor 消息树
+  // 内、以占位 turnId 注册——真 turnId 的首条事件到达时迁移 key 并转正。
+  if (!flow && anchor) {
+    for (const [pendingKey, pendingFlow] of _csPanels.entries()) {
+      if (pendingFlow.dataset.csPending !== '1') continue;
+      if (!(anchor.contains && anchor.contains(pendingFlow))) continue;
+      _csPanels.delete(pendingKey);
+      pendingFlow.dataset.csPending = '';
+      pendingFlow.dataset.csTurn = turnId;
+      _csPanels.set(key, pendingFlow);
+      return { flow: pendingFlow, body: pendingFlow.querySelector('.cs-flow-body') };
+    }
+  }
   // 注册表残留清理（真机踩坑 2026-09-08）：同 key 的 disconnected 旧流
-  // 先从注册表移除，防止 size 膨胀与惰性清理误删活跃流；不调用
+  // 先从注册表移除，防止 size 膀胀与惰性清理误删活跃流；不调用
   // _csRemoveFlow（旧 DOM 已销毁，重复 remove 无害但多余）。
   if (flow) _csPanels.delete(key);
   flow = _csCreateFlow(cid, turnId, { ...opts, anchor });
@@ -805,25 +818,48 @@ function _csRenderInteractionCard(body, ev) {
   return card;
 }
 
-/** 回合收尾：时间线正文交回 conversation 原管道（markdown/结构块保留），
- *  流内文字段移除，正文回到消息气泡位。流宿主=消息元素。 */
+/** 回合收尾：时间线「开放段」（最终正文）交回 conversation 原管道
+ *  （markdown/结构块保留），流内文字段只移除开放段——已关闭段
+ *  （cs-closed=被工具/思考截断的中间叙述）保留在时间线里按原时序
+ *  展示（实机反馈 2026-09-09：展开执行过程只见工具调用，AI 的中间
+ *  叙述无处可见）。流宿主=消息元素。 */
 function _csFinalizePanelText(flow) {
-  const txt = flow.dataset.csText || '';
+  // 开放段（无 cs-closed 标记）= 回合收尾时仍未被截断的最后一段 =
+  // 最终正文；已关闭段是中间叙述，留在过程时间线。
+  const openSegs = [];
+  let openText = '';
+  for (const seg of Array.from(flow.querySelectorAll('.cs-text'))) {
+    if (seg.dataset.csClosed === '1') continue;
+    openText += String(seg.dataset.csSeg || '');
+    openSegs.push(seg);
+  }
   const anchor = flow.parentNode;
-  if (txt && anchor) {
+  // 收尾无开放段（最后动作是工具/思考、无最终叙述）时，对齐 bus 的
+  // 回退语义（final 分支：segmentText 空则正文取全文）——交回全部文字
+  // 段聚合并清空：实时与重放一致、正文与过程区不重复（否则实时气泡
+  // 空占位、重放却按 GroupMessage.text 显示全文，刷新即跳变）。
+  let handBack = openText;
+  let removeSegs = openSegs;
+  if (!openText) {
+    const all = Array.from(flow.querySelectorAll('.cs-text'));
+    if (all.length) {
+      handBack = all.map((s) => String(s.dataset.csSeg || '')).join('');
+      removeSegs = all;
+    }
+  }
+  if (handBack && anchor) {
     try {
       if (typeof _streamingAppendFinalDelta === 'function') {
-        _streamingAppendFinalDelta(anchor, txt);
+        _streamingAppendFinalDelta(anchor, handBack);
       } else {
         const finalEl = anchor.querySelector('[data-role="final"]');
-        if (finalEl) finalEl.textContent = txt;
+        if (finalEl) finalEl.textContent = handBack;
       }
     } catch (err) {
       _csLog.warn('timeline text hand-back failed', { error: String(err && err.message || err) });
     }
   }
-  for (const seg of Array.from(flow.querySelectorAll('.cs-text'))) seg.remove();
-  delete flow.dataset.csText;
+  for (const seg of removeSegs) seg.remove();
   // 恢复运行时隐藏的空气泡（正文已交回，气泡重新有内容）。
   if (flow.dataset.csBubbleHidden === '1') {
     const bubble = anchor && anchor.querySelector
@@ -873,19 +909,18 @@ window.chatStreamHandleEvent = function chatStreamHandleEvent(cid, anchor, chatE
       const { flow, body } = _csEnsureFlow(cid, anchor, turnId);
       if (kind === 'text') {
         // 时间线接管正文（边思考边说边执行的真实交错）：delta 追加到当前
-        // 文字段，遇其它 item 关段；全文聚合在 flow.dataset.csText，回合
-        // 收尾交回 conversation 原管道渲染（markdown/结构块不损失）。
+        // 文字段，遇其它 item 关段；回合收尾只把「开放段」（最终正文）
+        // 交回 conversation 原管道渲染（markdown/结构块不损失），已关闭
+        // 段（中间叙述）留在时间线按原时序展示。
         _csCloseThinkRow(body);
         const piece = String((payload && payload.delta) || '');
-        flow.dataset.csText = (flow.dataset.csText || '') + piece;
         const kids = body.children;
         const last = kids[kids.length - 1];
         let seg = (last && last.className && String(last.className).includes('cs-text')
           && last.dataset.csClosed !== '1') ? last : null;
         if (!seg) {
           // 投影器在工具行后会补发 '\n\n' 分隔 delta（供 markdown 段落分隔）；
-          // 时间线段剥掉段首空白（行间距已分隔），否则渲染出一块空行。聚合
-          // 文本（flow.dataset.csText）不受影响，交回后 markdown 仍需要它。
+          // 时间线段剥掉段首空白（行间距已分隔），否则渲染出一块空行。
           const lead = piece.replace(/^[ \t\r\n]+/, '');
           if (!lead && !piece.trim()) return;
           seg = document.createElement('div');
@@ -900,11 +935,38 @@ window.chatStreamHandleEvent = function chatStreamHandleEvent(cid, anchor, chatE
         return;
       }
       // 非文字 item：关闭当前文字段与思考行（下次各自新开段，保持交错）。
+      // 例外：usage 等收尾行不截断正文——与 bus flushTextSegmentForPersist
+      // 的截断语义对齐（只有工具/思考 flush；usage 后的叙述仍是最终段的
+      // 一部分）。否则最终段被 usage 关掉后收尾交不回气泡、正文困在过程区。
+      const cutsText = kind !== 'usage';
       const kids2 = body.children;
       const openSeg = kids2[kids2.length - 1];
-      if (openSeg && String(openSeg.className || '').includes('cs-text')) openSeg.dataset.csClosed = '1';
+      if (cutsText && openSeg && String(openSeg.className || '').includes('cs-text')) openSeg.dataset.csClosed = '1';
       if (kind === 'reasoning') {
-        _csAppendReasoning(body, String((payload && payload.text) || ''));
+        const rDelta = String((payload && payload.delta) || '');
+        const rFull = String((payload && payload.text) || '');
+        if (status === 'inProgress') {
+          // 思考实时流式（子安 2026-09-09 需求）：增量逐段落入思考行，
+          // 行自动展开——进行中就能看到推理进度，不等完成态折叠块。
+          if (rDelta) {
+            const row = _csAppendReasoning(body, rDelta);
+            row.classList.add('cs-open');
+          }
+          return;
+        }
+        // completed：与思考行已画内容做前缀去重——实时流此前已按 delta
+        // 画过（整段=已画前缀+尾部差额），只补差额防重复；重放无前置
+        // 增量，整段落入新行（历史 completed 条目无 inProgress 落盘）。
+        const kids3 = body.children;
+        const openThink = kids3[kids3.length - 1];
+        const liveThink = openThink && String(openThink.className || '').includes('cs-row-think')
+          && openThink.dataset.csClosed !== '1' ? openThink : null;
+        if (liveThink && rFull && rFull.startsWith(String(liveThink.dataset.csFull || ''))) {
+          const tail = rFull.slice(String(liveThink.dataset.csFull || '').length);
+          if (tail) _csAppendReasoning(body, tail);
+        } else {
+          _csAppendReasoning(body, rFull);
+        }
         return;
       }
       _csCloseThinkRow(body);
@@ -1071,6 +1133,20 @@ window.chatStreamHasPanel = function chatStreamHasPanel(cid) {
     if (flow.isConnected && key.startsWith(`${cid}::`)) return true;
   }
   return false;
+};
+
+/** 发送即起计（子安 2026-09-09 需求：计时器在用户点击发送那一刻立即
+ *  出现，不等模型首事件——首 token 前有数秒空窗）。以占位 turnId 建
+ *  pending 流（徽章+计时+loading 全套挂载），真 turnId 的首条事件到达
+ *  时由 _csEnsureFlow 迁移接管；发送失败无事件时 chatStreamFinalize
+ *  的 cid 兜底把它收尾为 cancelled，不泄漏。 */
+window.chatStreamPrewarm = function chatStreamPrewarm(cid, anchor, startedAtMs) {
+  if (!anchor) return;
+  const pendingTurnId = `pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const { flow } = _csEnsureFlow(cid, anchor, pendingTurnId, {
+    startedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : Date.now(),
+  });
+  if (flow) flow.dataset.csPending = '1';
 };
 
 /**

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -12463,6 +12463,18 @@ function _makeConvChatController(cid, options = {}) {
         if (msgEl && Number.isFinite(options.sendWallMs)) {
           msgEl.dataset.localSendMs = String(options.sendWallMs);
         }
+        // 发送即起计（子安 2026-09-09）：面板与计时器在发送这一刻创建
+        // 并开始走秒，不等模型首事件（首 token 前的数秒空窗里用户就有
+        // 「已发出、正在跑」的反馈）。预热失败不阻塞发送链路。
+        if (msgEl && typeof window.chatStreamPrewarm === 'function') {
+          try {
+            window.chatStreamPrewarm(
+              id,
+              msgEl,
+              Number.isFinite(options.sendWallMs) ? options.sendWallMs : Date.now(),
+            );
+          } catch (_) { /* prewarm best-effort */ }
+        }
         pendingConvs.set(id, {
           loadingEl: msgEl,
           needsIndicator: false,

--- a/test/main/features/chat_events/process-persist.test.ts
+++ b/test/main/features/chat_events/process-persist.test.ts
@@ -94,4 +94,26 @@ describe('process-persist collector', () => {
     }
     expect(c.entries.length).toBeLessThanOrEqual(201); // 200 上限 + 终态余量
   });
+
+  it('思考实时 inProgress 不落盘（重放只消费 completed 整段）', () => {
+    // 投影器 progress 分支逐段外发 inProgress reasoning（实时流式，
+    // 2026-09-09）——收集器必须过滤该形状：落盘会刷爆条目上限并与截断
+    // 冲刷的 completed 整段重复。
+    const c = createProcessCollector({ cid: 'c1', actorId: 'a1', turnId: 't6' });
+    c.feed({ type: 'progress', text: '正在' });
+    c.feed({ type: 'progress', text: '读取文件…' });
+    c.feed({ type: 'progress', text: '继续分析…' });
+    const inProgress = c.entries.filter(
+      (e) => e.type === 'chatItem' && (e.item as { kind?: string; status?: string }).kind === 'reasoning',
+    );
+    expect(inProgress).toHaveLength(0);
+    // 截断冲刷（工具事件）后 completed 整段落盘一次。
+    c.feed(toolEvent('start', 'tool-z', {}));
+    const completed = c.entries.filter(
+      (e) => e.type === 'chatItem' && (e.item as { kind?: string; status?: string }).kind === 'reasoning',
+    );
+    expect(completed).toHaveLength(1);
+    expect((completed[0].item as { status?: string }).status).toBe('completed');
+    expect((completed[0].item as { payload?: { text?: string } }).payload?.text).toBe('正在读取文件…继续分析…');
+  });
 });

--- a/test/main/features/chat_events/project-upstream.test.ts
+++ b/test/main/features/chat_events/project-upstream.test.ts
@@ -126,10 +126,14 @@ describe('projectUpstreamEvent', () => {
   it('progress 聚合为单条 reasoning 卡片（一次思考=一条，与一次工具调用等价）', () => {
     // 基数修正（2026-09-08）：连续 progress 聚合到同一思考段，被后续
     // 事件截断时整段落盘——不逐条铸卡（长思考洪泛曾挤掉工具记录）。
+    // 实时流式（2026-09-09）：每段 progress 额外产出 inProgress 增量
+    // （实时链路逐步可见）；持久化侧由收集器过滤，重放只消费 completed。
     const state = newState();
     const r1 = projectUpstreamEvent(state, { type: 'progress', text: '正在' });
-    expect(r1[1]).toBeUndefined(); // 攒段中，不即时输出
-    projectUpstreamEvent(state, { type: 'progress', text: '读取文件…' });
+    expect(r1[1]).toMatchObject({ kind: 'reasoning', status: 'inProgress', payload: { delta: '正在' } });
+    const r2 = projectUpstreamEvent(state, { type: 'progress', text: '读取文件…' });
+    // 续段不再重发 turn.started（仅首段 unshift），inProgress 就是 out[0]。
+    expect(r2[0]).toMatchObject({ kind: 'reasoning', status: 'inProgress', payload: { delta: '读取文件…' } });
     const cut = projectUpstreamEvent(state, { type: 'delta', text: '正文开始' });
     const reason = cut.find((e) => (e as { kind?: string }).kind === 'reasoning');
     expect(reason).toMatchObject({ kind: 'reasoning', status: 'completed', payload: { text: '正在读取文件…' } });

--- a/test/main/features/local_agents/claude_e2e.test.ts
+++ b/test/main/features/local_agents/claude_e2e.test.ts
@@ -4,6 +4,13 @@
  * that emits valid stream-json on stdout and then exits, then exercise
  * `claudeBackend.run` against it. On Windows the fixture is launched via
  * a .cmd shim, matching the npm-global CLI mechanism used in production.
+ *
+ * These fixtures pin the ONE-SHOT backend's behavior (message wording,
+ * exit-code mapping, cancel semantics), so they run with the persistent
+ * runtime switched off — that locked parity is itself the acceptance
+ * evidence for the COGSEED_PERSISTENT=0 fallback. The persistent duplex
+ * path has its own real-machine evidence suite
+ * (claude_persistent_e2e.test.ts).
  */
 
 import { describe, it, expect, beforeEach, afterAll } from 'vitest';
@@ -12,6 +19,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { claudeBackend } from '../../../../src/main/features/local_agents/backends/claude';
+
+process.env.COGSEED_PERSISTENT = '0';
 
 const isWindows = process.platform === 'win32';
 const TEST_NODE = process.env.COGSEED_TEST_NODE || process.execPath;

--- a/test/main/features/local_agents/claude_persistent_e2e.test.ts
+++ b/test/main/features/local_agents/claude_persistent_e2e.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Persistent claude runtime — REAL CLI evidence run.
+ *
+ * NOT a CI/regression test — real-machine acceptance for
+ * feat/persistent-cli-runtime phase 3 (stream-json duplex window).
+ * Requires a logged-in `claude` CLI. Set RUN_REAL_PERSISTENT_EVIDENCE=1.
+ *
+ * Acceptance coverage:
+ *   - one resident process across turns (single process-info, no
+ *     respawn on turn 2), context continuity inside the window;
+ *   - SIGKILL the process → next turn recovers (--resume rebuild)
+ *     and completes;
+ *   - COGSEED_PERSISTENT=0 → one-shot spawn path, no persistent
+ *     process-info.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { describe, it, expect } from 'vitest';
+import { claudeBackend } from '../../../../src/main/features/local_agents/backends/claude';
+import { getPersistentRuntimeManager } from '../../../../src/main/features/local_agents/persistent/manager';
+import type { LocalEvent } from '../../../../src/main/features/local_agents/backends/base';
+
+const describeIfLocal = process.env.CI || process.env.RUN_REAL_PERSISTENT_EVIDENCE !== '1' ? describe.skip : describe;
+const EVIDENCE_DIR = '/tmp/persistent-claude-evidence';
+const WORK_DIR = path.join(EVIDENCE_DIR, 'workdir');
+const TOKEN = `emerald-${Date.now().toString(36)}`;
+
+const doneOf = (events: LocalEvent[]) => events.find(e => e.type === 'done') as any;
+const textOf = (events: LocalEvent[]) =>
+  events.filter(e => e.type === 'text-delta').map((e: any) => e.text).join('');
+
+async function run(prompt: string, over: Record<string, unknown> = {}) {
+  const claudePath = execSync('which claude').toString().trim();
+  const events: LocalEvent[] = [];
+  const startedAt = Date.now();
+  await claudeBackend.run({
+    binPath: claudePath,
+    cwd: WORK_DIR,
+    prompt,
+    signal: new AbortController().signal,
+    onEvent: e => events.push(e),
+    timeoutMs: 180_000,
+    ...over,
+  } as any);
+  return { events, elapsedMs: Date.now() - startedAt };
+}
+
+describeIfLocal('persistent claude runtime: real CLI evidence', () => {
+  it('turn 2 reuses the duplex window: one spawn, context continuity', async () => {
+    fs.mkdirSync(WORK_DIR, { recursive: true });
+    delete process.env.COGSEED_PERSISTENT;
+
+    const r1 = await run(`Note for our conversation: my favorite color code is ${TOKEN}. Reply with exactly: OK`);
+    fs.writeFileSync(path.join(EVIDENCE_DIR, 'turn1.jsonl'), r1.events.map(e => JSON.stringify(e)).join('\n'));
+    const done1 = doneOf(r1.events);
+    expect(done1?.status).toBe('completed');
+    expect(typeof done1?.sessionId).toBe('string');
+    const sid = done1.sessionId as string;
+    const proc1 = r1.events.find(e => e.type === 'process-info') as any;
+    expect(proc1?.persistent).toBe(true);
+
+    const r2 = await run('In this conversation, what is my favorite color code? Reply with the code only.', { resumeSessionId: sid });
+    fs.writeFileSync(path.join(EVIDENCE_DIR, 'turn2.jsonl'), r2.events.map(e => JSON.stringify(e)).join('\n'));
+    const done2 = doneOf(r2.events);
+    expect(done2?.status).toBe('completed');
+    expect(r2.events.filter(e => e.type === 'process-info')).toHaveLength(0);
+    expect(textOf(r2.events) || String(done2?.output || '')).toContain(TOKEN);
+    fs.appendFileSync(
+      path.join(EVIDENCE_DIR, 'timing.txt'),
+      `claude persistent turn1 (cold window): ${r1.elapsedMs}ms\nclaude persistent turn2 (reused window): ${r2.elapsedMs}ms\n`,
+    );
+  }, 400_000);
+
+  it('switch OFF (COGSEED_PERSISTENT=0) behaves like today: one-shot spawn', async () => {
+    process.env.COGSEED_PERSISTENT = '0';
+    try {
+      const r = await run('Reply with exactly: PONG');
+      fs.writeFileSync(path.join(EVIDENCE_DIR, 'switch-off.jsonl'), r.events.map(e => JSON.stringify(e)).join('\n'));
+      expect(doneOf(r.events)?.status).toBe('completed');
+      const proc = r.events.find(e => e.type === 'process-info') as any;
+      expect(proc && proc.persistent).toBeFalsy();
+      fs.appendFileSync(path.join(EVIDENCE_DIR, 'timing.txt'), `claude one-shot (switch off): ${r.elapsedMs}ms\n`);
+    } finally {
+      delete process.env.COGSEED_PERSISTENT;
+    }
+  }, 400_000);
+
+  it('survives a process crash: next turn recovers and completes', async () => {
+    delete process.env.COGSEED_PERSISTENT;
+    const crashDir = path.join(EVIDENCE_DIR, 'crash-workdir');
+    fs.mkdirSync(crashDir, { recursive: true });
+    const r1 = await run('Reply with exactly: OK', { cwd: crashDir });
+    const done1 = doneOf(r1.events);
+    expect(done1?.status).toBe('completed');
+    const sid = done1.sessionId as string;
+    const pid = (r1.events.find(e => e.type === 'process-info') as any)?.pid as number;
+    expect(typeof pid).toBe('number');
+
+    process.kill(pid, 'SIGKILL');
+    await new Promise(r => setTimeout(r, 500));
+
+    const r2 = await run('Reply with exactly: ALIVE', { cwd: crashDir, resumeSessionId: sid });
+    fs.writeFileSync(path.join(EVIDENCE_DIR, 'crash-recovery.jsonl'), r2.events.map(e => JSON.stringify(e)).join('\n'));
+    const done2 = doneOf(r2.events);
+    expect(done2?.status).toBe('completed');
+    const proc2 = r2.events.find(e => e.type === 'process-info') as any;
+    expect(proc2?.persistent).toBe(true);
+    expect(proc2?.pid).not.toBe(pid);
+
+    getPersistentRuntimeManager().shutdownAll();
+  }, 400_000);
+});

--- a/test/main/features/local_agents/opencode_persistent_e2e.test.ts
+++ b/test/main/features/local_agents/opencode_persistent_e2e.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Persistent opencode runtime — REAL CLI evidence run.
+ *
+ * NOT a CI/regression test — real-machine acceptance for
+ * feat/persistent-cli-runtime phase 2. Requires a real, logged-in
+ * `opencode` CLI. Set RUN_REAL_PERSISTENT_EVIDENCE=1 to opt in.
+ *
+ * Acceptance coverage:
+ *   a. same conversation: turn 2+ does NOT respawn (single
+ *      persistent process-info, same pid);
+ *   c. COGSEED_PERSISTENT=0 → behavior identical to today (one-shot
+ *      spawn path, no persistent process-info);
+ *   d. killing the serve process mid-conversation: the next turn
+ *      recovers (server restart, session resumed or rebuilt) and the
+ *      turn itself completes;
+ *   + context continuity inside the window (turn 2 recalls turn 1);
+ *   + wall-clock comparison one-shot vs persistent turn 2.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { describe, it, expect, afterEach } from 'vitest';
+import { opencodeBackend } from '../../../../src/main/features/local_agents/backends/opencode';
+import { getPersistentRuntimeManager } from '../../../../src/main/features/local_agents/persistent/manager';
+import type { LocalEvent } from '../../../../src/main/features/local_agents/backends/base';
+
+const describeIfLocal = process.env.CI || process.env.RUN_REAL_PERSISTENT_EVIDENCE !== '1' ? describe.skip : describe;
+const MODEL = process.env.PERSISTENT_EVIDENCE_MODEL || 'opencode-go/deepseek-v4-flash';
+const EVIDENCE_DIR = '/tmp/persistent-opencode-evidence';
+const WORK_DIR = path.join(EVIDENCE_DIR, 'workdir');
+
+const TOKEN = `alpha-${Date.now().toString(36)}`;
+
+function collect(): { events: LocalEvent[]; onEvent: (e: LocalEvent) => void } {
+  const events: LocalEvent[] = [];
+  return { events, onEvent: e => events.push(e) };
+}
+
+const doneOf = (events: LocalEvent[]) => events.find(e => e.type === 'done') as any;
+const textOf = (events: LocalEvent[]) =>
+  events.filter(e => e.type === 'text-delta').map((e: any) => e.text).join('');
+
+async function run(prompt: string, over: Record<string, unknown> = {}) {
+  const opencodePath = execSync('which opencode').toString().trim();
+  const { events, onEvent } = collect();
+  const startedAt = Date.now();
+  await opencodeBackend.run({
+    binPath: opencodePath,
+    cwd: WORK_DIR,
+    prompt,
+    model: MODEL,
+    signal: new AbortController().signal,
+    onEvent,
+    timeoutMs: 120_000,
+    ...over,
+  } as any);
+  return { events, elapsedMs: Date.now() - startedAt };
+}
+
+describeIfLocal('persistent opencode runtime: real CLI evidence', () => {
+  afterEach(() => {
+    fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  });
+
+  it('turn 2 reuses the window: one spawn, context continuity, faster', async () => {
+    fs.mkdirSync(WORK_DIR, { recursive: true });
+    delete process.env.COGSEED_PERSISTENT;
+
+    const r1 = await run(`Remember this secret token for later: ${TOKEN}. Reply with exactly: OK`);
+    fs.writeFileSync(path.join(EVIDENCE_DIR, 'turn1.jsonl'), r1.events.map(e => JSON.stringify(e)).join('\n'));
+    const done1 = doneOf(r1.events);
+    expect(done1?.status).toBe('completed');
+    expect(typeof done1?.sessionId).toBe('string');
+    const sid = done1.sessionId as string;
+    const proc1 = r1.events.find(e => e.type === 'process-info') as any;
+    expect(proc1?.persistent).toBe(true);
+
+    const r2 = await run('What was the secret token I gave you? Reply with the token only.', { resumeSessionId: sid });
+    fs.writeFileSync(path.join(EVIDENCE_DIR, 'turn2.jsonl'), r2.events.map(e => JSON.stringify(e)).join('\n'));
+    const done2 = doneOf(r2.events);
+    expect(done2?.status).toBe('completed');
+    // (a) no respawn on the reused turn: no second process-info.
+    const procInfos = r2.events.filter(e => e.type === 'process-info');
+    expect(procInfos).toHaveLength(0);
+    // context continuity inside the window.
+    expect(textOf(r2.events) || String(done2?.output || '')).toContain(TOKEN);
+    // timing evidence (informational, not a hard gate).
+    fs.appendFileSync(
+      path.join(EVIDENCE_DIR, 'timing.txt'),
+      `persistent turn1 (cold window): ${r1.elapsedMs}ms\npersistent turn2 (reused window): ${r2.elapsedMs}ms\n`,
+    );
+  }, 300_000);
+
+  it('switch OFF (COGSEED_PERSISTENT=0) behaves like today: one-shot spawn', async () => {
+    process.env.COGSEED_PERSISTENT = '0';
+    try {
+      const r = await run('Reply with exactly: PONG');
+      fs.writeFileSync(path.join(EVIDENCE_DIR, 'switch-off.jsonl'), r.events.map(e => JSON.stringify(e)).join('\n'));
+      const done = doneOf(r.events);
+      expect(done?.status).toBe('completed');
+      // one-shot path: process-info WITHOUT the persistent marker.
+      const proc = r.events.find(e => e.type === 'process-info') as any;
+      expect(proc && proc.persistent).toBeFalsy();
+      fs.appendFileSync(path.join(EVIDENCE_DIR, 'timing.txt'), `one-shot (switch off): ${r.elapsedMs}ms\n`);
+    } finally {
+      delete process.env.COGSEED_PERSISTENT;
+    }
+  }, 300_000);
+
+  it('survives a serve crash: next turn recovers and completes', async () => {
+    delete process.env.COGSEED_PERSISTENT;
+    // Fresh cwd → fresh server, so this turn carries its own
+    // process-info (the shared-cwd server from case 1 is reused and
+    // wouldn't re-emit one).
+    const crashDir = path.join(EVIDENCE_DIR, 'crash-workdir');
+    fs.mkdirSync(crashDir, { recursive: true });
+    const r1 = await run('Reply with exactly: OK', { cwd: crashDir });
+    const done1 = doneOf(r1.events);
+    expect(done1?.status).toBe('completed');
+    const sid = done1.sessionId as string;
+    const pid = (r1.events.find(e => e.type === 'process-info') as any)?.pid as number;
+    expect(typeof pid).toBe('number');
+
+    // Kill the resident server outright.
+    process.kill(pid, 'SIGKILL');
+    await new Promise(r => setTimeout(r, 500));
+
+    const r2 = await run('Reply with exactly: ALIVE', { cwd: crashDir, resumeSessionId: sid });
+    fs.writeFileSync(path.join(EVIDENCE_DIR, 'crash-recovery.jsonl'), r2.events.map(e => JSON.stringify(e)).join('\n'));
+    const done2 = doneOf(r2.events);
+    // (d) the turn is not lost: completed, with a fresh process-info
+    // for the restarted server.
+    expect(done2?.status).toBe('completed');
+    const proc2 = r2.events.find(e => e.type === 'process-info') as any;
+    expect(proc2?.persistent).toBe(true);
+    expect(proc2?.pid).not.toBe(pid);
+
+    getPersistentRuntimeManager().shutdownAll();
+  }, 300_000);
+});

--- a/test/main/features/local_agents/persistent-manager.test.ts
+++ b/test/main/features/local_agents/persistent-manager.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { BackendRunOptions, LocalBackend, LocalEvent } from '../../../../src/main/features/local_agents/backends/base.js';
+import type { LocalCliType } from '../../../../src/main/features/local_agents/registry.js';
+import {
+  PersistentRuntimeManager,
+  persistentEnabled,
+  resolveIdleReclaimMs,
+} from '../../../../src/main/features/local_agents/persistent/manager.js';
+import {
+  WindowDiedError,
+  type PersistentAdapter,
+  type PersistentCancelReason,
+  type PersistentWindow,
+  type PersistentSendOpts,
+  type PersistentTurnResult,
+} from '../../../../src/main/features/local_agents/persistent/types.js';
+
+// ── fakes ────────────────────────────────────────────────────────────────
+
+/** Global sid sequence so revived windows report fresh ids the same
+ *  way real CLIs do (claude forks a new sid on --resume, opencode
+ *  keeps its own; both diverge from the pre-crash value). */
+let globalSidSeq = 0;
+
+class FakeWindow implements PersistentWindow {
+  readonly cli: LocalCliType = 'claude';
+  sessionId: string | undefined;
+  lastActiveAt = Date.now();
+  private aliveFlag = true;
+  stopped = false;
+  readonly sendCalls: string[] = [];
+  readonly cancelReasons: PersistentCancelReason[] = [];
+  /** per-send behavior, consumed in order; last entry repeats. */
+  script: Array<'ok' | 'die' | 'fail' | 'hang'> = ['ok'];
+  /** concurrency probe: max simultaneous in-flight sends. */
+  maxConcurrent = 0;
+  private inFlight = 0;
+  private hangResolvers: Array<(r: PersistentTurnResult) => void> = [];
+
+  alive(): boolean { return this.aliveFlag; }
+
+  async send(opts: PersistentSendOpts): Promise<PersistentTurnResult> {
+    this.inFlight += 1;
+    this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
+    const behavior = this.script[Math.min(this.sendCalls.length, this.script.length - 1)];
+    this.sendCalls.push(opts.prompt);
+    try {
+      if (behavior === 'die') {
+        this.aliveFlag = false;
+        throw new WindowDiedError('process exited unexpectedly');
+      }
+      if (behavior === 'fail') {
+        return { status: 'failed', error: 'turn failed' };
+      }
+      if (behavior === 'hang') {
+        return new Promise<PersistentTurnResult>(resolve => { this.hangResolvers.push(resolve); });
+      }
+      globalSidSeq += 1;
+      this.sessionId = `sid-${globalSidSeq}`;
+      this.lastActiveAt = Date.now();
+      opts.onEvent({ type: 'text-delta', text: 'hi' });
+      return { status: 'completed', output: `ok:${opts.prompt}`, sessionId: this.sessionId, usage: { input: 1 } };
+    } finally {
+      this.inFlight -= 1;
+    }
+  }
+
+  cancelTurn(reason: PersistentCancelReason): void {
+    this.cancelReasons.push(reason);
+    for (const resolve of this.hangResolvers.splice(0)) {
+      resolve({ status: reason === 'user' ? 'cancelled' : 'timeout' });
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.aliveFlag = false;
+  }
+}
+
+class FakeAdapter implements PersistentAdapter {
+  readonly cli: LocalCliType = 'claude';
+  supported = true;
+  acquireCalls = 0;
+  /** resumeSessionId each acquire received, in order. */
+  readonly acquireResumeArgs: Array<string | undefined> = [];
+  readonly windows: FakeWindow[] = [];
+  /** per-acquire script, consumed in order; last entry repeats. */
+  acquireScript: Array<Array<'ok' | 'die' | 'fail' | 'hang'>> = [];
+
+  async acquire(opts: { binPath: string; cwd: string; resumeSessionId?: string; onEvent: (e: LocalEvent) => void }): Promise<PersistentWindow> {
+    this.acquireCalls += 1;
+    this.acquireResumeArgs.push(opts.resumeSessionId);
+    const w = new FakeWindow();
+    w.script = this.acquireScript[Math.min(this.acquireCalls - 1, this.acquireScript.length - 1)] ?? ['ok'];
+    if (opts.resumeSessionId) w.sessionId = opts.resumeSessionId;
+    this.windows.push(w);
+    opts.onEvent({ type: 'process-info', pid: 100 + this.acquireCalls, cwd: opts.cwd, cmd: opts.binPath, args: [] });
+    return w;
+  }
+}
+
+function makeFallback(runs: string[]): LocalBackend {
+  return {
+    async run(opts: BackendRunOptions): Promise<void> {
+      runs.push(opts.prompt);
+      opts.onEvent({ type: 'done', status: 'completed', output: `fallback:${opts.prompt}` });
+    },
+  };
+}
+
+function makeOpts(events: LocalEvent[], over: Partial<BackendRunOptions> = {}): BackendRunOptions {
+  return {
+    binPath: '/bin/claude',
+    prompt: 'p1',
+    cwd: '/w',
+    signal: new AbortController().signal,
+    onEvent: e => events.push(e),
+    timeoutMs: 5_000,
+    ...over,
+  };
+}
+
+function doneEvents(events: LocalEvent[]): LocalEvent[] {
+  return events.filter(e => e.type === 'done');
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+// ── env switches ─────────────────────────────────────────────────────────
+
+describe('persistent env switches', () => {
+  it('defaults to enabled; COGSEED_PERSISTENT=0 disables', () => {
+    expect(persistentEnabled({})).toBe(true);
+    expect(persistentEnabled({ COGSEED_PERSISTENT: '1' })).toBe(true);
+    expect(persistentEnabled({ COGSEED_PERSISTENT: '0' })).toBe(false);
+    expect(persistentEnabled({ COGSEED_PERSISTENT: ' 0 ' })).toBe(false);
+  });
+
+  it('idle reclaim defaults to 10min; env overrides; <=0 not forced', () => {
+    expect(resolveIdleReclaimMs({})).toBe(10 * 60 * 1000);
+    expect(resolveIdleReclaimMs({ COGSEED_PERSISTENT_IDLE_MS: '1234' })).toBe(1234);
+    expect(resolveIdleReclaimMs({ COGSEED_PERSISTENT_IDLE_MS: 'abc' })).toBe(10 * 60 * 1000);
+  });
+});
+
+// ── lifecycle ────────────────────────────────────────────────────────────
+
+describe('PersistentRuntimeManager lifecycle', () => {
+  let events: LocalEvent[];
+  let adapter: FakeAdapter;
+  let fallbackRuns: string[];
+  let fallback: LocalBackend;
+  let mgr: PersistentRuntimeManager;
+
+  beforeEach(() => {
+    globalSidSeq = 0;
+    events = [];
+    adapter = new FakeAdapter();
+    fallbackRuns = [];
+    fallback = makeFallback(fallbackRuns);
+    mgr = new PersistentRuntimeManager({}, 10);
+  });
+
+  it('lazily starts: nothing acquired until the first dispatch', async () => {
+    expect(mgr.size).toBe(0);
+    expect(adapter.acquireCalls).toBe(0);
+  });
+
+  it('reuses the live window across turns with the same resumeSessionId', async () => {
+    await mgr.run(makeOpts(events), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(1);
+    const firstDone = doneEvents(events)[0] as any;
+    expect(firstDone.status).toBe('completed');
+    expect(firstDone.sessionId).toBe('sid-1');
+
+    events.length = 0;
+    await mgr.run(makeOpts(events, { resumeSessionId: 'sid-1', prompt: 'p2' }), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(1);                 // no second spawn
+    expect(adapter.windows[0].sendCalls).toEqual(['p1', 'p2']);
+    const reusedLog = events.find(e => e.type === 'log' && String((e as any).message).includes('reused'));
+    expect(reusedLog).toBeTruthy();                        // reuse is log-provable
+    expect(doneEvents(events)).toHaveLength(1);
+    expect(fallbackRuns).toEqual([]);
+  });
+
+  it('opens a fresh window for a first turn (no resumeSessionId) even when one is live', async () => {
+    await mgr.run(makeOpts(events), adapter, fallback);                    // agent A first turn
+    await mgr.run(makeOpts(events, { prompt: 'pB' }), adapter, fallback);  // agent B first turn
+    expect(adapter.acquireCalls).toBe(2);
+    expect(adapter.windows).toHaveLength(2);
+    expect(adapter.windows[0].sendCalls).toEqual(['p1']);
+    expect(adapter.windows[1].sendCalls).toEqual(['pB']);
+  });
+
+  it('re-keys the window onto the CLI-reported session id', async () => {
+    await mgr.run(makeOpts(events), adapter, fallback);
+    expect(mgr._keysForTest()).toContain('claude::/w::sid-1');
+    expect(mgr._keysForTest().some(k => k.includes('@fresh'))).toBe(false);
+  });
+
+  it('emits exactly one terminal done per dispatch with sessionId/usage', async () => {
+    await mgr.run(makeOpts(events), adapter, fallback);
+    const dones = doneEvents(events);
+    expect(dones).toHaveLength(1);
+    expect((dones[0] as any).sessionId).toBe('sid-1');
+    expect((dones[0] as any).usage).toEqual({ input: 1 });
+    expect((dones[0] as any).durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('forwards turn status failures through done without recovery', async () => {
+    adapter.acquireScript = [['fail']];
+    await mgr.run(makeOpts(events), adapter, fallback);
+    const done = doneEvents(events)[0] as any;
+    expect(done.status).toBe('failed');
+    expect(done.error).toBe('turn failed');
+    expect(fallbackRuns).toEqual([]);   // ordinary failures are NOT fallback-worthy
+  });
+
+  it('recovers a dead window by re-acquiring once, then falls back if that fails', async () => {
+    // Both the first and the revived window die mid-turn → fallback runs the turn.
+    adapter.acquireScript = [['die'], ['die']];
+    await mgr.run(makeOpts(events), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(2);
+    expect(fallbackRuns).toEqual(['p1']);
+    expect(mgr.size).toBe(0);
+  });
+
+  it('recovers a dead window successfully on the retry', async () => {
+    adapter.acquireScript = [['die'], ['ok']];
+    await mgr.run(makeOpts(events), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(2);
+    expect(fallbackRuns).toEqual([]);
+    const done = doneEvents(events)[0] as any;
+    expect(done.status).toBe('completed');
+    expect(done.sessionId).toBe('sid-1');   // revived window reports fresh sid; manager re-keys
+  });
+
+  it('restores from the last known session id when reviving', async () => {
+    // First turn OK (sid-1). Second turn the reused window dies — revival
+    // must pass resumeSessionId=sid-1 into acquire.
+    adapter.acquireScript = [['ok'], ['ok']];
+    await mgr.run(makeOpts(events), adapter, fallback);
+    adapter.windows[0].script = ['ok', 'die'];   // reused window dies on turn 2
+    await mgr.run(makeOpts(events, { resumeSessionId: 'sid-1', prompt: 'p2' }), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(2);
+    // the recovery acquire got the resume handle
+    expect(adapter.acquireResumeArgs[1]).toBe('sid-1');
+    const done = doneEvents(events)[1] as any;
+    expect(done.status).toBe('completed');
+    expect(done.sessionId).toBe('sid-2');
+  });
+
+  it('serializes concurrent sends on the same window', async () => {
+    adapter.acquireScript = [['ok']];
+    await mgr.run(makeOpts(events), adapter, fallback);  // establishes sid-1
+    await Promise.all([
+      mgr.run(makeOpts(events, { resumeSessionId: 'sid-1', prompt: 'a' }), adapter, fallback),
+      mgr.run(makeOpts(events, { resumeSessionId: 'sid-1', prompt: 'b' }), adapter, fallback),
+    ]);
+    expect(adapter.acquireCalls).toBe(1);
+    expect(adapter.windows[0].maxConcurrent).toBe(1);
+    expect(adapter.windows[0].sendCalls.slice(1).sort()).toEqual(['a', 'b']);
+  });
+
+  it('idle-reclaims idle windows but never a busy one', async () => {
+    const m = new PersistentRuntimeManager({ COGSEED_PERSISTENT_IDLE_MS: '30' }, 5);
+    await m.run(makeOpts(events), adapter, fallback);
+    const win = adapter.windows[0];
+    expect(win.stopped).toBe(false);
+    await sleep(80);
+    expect(win.stopped).toBe(true);
+    expect(m.size).toBe(0);
+
+    // Busy windows are exempt: a hanging turn keeps the window alive.
+    events.length = 0;
+    adapter.acquireScript = [['ok'], ['hang']];
+    const hanging = m.run(
+      makeOpts(events, { resumeSessionId: 'sid-1', prompt: 'p2', timeoutMs: 60_000 }),
+      adapter, fallback,
+    );
+    await sleep(80);
+    expect(m.size).toBe(1);          // still there — in-flight turn
+    adapter.windows[1].cancelTurn('user');
+    await hanging;
+    await sleep(80);
+    expect(m.size).toBe(0);          // reclaimed after the turn ended
+    m.shutdownAll();
+  });
+
+  it('wall-clock watchdog cancels the turn with status timeout', async () => {
+    await mgr.run(makeOpts(events), adapter, fallback);
+    adapter.windows[0].script = ['ok', 'hang'];   // reused window hangs on turn 2
+    events.length = 0;
+    await mgr.run(
+      makeOpts(events, { resumeSessionId: 'sid-1', prompt: 'p2', timeoutMs: 60 }),
+      adapter, fallback,
+    );
+    const done = doneEvents(events)[0] as any;
+    expect(done.status).toBe('timeout');
+    expect(adapter.windows[0].cancelReasons).toContain('timeout');
+  });
+
+  it('user abort cancels the turn with status cancelled', async () => {
+    const ac = new AbortController();
+    adapter.acquireScript = [['hang']];
+    const p = mgr.run(makeOpts(events, { signal: ac.signal, timeoutMs: 60_000 }), adapter, fallback);
+    await sleep(20);
+    ac.abort();
+    await p;
+    const done = doneEvents(events)[0] as any;
+    expect(done.status).toBe('cancelled');
+    expect(adapter.windows[0].cancelReasons).toContain('user');
+  });
+
+  it('idle watchdog cancels a silent turn', async () => {
+    await mgr.run(makeOpts(events), adapter, fallback);
+    adapter.windows[0].script = ['ok', 'hang'];   // reused window goes silent on turn 2
+    events.length = 0;
+    const lastEventAt = Date.now();
+    await mgr.run(
+      makeOpts(events, {
+        resumeSessionId: 'sid-1', prompt: 'p2', timeoutMs: 60_000,
+        idleKillMs: 50, lastEventAt: () => lastEventAt,
+      }),
+      adapter, fallback,
+    );
+    const done = doneEvents(events)[0] as any;
+    expect(done.status).toBe('timeout');
+    expect(adapter.windows[0].cancelReasons).toContain('idle');
+  });
+
+  it('drops a dead window instead of reusing it', async () => {
+    await mgr.run(makeOpts(events), adapter, fallback);
+    const win = adapter.windows[0];
+    (win as any).stopped = false;
+    // simulate process death between turns
+    await win.stop();
+    events.length = 0;
+    await mgr.run(makeOpts(events, { resumeSessionId: 'sid-1', prompt: 'p2' }), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(2);  // dead hit dropped, fresh acquire
+  });
+
+  it('COGSEED_PERSISTENT=0 routes everything to the one-shot backend', async () => {
+    const m = new PersistentRuntimeManager({ COGSEED_PERSISTENT: '0' }, 10);
+    await m.run(makeOpts(events), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(0);
+    expect(fallbackRuns).toEqual(['p1']);
+  });
+
+  it('an unsupported adapter runs the one-shot backend', async () => {
+    adapter.supported = false;
+    await mgr.run(makeOpts(events), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(0);
+    expect(fallbackRuns).toEqual(['p1']);
+  });
+
+  it('shutdownAll stops every window and disables the manager', async () => {
+    await mgr.run(makeOpts(events), adapter, fallback);
+    expect(mgr.size).toBe(1);
+    mgr.shutdownAll();
+    expect(adapter.windows[0].stopped).toBe(true);
+    expect(mgr.size).toBe(0);
+    // Post-shutdown dispatches go straight to the fallback.
+    await mgr.run(makeOpts(events, { resumeSessionId: 'sid-1' }), adapter, fallback);
+    expect(adapter.acquireCalls).toBe(1);
+    expect(fallbackRuns).toEqual(['p1']);
+  });
+});

--- a/test/main/features/p3394_bridge/gateway-models-probe.test.ts
+++ b/test/main/features/p3394_bridge/gateway-models-probe.test.ts
@@ -494,6 +494,101 @@ describe('gateway probeConfigModels — declared-config enumeration (hermes/open
     expect(result.current).toBe('example-model-2.5-flash');
   });
 
+  it('claude config enumeration reads settings.json env slots, dedupes, strips ctx suffixes (2026-09-09 实机)', () => {
+    // 自定义模型网关部署：全家模型映射进槽位变量，init/列表探测只披露
+    // current——完整清单以 settings.json 为事实源。样例只含模型变量
+    //（真实配置的鉴权字段与枚举无关，不进测试）。
+    const CLAUDE_SETTINGS = JSON.stringify({
+      env: {
+        ANTHROPIC_MODEL: 'deepseek-v4-pro',
+        ANTHROPIC_DEFAULT_OPUS_MODEL: 'deepseek-v4-flash-vision-exp[1M]',
+        ANTHROPIC_DEFAULT_OPUS_MODEL_NAME: 'deepseek-v4-flash-vision-exp',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'deepseek-v4-flash-vision-exp[1M]',
+        ANTHROPIC_DEFAULT_SONNET_MODEL_NAME: 'deepseek-v4-flash-vision-exp',
+        ANTHROPIC_DEFAULT_FABLE_MODEL: 'deepseek-v4-flash-vision-exp[1M]',
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: 'deepseek-v4-flash',
+      },
+    });
+    const fakeHome = path.join(os.tmpdir(), 'p3394-model-probe-claude-home');
+    const result = probeConfigModels({
+      configModels: 'claude',
+      env: { HOME: fakeHome },
+      readFileSync: (p: string) => {
+        if (p === path.join(fakeHome, '.claude', 'settings.json')) return CLAUDE_SETTINGS;
+        throw new Error('ENOENT: ' + p);
+      },
+    }) as { status: string; current: string; models: Array<{ id: string }> };
+    expect(result.status).toBe('ready');
+    // 三槽位同模型去重 + [1M] 上下文后缀剥除 + 默认槽位最前。
+    expect(result.models.map((m) => m.id)).toEqual([
+      'deepseek-v4-pro',
+      'deepseek-v4-flash-vision-exp',
+      'deepseek-v4-flash',
+    ]);
+    expect(result.current).toBe('deepseek-v4-pro');
+  });
+
+  it('claude config enumeration degrades honestly without model slots', () => {
+    const EMPTY_SETTINGS = JSON.stringify({ env: { ANTHROPIC_BASE_URL: 'https://example.invalid' } });
+    const fakeHome = path.join(os.tmpdir(), 'p3394-model-probe-claude-empty');
+    const result = probeConfigModels({
+      configModels: 'claude',
+      env: { HOME: fakeHome },
+      readFileSync: () => EMPTY_SETTINGS,
+    }) as { status: string; reason: string };
+    expect(result.status).toBe('unavailable');
+    expect(result.reason).toBe('config_no_models');
+  });
+
+  it('gemini config enumeration: current from settings.json + official series deduped (2026-09-09 全量补全)', () => {
+    const result = probeConfigModels({
+      configModels: 'gemini',
+      env: { HOME: '/tmp/nope' },
+      readFileSync: (p: string) => {
+        if (p.endsWith('.gemini/settings.json')) return JSON.stringify({ model: { name: 'gemini-2.5-flash' } });
+        throw new Error('ENOENT: ' + p);
+      },
+    }) as { status: string; current: string; models: Array<{ id: string }> };
+    expect(result.status).toBe('ready');
+    // 配置里的当前模型置顶，官方常规模型去重补底。
+    expect(result.models.map((m) => m.id)).toEqual([
+      'gemini-2.5-flash',
+      'gemini-2.5-pro',
+      'gemini-2.5-flash-lite',
+    ]);
+    expect(result.current).toBe('gemini-2.5-flash');
+  });
+
+  it('aider config enumeration: model.settings.yml entries + conf current first (2026-09-09 全量补全)', () => {
+    const result = probeConfigModels({
+      configModels: 'aider',
+      env: { HOME: '/tmp/nope' },
+      readFileSync: (p: string) => {
+        if (p.endsWith('.aider.model.settings.yml')) return '- name: deepseek-chat\n  extra: x\n- name: gpt-5\n';
+        if (p.endsWith('.aider.conf.yml')) return 'model: deepseek-chat\n';
+        throw new Error('ENOENT: ' + p);
+      },
+    }) as { status: string; current: string; models: Array<{ id: string }> };
+    expect(result.status).toBe('ready');
+    expect(result.models.map((m) => m.id)).toEqual(['deepseek-chat', 'gpt-5']);
+    expect(result.current).toBe('deepseek-chat');
+  });
+
+  it('codex config enumeration: top-level model current + profiles bindings (2026-09-09 全量补全)', () => {
+    const result = probeConfigModels({
+      configModels: 'codex',
+      env: { HOME: '/tmp/nope' },
+      readFileSync: (p: string) => {
+        if (p.endsWith('config.toml')) return 'model = "gpt-5-codex"\nmodel_provider = "openai"\n\n[profiles.fast]\nmodel = "gpt-5-mini"\n\n[profiles.think]\nmodel = "gpt-5"\n';
+        throw new Error('ENOENT: ' + p);
+      },
+    }) as { status: string; current: string; models: Array<{ id: string }> };
+    expect(result.status).toBe('ready');
+    // 顶层默认置顶（current），[profiles.*] 绑定枚举成清单。
+    expect(result.models.map((m) => m.id)).toEqual(['gpt-5-codex', 'gpt-5-mini', 'gpt-5']);
+    expect(result.current).toBe('gpt-5-codex');
+  });
+
   it('returns no_config_probe for unknown config keys', () => {
     const unknown = probeConfigModels({ configModels: 'nope', env: {}, readFileSync: () => '' }) as { status: string; reason: string };
     expect(unknown.status).toBe('unavailable');

--- a/test/renderer/chat-stream.test.ts
+++ b/test/renderer/chat-stream.test.ts
@@ -136,6 +136,17 @@ function makeEl(tag: string): StubEl {
       };
       return walk(el);
     },
+    contains(node) {
+      // DOM contains 语义（含自身）：prewarm 迁移判定依赖它。
+      if (node === el) return true;
+      const walk = (n: StubEl): boolean => {
+        for (const child of n.children) {
+          if (child === node || walk(child)) return true;
+        }
+        return false;
+      };
+      return walk(el);
+    },
     remove() {
       el.connected = false;
       if (el.parentNode && Array.isArray(el.parentNode.children)) {
@@ -324,6 +335,49 @@ describe('chat-stream module', () => {
     expect(thinks[0].innerHTML).toContain('持续了');
   });
 
+  it('思考实时流式（2026-09-09）：inProgress 增量逐段落入且行自动展开，completed 前缀去重不重复', () => {
+    handle({ type: 'chat.turn.started', turnId: 'T1', cid: 'c-1', actorId: 'a', startedAt: '' });
+    const flow = inserts[0].node;
+    handle({ type: 'chat.item', turnId: 'T1', itemId: 'r1', kind: 'reasoning', status: 'inProgress', payload: { delta: '正在' } });
+    handle({ type: 'chat.item', turnId: 'T1', itemId: 'r1', kind: 'reasoning', status: 'inProgress', payload: { delta: '读取文件…' } });
+    const body = bodyOf(flow);
+    let thinks = body.children.filter((c) => String(c.className).includes('cs-row-think'));
+    expect(thinks).toHaveLength(1);
+    // 进行中：增量聚合完整可见，且行自动展开（同步看到推理进度）。
+    expect(thinks[0].dataset.csFull).toBe('正在读取文件…');
+    expect(String(thinks[0].className)).toContain('cs-open');
+    // completed 整段（=已画前缀，无尾部差额）：不重复落入。
+    handle({ type: 'chat.item', turnId: 'T1', itemId: 'r1', kind: 'reasoning', status: 'completed', payload: { text: '正在读取文件…' } });
+    thinks = body.children.filter((c) => String(c.className).includes('cs-row-think'));
+    expect(thinks).toHaveLength(1);
+    expect(thinks[0].dataset.csFull).toBe('正在读取文件…');
+    // completed 带尾部差额（实时流只画到一半的补齐场景）：只补差额。
+    handle({ type: 'chat.item', turnId: 'T1', itemId: 'r2', kind: 'reasoning', status: 'completed', payload: { text: '正在读取文件…还有后续' } });
+    expect(thinks[0].dataset.csFull).toBe('正在读取文件…还有后续');
+  });
+
+  it('prewarm 发送即起计（2026-09-09）：面板与计时立即存在，真 turnId 首事件迁移接管', () => {
+    const prewarm = g.window.chatStreamPrewarm as (c: string, m: unknown, t: number) => void;
+    expect(typeof prewarm).toBe('function');
+    prewarm('c-1', anchor, Date.now() - 2500);
+    // 发送瞬间：pending 流已建（徽章+计时走秒），不等模型首事件。
+    let flow = inserts[inserts.length - 1].node;
+    expect(String(flow.className)).toContain('cs-flow');
+    expect(flow.dataset.csPending).toBe('1');
+    const badge = flow._csBadge as StubEl;
+    const elapsed = badge && badge.querySelector('.cs-badge-elapsed');
+    expect(elapsed && String(elapsed.textContent)).toContain('2 秒');
+    // 首 turn.started（真 turnId）到达：pending 迁移接管为同一流，计时起点保留。
+    handle({ type: 'chat.turn.started', turnId: 'real-1', cid: 'c-1', actorId: 'a', startedAt: '' });
+    const flow2 = g.window.chatStreamHasPanel('c-1');
+    expect(flow2).toBe(true);
+    const taken = inserts[inserts.length - 1].node;
+    expect(taken).toBe(flow); // 同一流被复用（未新建）
+    expect(flow.dataset.csPending).toBe('');
+    expect(flow.dataset.csTurn).toBe('real-1');
+    expect(Number(flow.dataset.csT0)).toBeLessThanOrEqual(Date.now() - 2500);
+  });
+
   it('时间线接管正文：text 段交错、完成交回清空、思考行随之收行', () => {
     handle({ type: 'chat.turn.started', turnId: 'T1', cid: 'c-1', actorId: 'a', startedAt: '' });
     handle({ type: 'chat.item', turnId: 'T1', itemId: 'i1', kind: 'text', status: 'inProgress', payload: { delta: '我先查一下：' } });
@@ -338,13 +392,17 @@ describe('chat-stream module', () => {
     expect(segs).toHaveLength(2);
     expect(segs[0].textContent).toBe('我先查一下：');
     expect(segs[1].textContent).toBe('查完了。');
-    expect(flow.dataset.csText).toBe('我先查一下：查完了。');
+    // 中间段被工具行关闭（cs-closed），最终段保持开放。
+    expect(segs[0].dataset.csClosed).toBe('1');
+    expect(segs[1].dataset.csClosed).toBeUndefined();
 
-    // turn.completed：交回（_streamingAppendFinalDelta 不在测试环境，走
-    // finalEl fallback 亦无），段移除、聚合清空；有动作行 → 流保留为 done。
+    // turn.completed：交回只针对开放段（最终正文'查完了。'，交回在测试
+    // 环境无 _streamingAppendFinalDelta/finalEl 落点，观测时间线侧）——
+    // 已关闭的中间段保留在时间线按原时序展示，开放段移除。
     handle({ type: 'chat.turn.completed', turnId: 'T1', status: 'completed', endedAt: '' });
-    expect(flow.querySelectorAll('.cs-text')).toHaveLength(0);
-    expect(flow.dataset.csText).toBeUndefined();
+    const restSegs = flow.querySelectorAll('.cs-text');
+    expect(restSegs).toHaveLength(1);
+    expect(restSegs[0].textContent).toBe('我先查一下：');
     expect(flow.className).toContain('done');
     expect(flow.className).not.toContain('running');
     expect(flow.isConnected).toBe(true);
@@ -431,13 +489,17 @@ describe('chat-stream module', () => {
     expect(segs).toHaveLength(2);
     expect(segs[0].textContent).toBe('我先查一下：');
     expect(segs[1].textContent).toBe('查完了。');
-    expect(flow.dataset.csText).toBe('我先查一下：查完了。');
+    // 中间段被工具行关闭（cs-closed），最终段保持开放。
+    expect(segs[0].dataset.csClosed).toBe('1');
+    expect(segs[1].dataset.csClosed).toBeUndefined();
 
-    // turn.completed：交回（_streamingAppendFinalDelta 不在测试环境，走
-    // finalEl fallback 亦无），段移除、聚合清空；有动作行 → 流保留为 done。
+    // turn.completed：交回只针对开放段（最终正文'查完了。'，交回在测试
+    // 环境无 _streamingAppendFinalDelta/finalEl 落点，观测时间线侧）——
+    // 已关闭的中间段保留在时间线按原时序展示，开放段移除。
     handle({ type: 'chat.turn.completed', turnId: 'T1', status: 'completed', endedAt: '' });
-    expect(flow.querySelectorAll('.cs-text')).toHaveLength(0);
-    expect(flow.dataset.csText).toBeUndefined();
+    const restSegs = flow.querySelectorAll('.cs-text');
+    expect(restSegs).toHaveLength(1);
+    expect(restSegs[0].textContent).toBe('我先查一下：');
     expect(flow.className).toContain('done');
     expect(flow.className).not.toContain('running');
     expect(flow.isConnected).toBe(true);
@@ -465,9 +527,11 @@ describe('chat-stream module', () => {
     const body = bodyOf(flow);
     const segs = body.children.filter((c) => String(c.className).includes('cs-text'));
     expect(segs).toHaveLength(1);
-    // 段首空白被剥掉（时间线显示），聚合文本保留（markdown 分段需要）。
+    // 段首空白被剥掉（时间线显示）；段文本经 dataset.csSeg 聚合（收尾
+    // 只交回开放段，不再做全文 csText 聚合）。
     expect(segs[0].textContent).toBe('正文第一段。');
-    expect(flow.dataset.csText).toBe('\n\n正文第一段。');
+    expect(segs[0].dataset.csSeg).toBe('正文第一段。');
+    expect(flow.dataset.csText).toBeUndefined();
   });
 
   it('usage 行渲染并含上下文告警，diff 行渲染增删统计与着色行', () => {
@@ -711,18 +775,19 @@ describe('chat-stream module', () => {
     expect(rows).toHaveLength(2);
     expect(rows[0].innerHTML).toContain('done');
     expect(rows[0].innerHTML).toContain('npm test');
-    // 工具行显示权威耗时（1500ms → 「2 秒」取整口径见 _csFmtDur），
-    // 徽章显示整段总耗时（末终态 4s = 幻影收编后跨度）与工具数 2。
+    // 工具行显示权威耗时（1500ms → 「1 秒」，floor 整秒口径见
+    // _csFmtDur，子安 2026-09-09 去小数需求），徽章显示整段总耗时
+    // （末终态 4s = 幻影收编后跨度）与工具数 2。
     expect(rows[0].innerHTML).toContain('cs-dur');
-    expect(rows[0].innerHTML).toContain('2 秒');
+    expect(rows[0].innerHTML).toContain('1 秒');
     expect(rows[1].innerHTML).toContain('搜索');
     expect(rows[1].innerHTML).toContain('ok');
     const badge = flow.querySelector('.cs-badge')!;
     expect(badge).toBeTruthy();
     const elapsed = badge.querySelector('.cs-badge-elapsed')!;
     expect(elapsed).toBeTruthy();
-    // 新格式保留 1 位小数（任务耗时需求 2026-09-08）。
-    expect(elapsed.textContent).toContain('4.0 秒');
+    // 整秒计数（任务耗时 2026-09-09 修订：去小数位）。
+    expect(elapsed.textContent).toContain('4 秒');
     const tools = badge.querySelector('.cs-badge-tools')!;
     expect(tools).toBeTruthy();
     expect(tools.textContent).toContain('2');


### PR DESCRIPTION
## 概述

对话过程 UI 两项修复 + CLI 常驻运行时框架 + 外接智能体模型枚举全量打通 + 外接 CLI 用量统计下线。基于最新 develop（a2e3abea），11 个提交，24 文件 +2926/−85。

## 一、对话过程 UI 修复（2 提交）

**执行过程显示 AI 中间叙述**：展开执行过程后，AI 穿插在工具调用之间的叙述性正文按时间序展示（此前收尾清理与全文正文两头挤压导致彻底不可见）；消息正文只承载最终段，与过程区不重复，实时与历史重放一致。

**计时即时启动 + 整秒显示 + 思考实时流式**：
- 发送瞬间即创建过程面板并起表（prewarm + pending 接管），不再等模型首事件（此前延迟 5-10 秒）；
- 计时按整秒计数（去掉小数位）；
- 思考内容逐段实时流式展示（投影器 inProgress 增量外发 + 思考行自动展开），持久化侧过滤增量防重复，重放仍只消费 completed 整段。

## 二、CLI 常驻运行时框架（4 提交，09-03 存量）

外接 CLI（opencode/claude）常驻后台进程：生命周期管理器（惰性启动/会话复用/崩溃单次恢复/一次性回退）+ opencode serve 适配器 + claude stream-json 双工适配器。**空闲 10 分钟自动回收**（env 可调），忙碌窗口豁免——常驻只省冷启动（8-12 秒），不长期占内存。

## 三、外接智能体模型枚举全量打通（4 提交）

模型清单以各 CLI 自身配置为事实源（外接 CLI 普遍接自定义网关，静态目录猜不出网关模型）：

| CLI | 清单来源 | 实测 |
|---|---|---|
| hermes | 网关通道接入预设探测（#209 G-19 迁移断点修复） | 本机 12 个模型 ✓ |
| claude | settings.json env 槽位变量（自定义网关下列表探测只披露 current） | 本机 1→3 个 ✓ |
| gemini / aider / codex | 各自配置文件声明式枚举（新实现；codex 常驻通道 RPC 失败回落 profiles） | 模拟配置实测 ✓（本机未装） |
| opencode | 常驻 serve 的 GET /api/model（该通道原缺 inspectModels） | 本机 31 个 ✓ |

## 四、外接 CLI 用量统计下线（1 提交）

CLI 回合的 token 输入/输出与缓存命中不再显示（自报/估算口径不可靠）：时间线 usage 行、消息头 metrics 小字、页脚会话统计三处一并消失，改在数据源头剥除；本地计时（时长/首 token）保留，内置模型回合统计不受影响，历史消息如实保留。

## 验证

- `tsc --noEmit` 0 错误 / `eslint .` 0 告警
- 受影响域测试全绿：探测 42 / renderer+group_chat 2577 / local_agents 350（3 个失败为 better-sqlite3 原生模块 ABI 与沙箱探针，纯 develop 基线同挂，与本分支无关）
- 过程 UI / 模型枚举均经 dev 实例 CDP 真机验证（计时 0.5s 内起跳、思考 163→4200 字符逐段增长、Hermes/claude/opencode 清单实测如上表）

## 测试口径

全量套件未在本分支重跑（评审环境 sandbox-exec/sherpa 缺失的已知环境类失败见 PR #209 记录）；本分支改动的全部模块域已如上覆盖。
