### PR TITLE
修复：设置配置页顶部多余执行区块，恢复从模型配置开始渲染

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1284,52 +1284,7 @@
             <!-- ───────────────────────── 配置 ───────────────────────── -->
 
             <div class="settings-tab-pane" data-settings-pane="configuration" hidden>
-              <section class="settings-execution" id="settings-execution-collaboration" aria-labelledby="settings-execution-title" tabindex="-1">
-                <div class="settings-section-head" id="settings-execution-title" data-i18n="settings.execution.title">Execution &amp; collaboration</div>
-                <div class="settings-section-note" data-i18n="settings.execution.subtitle">Manage Agents, external gateways, message channels, worktrees, and safe diagnostics here.</div>
-
-                <section class="settings-execution-region" id="settings-execution-agents" aria-labelledby="settings-execution-agents-title" tabindex="-1">
-                  <div class="settings-group-head">
-                    <div>
-                      <div class="settings-group-title" id="settings-execution-agents-title" data-i18n="settings.execution.agents_title">Agents and executors</div>
-                      <div class="settings-group-sub" data-i18n="settings.execution.agents_subtitle">Install, authorize, enable, and manage execution Agents.</div>
-                    </div>
-                  </div>
-                  <div id="run-center-settings-agents-host"></div>
-                </section>
-
-                <section class="settings-execution-region" id="settings-execution-gateways" aria-labelledby="settings-execution-gateways-title" tabindex="-1">
-                  <div class="settings-group-head">
-                    <div>
-                      <div class="settings-group-title" id="settings-execution-gateways-title" data-i18n="settings.execution.gateways_title">External gateways and message channels</div>
-                      <div class="settings-group-sub" data-i18n="settings.execution.gateways_subtitle">Control managed execution gateways and configure message channels.</div>
-                    </div>
-                  </div>
-                  <div id="run-center-settings-gateways"></div>
-                  <div id="run-center-settings-channels-host"></div>
-                </section>
-
-                <section class="settings-execution-region" id="settings-execution-worktrees" aria-labelledby="settings-execution-worktrees-title" tabindex="-1">
-                  <div class="settings-group-head">
-                    <div>
-                      <div class="settings-group-title" id="settings-execution-worktrees-title" data-i18n="settings.execution.worktrees_title">Worktrees</div>
-                      <div class="settings-group-sub" data-i18n="settings.execution.worktrees_subtitle">Create and safely remove CogSeed-managed Git worktrees.</div>
-                    </div>
-                  </div>
-                  <div id="run-center-settings-worktrees"></div>
-                </section>
-
-                <section class="settings-execution-region" id="settings-execution-diagnostics" aria-labelledby="settings-execution-diagnostics-title" tabindex="-1">
-                  <div class="settings-group-head">
-                    <div>
-                      <div class="settings-group-title" id="settings-execution-diagnostics-title" data-i18n="settings.execution.diagnostics_title">Diagnostics and safe export</div>
-                      <div class="settings-group-sub" data-i18n="settings.execution.diagnostics_subtitle">Inspect projection health and export sanitized diagnostics.</div>
-                    </div>
-                  </div>
-                  <div id="run-center-settings-diagnostics"></div>
-                </section>
-              </section>
-
+              
               <div class="settings-section-note" data-i18n="settings.section.models_note">API keys and OAuth tokens are stored locally only — never synced or sent off-device.</div>
 
               <div class="settings-group" id="settings-auth-profiles-recovery" hidden>

--- a/test/renderer/run-center-settings.test.ts
+++ b/test/renderer/run-center-settings.test.ts
@@ -286,17 +286,23 @@ function createHarness() {
 }
 
 describe('Run Center settings boundary', () => {
-  it('declares one canonical configuration surface with four independent regions', () => {
+  it('keeps the configuration pane model-first (no embedded execution regions)', () => {
     const html = read('src/renderer/index.html');
     const lazyFeatures = read('src/renderer/modules/lazy-features.js');
     const settings = read('src/renderer/modules/settings_tabs.js');
 
     expect(html).toContain('data-settings-tab="configuration"');
     expect(html).toContain('data-settings-pane="configuration"');
+    // 配置页从「模型配置」开始（2026-09-09 子安指令）：设置页不再内嵌
+    // 执行与协作区——Agents 面板归连接页（#216 语义），管理面留在
+    // run-center。run-center-settings 模块保留（host 缺失时 no-op），
+    // run-center 菜单的 worktrees/diagnostics 锚点跳转静默降级。
     for (const id of [
       'settings-execution-agents', 'settings-execution-gateways',
       'settings-execution-worktrees', 'settings-execution-diagnostics',
-    ]) expect(html).toContain(`id="${id}"`);
+      'settings-execution-collaboration',
+    ]) expect(html).not.toContain(`id="${id}"`);
+    expect(html).toContain('id="settings-model-authorizations"');
     expect(html.match(/id="panel-agents"/g)).toHaveLength(1);
     expect(html.match(/class="touchpoint-settings-shell/g)).toHaveLength(1);
     expect(settings).toContain("name === 'credentials' ? 'configuration' : name");


### PR DESCRIPTION
## 现象

设置 → 配置页顶部出现大量多余内容（工作树管理、诊断与安全导出等区块），正常展示应从「模型配置」开始。群内曾反馈由 #216 修复——实际 #216 修复的是连接页/设置页跳转串台（导航问题），本问题在最新 develop 上仍复现。

## 造成问题的原因

**直接原因**：run-center 系列改造（提交 db651e25）把「执行与协作」区（Agents、外部网关、工作树、诊断导出四个区块）以静态 HTML 内嵌进了设置-配置页顶部。该改动随 PR #197 捎带合入 develop，未经独立的界面布局评审——「工作树/诊断这类管理面是否应放进设置页」没有机会被质疑。

**为什么 #216 之后看起来更乱**：#216 将 Agents 面板归回连接页时只修了导航跳转，设置页内嵌的四区被留下——工作树与诊断导出成为孤儿区块展示在配置页顶部；且嵌入实现采用 DOM 物理搬移（打开设置页会把连接页的 panel-agents 搬进设置页），同一面板被两个页面争用。

**根本原因**：设置/连接/自动化三个页面的功能归属只存在于团队习惯，没有成文约定——run-center 线按「管理面集中」的心智模型重构时无规则可依，布局冲突因此积累。

## 修复

配置页删除整个执行与协作区块（index.html 45 行），恢复从「添加模型授权」起按原有顺序渲染。改动仅在 HTML 层——run-center-settings 模块保留（宿主节点缺失时全部 no-op）：

- panel-agents 不再被搬移，连接页 Agent 面板归属固定（#216 语义完整保留，实机验证面板内容完整）；
- 工作树/诊断导出的管理入口本就在自动化（run-center）页「更多工具」菜单，设置页区块为重复展示，移除不影响功能本体。

**需 run-center 线知悉**：自动化页「更多工具」菜单的 worktrees/diagnostics 锚点跳转目的地已移除，点击后打开设置页停在模型配置顶部（静默降级、无报错）；这两项功能的界面安置请 run-center 侧后续决定（建议在自动化页内呈现）。

## 验证

- renderer 全量 1896 用例绿（run-center-settings 的布局钉子按新现实更新：配置页不含执行区、模型授权组在位）；
- 实机验证：配置页首屏从「添加模型授权」开始、顶部多余区块全部消失；连接页 Agent 面板内容完整不受影响。

## 防复发建议

补一份界面功能归属约定（什么住设置页、什么住连接页、什么住自动化页）入开发流程速查；涉及设置页/连接页新增区块的改动，评审时对归属多问一句。
