### PR TITLE
test(windows): stabilize async test cleanup

### DIFF
--- a/test/main/features/cogseed_backend/runtime-controller.test.ts
+++ b/test/main/features/cogseed_backend/runtime-controller.test.ts
@@ -540,7 +540,7 @@ describe('CogSeed Runtime controller', () => {
     const projectTaskEvent = vi.fn(async () => 'projected');
     const { createCogSeedRuntimeController } = await import('../../../../src/main/features/cogseed_backend/runtime-controller');
     const tasks = await import('../../../../src/main/features/cogseed_backend/task-store');
-    const controller = createCogSeedRuntimeController({ runtime, projectTaskEvent, resultDeliveryStore } as any);
+    const controller = trackController(createCogSeedRuntimeController({ runtime, projectTaskEvent, resultDeliveryStore } as any));
 
     const task = await controller.startCogSeedTask(USER, {
       requestId: 'req-cleanup-order',
@@ -1597,7 +1597,7 @@ describe('CogSeed Runtime controller', () => {
     };
     const { createCogSeedRuntimeController } = await import('../../../../src/main/features/cogseed_backend/runtime-controller');
     const tasks = await import('../../../../src/main/features/cogseed_backend/task-store');
-    const controller = createCogSeedRuntimeController({ runtime });
+    const controller = trackController(createCogSeedRuntimeController({ runtime }));
     const task = await controller.startCogSeedTask(USER, { requestId: 'req-concurrent-resume-original', task: 'Resume once.' });
     await eventually(async () => expect(await tasks.readCogSeedTask(USER, task.taskId)).toMatchObject({ status: 'recoverable' }));
 
@@ -1834,7 +1834,7 @@ describe('CogSeed Runtime controller', () => {
     };
     const { createCogSeedRuntimeController } = await import('../../../../src/main/features/cogseed_backend/runtime-controller');
     const tasks = await import('../../../../src/main/features/cogseed_backend/task-store');
-    const controller = createCogSeedRuntimeController({ runtime });
+    const controller = trackController(createCogSeedRuntimeController({ runtime }));
     const conversationId = 'cid-resume-first-reservation';
     const source = await controller.startCogSeedTask(USER, {
       requestId: 'req-resume-first-source',
@@ -1917,7 +1917,7 @@ describe('CogSeed Runtime controller', () => {
     const lifecycle = await import('../../../../src/main/features/cogseed_backend/lifecycle');
     const tasks = await import('../../../../src/main/features/cogseed_backend/task-store');
     const deliveries = await import('../../../../src/main/features/cogseed_backend/result-delivery-store');
-    const controller = createCogSeedRuntimeController({ runtime, projectTaskEvent });
+    const controller = trackController(createCogSeedRuntimeController({ runtime, projectTaskEvent }));
     const task = await controller.startCogSeedTask(USER, {
       requestId: 'req-stale-terminal-fence',
       task: 'Fence the old attempt before recovery.',

--- a/test/main/features/kstar/kstar-v4-chain.test.ts
+++ b/test/main/features/kstar/kstar-v4-chain.test.ts
@@ -80,8 +80,13 @@ beforeEach(async () => {
 afterEach(async () => {
   _stopClosure?.();
   _stopClosure = undefined;
+  const closure = await import('../../../../src/main/features/kstar/task-closure');
   const groupChat = await import('../../../../src/main/features/group_chat');
-  for (const cid of cids.splice(0)) await groupChat.dropConv('user-a', cid).catch(() => undefined);
+  for (const cid of cids.splice(0)) {
+    await closure.cancelAutoClose('user-a', cid).catch(() => undefined);
+    await groupChat.dropConv('user-a', cid).catch(() => undefined);
+  }
+  closure._setAutoCloseQuietMsForTest(undefined);
   if (prevWs === undefined) delete process.env.COGSEED_WORKSPACE_ROOT;
   else process.env.COGSEED_WORKSPACE_ROOT = prevWs;
   if (prevFlag === undefined) delete process.env.COGSEED_COMMANDER_CENTRIC_KSTAR;
@@ -216,6 +221,7 @@ describe('KStar design-v4 chain (candidate pool + semantic dedup + auto-close)',
     const requirementId = await seedRequirementWithLesson(cid, '写一份 500 字资料', 'N 字资料类请求：交付开头注明实际字数');
     const store = await import('../../../../src/main/features/kstar/requirement-store');
     const closure = await import('../../../../src/main/features/kstar/task-closure');
+    closure._setAutoCloseQuietMsForTest(5_000);
 
     // Schedule the quiet window (as the terminal listener would).
     const scheduled = await closure.scheduleAutoClose('user-a', cid);


### PR DESCRIPTION
## Summary
- wait for affected CogSeed runtime controllers to shut down before Windows test temp-directory cleanup
- cancel KStar auto-close timers and reset the test quiet-window override during teardown
- isolate manual auto-close testing from the real short timer race

## Verification
- `node scripts/run-tests.mjs run test/main/features/local_agents/version.test.ts test/main/features/local_agents/base.test.ts test/main/features/cogseed_backend/runtime-controller.test.ts test/main/features/kstar/kstar-v4-chain.test.ts` (106 passed)
- `npm run typecheck`
- `npm run lint`
- `git diff --cached --check`

## Scope note
The separate `local-tools.test.ts` 60-second shell-startup timeout from PR #202 was reproducible only under full-suite pressure; its file passes locally (64/64) and is intentionally not masked by increasing timeouts in this PR.