### PR TITLE
feat(kstar): expose run-scoped evidence contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-09-10
+
 ### Security
 
 - Remove private development records and personal identifiers from source,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cogseed",
-  "version": "0.9.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cogseed",
-      "version": "0.9.0",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogseed",
-  "version": "0.9.0",
+  "version": "1.0.2",
   "private": true,
   "description": "CogSeed desktop — personal cognition asset workspace",
   "main": "bootstrap.cjs",

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -3,8 +3,8 @@ publiccodeYmlVersion: "0.2"
 name: CogSeed
 url: "https://github.com/bonc-ai/cogseed"
 landingURL: "https://github.com/bonc-ai/cogseed"
-softwareVersion: "0.9.0"
-releaseDate: "2026-09-07"
+softwareVersion: "1.0.2"
+releaseDate: "2026-09-10"
 logo: "assets/cogseed-icon.png"
 monochromeLogo: "assets/cogseed-icon.png"
 

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -98,8 +98,8 @@
     "component": {
       "type": "application",
       "name": "cogseed",
-      "version": "0.9.0",
-      "bom-ref": "cogseed@0.9.0",
+      "version": "1.0.2",
+      "bom-ref": "cogseed@1.0.2",
       "author": "BONC 东方国信",
       "description": "CogSeed desktop — personal cognition asset workspace",
       "licenses": [
@@ -110,7 +110,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/cogseed@0.9.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbonc-ai%2Fcogseed.git",
+      "purl": "pkg:npm/cogseed@1.0.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbonc-ai%2Fcogseed.git",
       "externalReferences": [
         {
           "url": "git+https://github.com/bonc-ai/cogseed.git",
@@ -146,7 +146,7 @@
       "name": "pi-ai",
       "group": "@earendil-works",
       "version": "0.79.10",
-      "bom-ref": "cogseed@0.9.0|@earendil-works/pi-ai@0.79.10",
+      "bom-ref": "cogseed@1.0.2|@earendil-works/pi-ai@0.79.10",
       "author": "Mario Zechner",
       "description": "Unified LLM API with automatic model discovery and provider configuration",
       "licenses": [
@@ -202,7 +202,7 @@
       "name": "rebuild",
       "group": "@electron",
       "version": "4.2.0",
-      "bom-ref": "cogseed@0.9.0|@electron/rebuild@4.2.0",
+      "bom-ref": "cogseed@1.0.2|@electron/rebuild@4.2.0",
       "description": "Electron supporting package to rebuild native node modules against the currently installed electron",
       "licenses": [
         {
@@ -260,7 +260,7 @@
           "type": "library",
           "name": "node-abi",
           "version": "4.33.0",
-          "bom-ref": "cogseed@0.9.0|@electron/rebuild@4.2.0|node-abi@4.33.0",
+          "bom-ref": "cogseed@1.0.2|@electron/rebuild@4.2.0|node-abi@4.33.0",
           "author": "Lukas Geiger",
           "description": "Get the Node ABI for a given target and runtime, and vice versa.",
           "licenses": [
@@ -322,7 +322,7 @@
       "name": "js",
       "group": "@eslint",
       "version": "10.0.1",
-      "bom-ref": "cogseed@0.9.0|@eslint/js@10.0.1",
+      "bom-ref": "cogseed@1.0.2|@eslint/js@10.0.1",
       "description": "ESLint JavaScript language implementation",
       "licenses": [
         {
@@ -381,7 +381,7 @@
       "name": "webp",
       "group": "@jsquash",
       "version": "1.5.0",
-      "bom-ref": "cogseed@0.9.0|@jsquash/webp@1.5.0",
+      "bom-ref": "cogseed@1.0.2|@jsquash/webp@1.5.0",
       "author": "Jamie Sinclair",
       "description": "Wasm webp encoder and decoder supporting the browser. Repackaged from Squoosh App.",
       "licenses": [
@@ -433,7 +433,7 @@
       "name": "node-sdk",
       "group": "@larksuiteoapi",
       "version": "1.73.0",
-      "bom-ref": "cogseed@0.9.0|@larksuiteoapi/node-sdk@1.73.0",
+      "bom-ref": "cogseed@1.0.2|@larksuiteoapi/node-sdk@1.73.0",
       "author": "mazhe.nerd",
       "description": "larksuite open sdk for nodejs",
       "licenses": [
@@ -485,7 +485,7 @@
       "name": "sdk",
       "group": "@modelcontextprotocol",
       "version": "1.29.0",
-      "bom-ref": "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0",
+      "bom-ref": "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0",
       "author": "Anthropic, PBC",
       "description": "Model Context Protocol implementation for TypeScript",
       "licenses": [
@@ -540,7 +540,7 @@
           "type": "library",
           "name": "ajv-formats",
           "version": "3.0.1",
-          "bom-ref": "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0|ajv-formats@3.0.1",
+          "bom-ref": "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0|ajv-formats@3.0.1",
           "author": "Evgeny Poberezkin",
           "description": "Format validation for Ajv v7+",
           "licenses": [
@@ -591,7 +591,7 @@
           "type": "library",
           "name": "json-schema-typed",
           "version": "8.0.2",
-          "bom-ref": "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0|json-schema-typed@8.0.2",
+          "bom-ref": "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0|json-schema-typed@8.0.2",
           "author": "Remy Rylan",
           "description": "JSON Schema TypeScript definitions with complete inline documentation.",
           "licenses": [
@@ -645,7 +645,7 @@
       "name": "adm-zip",
       "group": "@types",
       "version": "0.5.8",
-      "bom-ref": "cogseed@0.9.0|@types/adm-zip@0.5.8",
+      "bom-ref": "cogseed@1.0.2|@types/adm-zip@0.5.8",
       "description": "TypeScript definitions for adm-zip",
       "licenses": [
         {
@@ -700,7 +700,7 @@
       "name": "node",
       "group": "@types",
       "version": "25.6.0",
-      "bom-ref": "cogseed@0.9.0|@types/node@25.6.0",
+      "bom-ref": "cogseed@1.0.2|@types/node@25.6.0",
       "description": "TypeScript definitions for node",
       "licenses": [
         {
@@ -739,7 +739,7 @@
           "type": "library",
           "name": "undici-types",
           "version": "7.19.2",
-          "bom-ref": "cogseed@0.9.0|@types/node@25.6.0|undici-types@7.19.2",
+          "bom-ref": "cogseed@1.0.2|@types/node@25.6.0|undici-types@7.19.2",
           "description": "A stand-alone types package for Undici",
           "licenses": [
             {
@@ -781,7 +781,7 @@
       "name": "coverage-v8",
       "group": "@vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|@vitest/coverage-v8@4.1.11",
+      "bom-ref": "cogseed@1.0.2|@vitest/coverage-v8@4.1.11",
       "author": "Anthony Fu",
       "description": "V8 coverage provider for Vitest",
       "licenses": [
@@ -837,7 +837,7 @@
       "name": "aibot-node-sdk",
       "group": "@wecom",
       "version": "1.0.7",
-      "bom-ref": "cogseed@0.9.0|@wecom/aibot-node-sdk@1.0.7",
+      "bom-ref": "cogseed@1.0.2|@wecom/aibot-node-sdk@1.0.7",
       "description": "企业微信智能机器人 Node.js SDK - WebSocket 长连接通道",
       "licenses": [
         {
@@ -887,7 +887,7 @@
       "type": "library",
       "name": "7zip-bin",
       "version": "5.2.0",
-      "bom-ref": "cogseed@0.9.0|7zip-bin@5.2.0",
+      "bom-ref": "cogseed@1.0.2|7zip-bin@5.2.0",
       "description": "7-Zip precompiled binaries",
       "licenses": [
         {
@@ -941,7 +941,7 @@
       "type": "library",
       "name": "adm-zip",
       "version": "0.6.0",
-      "bom-ref": "cogseed@0.9.0|adm-zip@0.6.0",
+      "bom-ref": "cogseed@1.0.2|adm-zip@0.6.0",
       "author": "Nasca Iacob",
       "description": "Javascript implementation of zip for nodejs with support for electron original-fs. Allows user to create or extract zip files both in memory or to/from disk",
       "licenses": [
@@ -996,7 +996,7 @@
       "type": "library",
       "name": "async-mutex",
       "version": "0.5.0",
-      "bom-ref": "cogseed@0.9.0|async-mutex@0.5.0",
+      "bom-ref": "cogseed@1.0.2|async-mutex@0.5.0",
       "author": "Christian Speckner",
       "description": "A mutex for guarding async workflows",
       "licenses": [
@@ -1036,7 +1036,7 @@
       "type": "library",
       "name": "better-sqlite3",
       "version": "12.10.0",
-      "bom-ref": "cogseed@0.9.0|better-sqlite3@12.10.0",
+      "bom-ref": "cogseed@1.0.2|better-sqlite3@12.10.0",
       "author": "Joshua Wise",
       "description": "The fastest and simplest library for SQLite in Node.js.",
       "licenses": [
@@ -1091,7 +1091,7 @@
       "type": "library",
       "name": "electron-builder",
       "version": "26.15.7",
-      "bom-ref": "cogseed@0.9.0|electron-builder@26.15.7",
+      "bom-ref": "cogseed@1.0.2|electron-builder@26.15.7",
       "author": "Vladimir Krivosheev",
       "description": "A complete solution to package and build a ready for distribution Electron app for MacOS, Windows and Linux with “auto update” support out of the box",
       "licenses": [
@@ -1150,7 +1150,7 @@
       "type": "library",
       "name": "electron-log",
       "version": "5.4.4",
-      "bom-ref": "cogseed@0.9.0|electron-log@5.4.4",
+      "bom-ref": "cogseed@1.0.2|electron-log@5.4.4",
       "author": "Alexey Prokhorov",
       "description": "Just a simple logging module for your Electron application",
       "licenses": [
@@ -1205,7 +1205,7 @@
       "type": "library",
       "name": "electron",
       "version": "41.10.6",
-      "bom-ref": "cogseed@0.9.0|electron@41.10.6",
+      "bom-ref": "cogseed@1.0.2|electron@41.10.6",
       "author": "Electron Community",
       "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
       "licenses": [
@@ -1265,7 +1265,7 @@
           "name": "node",
           "group": "@types",
           "version": "24.12.4",
-          "bom-ref": "cogseed@0.9.0|electron@41.10.6|@types/node@24.12.4",
+          "bom-ref": "cogseed@1.0.2|electron@41.10.6|@types/node@24.12.4",
           "description": "TypeScript definitions for node",
           "licenses": [
             {
@@ -1321,7 +1321,7 @@
       "type": "library",
       "name": "esbuild",
       "version": "0.28.2",
-      "bom-ref": "cogseed@0.9.0|esbuild@0.28.2",
+      "bom-ref": "cogseed@1.0.2|esbuild@0.28.2",
       "description": "An extremely fast JavaScript and CSS bundler and minifier.",
       "licenses": [
         {
@@ -1375,7 +1375,7 @@
       "type": "library",
       "name": "eslint",
       "version": "10.9.0",
-      "bom-ref": "cogseed@0.9.0|eslint@10.9.0",
+      "bom-ref": "cogseed@1.0.2|eslint@10.9.0",
       "author": "Nicholas C. Zakas",
       "description": "An AST-based pattern checker for JavaScript.",
       "licenses": [
@@ -1434,7 +1434,7 @@
           "type": "library",
           "name": "ajv",
           "version": "6.15.0",
-          "bom-ref": "cogseed@0.9.0|eslint@10.9.0|ajv@6.15.0",
+          "bom-ref": "cogseed@1.0.2|eslint@10.9.0|ajv@6.15.0",
           "author": "Evgeny Poberezkin",
           "description": "Another JSON Schema Validator",
           "licenses": [
@@ -1489,7 +1489,7 @@
           "type": "library",
           "name": "json-schema-traverse",
           "version": "0.4.1",
-          "bom-ref": "cogseed@0.9.0|eslint@10.9.0|json-schema-traverse@0.4.1",
+          "bom-ref": "cogseed@1.0.2|eslint@10.9.0|json-schema-traverse@0.4.1",
           "author": "Evgeny Poberezkin",
           "description": "Traverse JSON Schema passing each schema object to callback",
           "licenses": [
@@ -1546,7 +1546,7 @@
       "type": "library",
       "name": "fastembed",
       "version": "2.1.0",
-      "bom-ref": "cogseed@0.9.0|fastembed@2.1.0",
+      "bom-ref": "cogseed@1.0.2|fastembed@2.1.0",
       "author": "Anush008",
       "description": "NodeJS implementation of @Qdrant/fastembed",
       "licenses": [
@@ -1597,7 +1597,7 @@
       "type": "library",
       "name": "get-tsconfig",
       "version": "4.14.0",
-      "bom-ref": "cogseed@0.9.0|get-tsconfig@4.14.0",
+      "bom-ref": "cogseed@1.0.2|get-tsconfig@4.14.0",
       "author": "Hiroki Osame",
       "description": "Find and parse the tsconfig.json file from a directory path",
       "licenses": [
@@ -1637,7 +1637,7 @@
       "type": "library",
       "name": "jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|jimp@1.6.1",
+      "bom-ref": "cogseed@1.0.2|jimp@1.6.1",
       "author": "Andrew Lisowski",
       "description": "An image processing library written entirely in JavaScript.",
       "licenses": [
@@ -1692,7 +1692,7 @@
       "type": "library",
       "name": "mammoth",
       "version": "1.12.1",
-      "bom-ref": "cogseed@0.9.0|mammoth@1.12.1",
+      "bom-ref": "cogseed@1.0.2|mammoth@1.12.1",
       "author": "Michael Williamson",
       "description": "Convert Word documents from docx to simple HTML and Markdown",
       "licenses": [
@@ -1747,7 +1747,7 @@
       "type": "library",
       "name": "node-pty",
       "version": "1.1.0",
-      "bom-ref": "cogseed@0.9.0|node-pty@1.1.0",
+      "bom-ref": "cogseed@1.0.2|node-pty@1.1.0",
       "author": "Microsoft Corporation",
       "description": "Fork pseudoterminals in Node.JS",
       "licenses": [
@@ -1798,7 +1798,7 @@
       "type": "library",
       "name": "pdfjs-dist",
       "version": "6.2.108",
-      "bom-ref": "cogseed@0.9.0|pdfjs-dist@6.2.108",
+      "bom-ref": "cogseed@1.0.2|pdfjs-dist@6.2.108",
       "description": "Generic build of Mozilla's PDF.js library.",
       "licenses": [
         {
@@ -1852,7 +1852,7 @@
       "type": "library",
       "name": "resolve-pkg-maps",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|resolve-pkg-maps@1.0.0",
+      "bom-ref": "cogseed@1.0.2|resolve-pkg-maps@1.0.0",
       "author": "Hiroki Osame",
       "description": "Resolve package.json exports & imports maps",
       "licenses": [
@@ -1892,7 +1892,7 @@
       "type": "library",
       "name": "sherpa-onnx-node",
       "version": "1.13.6",
-      "bom-ref": "cogseed@0.9.0|sherpa-onnx-node@1.13.6",
+      "bom-ref": "cogseed@1.0.2|sherpa-onnx-node@1.13.6",
       "author": "The next-gen Kaldi team",
       "description": "Speech-to-text, text-to-speech, speaker diarization, and speech enhancement using Next-gen Kaldi without internet connection",
       "licenses": [
@@ -1943,7 +1943,7 @@
       "type": "library",
       "name": "socks-proxy-agent",
       "version": "8.0.5",
-      "bom-ref": "cogseed@0.9.0|socks-proxy-agent@8.0.5",
+      "bom-ref": "cogseed@1.0.2|socks-proxy-agent@8.0.5",
       "author": "Nathan Rajlich",
       "description": "A SOCKS proxy `http.Agent` implementation for HTTP and HTTPS",
       "licenses": [
@@ -1998,7 +1998,7 @@
       "type": "library",
       "name": "sqlite-vec",
       "version": "0.1.9",
-      "bom-ref": "cogseed@0.9.0|sqlite-vec@0.1.9",
+      "bom-ref": "cogseed@1.0.2|sqlite-vec@0.1.9",
       "author": "Alex Garcia",
       "description": "A vector search SQLite extension.",
       "licenses": [
@@ -2049,7 +2049,7 @@
       "type": "library",
       "name": "tar",
       "version": "7.5.22",
-      "bom-ref": "cogseed@0.9.0|tar@7.5.22",
+      "bom-ref": "cogseed@1.0.2|tar@7.5.22",
       "author": "Isaac Z. Schlueter",
       "description": "tar for node",
       "licenses": [
@@ -2104,7 +2104,7 @@
           "type": "library",
           "name": "chownr",
           "version": "3.0.0",
-          "bom-ref": "cogseed@0.9.0|tar@7.5.22|chownr@3.0.0",
+          "bom-ref": "cogseed@1.0.2|tar@7.5.22|chownr@3.0.0",
           "author": "Isaac Z. Schlueter",
           "description": "like `chown -R`",
           "licenses": [
@@ -2161,7 +2161,7 @@
       "type": "library",
       "name": "tsx",
       "version": "4.23.13",
-      "bom-ref": "cogseed@0.9.0|tsx@4.23.13",
+      "bom-ref": "cogseed@1.0.2|tsx@4.23.13",
       "author": "Hiroki Osame",
       "description": "TypeScript Execute (tsx): Node.js enhanced with esbuild to run TypeScript & ESM files",
       "licenses": [
@@ -2216,7 +2216,7 @@
       "type": "library",
       "name": "typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|typescript-eslint@8.67.0",
+      "bom-ref": "cogseed@1.0.2|typescript-eslint@8.67.0",
       "description": "Tooling which enables you to use TypeScript with ESLint",
       "licenses": [
         {
@@ -2274,7 +2274,7 @@
       "type": "library",
       "name": "typescript",
       "version": "6.0.3",
-      "bom-ref": "cogseed@0.9.0|typescript@6.0.3",
+      "bom-ref": "cogseed@1.0.2|typescript@6.0.3",
       "author": "Microsoft Corp.",
       "description": "TypeScript is a language for application scale JavaScript development",
       "licenses": [
@@ -2322,7 +2322,7 @@
       "type": "library",
       "name": "undici",
       "version": "7.29.0",
-      "bom-ref": "cogseed@0.9.0|undici@7.29.0",
+      "bom-ref": "cogseed@1.0.2|undici@7.29.0",
       "description": "An HTTP/1.1 client, written from scratch for Node.js",
       "licenses": [
         {
@@ -2376,7 +2376,7 @@
       "type": "library",
       "name": "vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|vitest@4.1.11",
+      "bom-ref": "cogseed@1.0.2|vitest@4.1.11",
       "author": "Anthony Fu",
       "description": "Next generation testing framework powered by Vite",
       "licenses": [
@@ -2435,7 +2435,7 @@
           "type": "library",
           "name": "es-module-lexer",
           "version": "2.0.0",
-          "bom-ref": "cogseed@0.9.0|vitest@4.1.11|es-module-lexer@2.0.0",
+          "bom-ref": "cogseed@1.0.2|vitest@4.1.11|es-module-lexer@2.0.0",
           "author": "Guy Bedford",
           "description": "Lexes ES modules returning their import/export metadata",
           "licenses": [
@@ -2479,7 +2479,7 @@
           "type": "library",
           "name": "tinyexec",
           "version": "1.1.1",
-          "bom-ref": "cogseed@0.9.0|vitest@4.1.11|tinyexec@1.1.1",
+          "bom-ref": "cogseed@1.0.2|vitest@4.1.11|tinyexec@1.1.1",
           "author": "James Garbutt",
           "description": "A minimal library for executing processes in Node",
           "licenses": [
@@ -2529,7 +2529,7 @@
       "type": "library",
       "name": "ws",
       "version": "8.21.3",
-      "bom-ref": "cogseed@0.9.0|ws@8.21.3",
+      "bom-ref": "cogseed@1.0.2|ws@8.21.3",
       "author": "Einar Otto Stangvik",
       "description": "Simple to use, blazing fast and thoroughly tested websocket client and server for Node.js",
       "licenses": [
@@ -2584,7 +2584,7 @@
       "type": "library",
       "name": "yaml",
       "version": "2.9.0",
-      "bom-ref": "cogseed@0.9.0|yaml@2.9.0",
+      "bom-ref": "cogseed@1.0.2|yaml@2.9.0",
       "author": "Eemeli Aro",
       "description": "JavaScript parser and stringifier for YAML",
       "licenses": [
@@ -2639,7 +2639,7 @@
       "type": "library",
       "name": "zod",
       "version": "3.25.76",
-      "bom-ref": "cogseed@0.9.0|zod@3.25.76",
+      "bom-ref": "cogseed@1.0.2|zod@3.25.76",
       "author": "Colin McDonnell",
       "description": "TypeScript-first schema declaration and validation library with static type inference",
       "licenses": [
@@ -2680,7 +2680,7 @@
       "name": "sdk",
       "group": "@anthropic-ai",
       "version": "0.91.1",
-      "bom-ref": "cogseed@0.9.0|@anthropic-ai/sdk@0.91.1",
+      "bom-ref": "cogseed@1.0.2|@anthropic-ai/sdk@0.91.1",
       "author": "Anthropic",
       "description": "The official TypeScript library for the Anthropic API",
       "licenses": [
@@ -2732,7 +2732,7 @@
       "name": "client-bedrock-runtime",
       "group": "@aws-sdk",
       "version": "3.1048.0",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/client-bedrock-runtime@3.1048.0",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/client-bedrock-runtime@3.1048.0",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS SDK for JavaScript Bedrock Runtime Client for Node.js, Browser and React Native",
       "licenses": [
@@ -2788,7 +2788,7 @@
       "name": "genai",
       "group": "@google",
       "version": "1.52.0",
-      "bom-ref": "cogseed@0.9.0|@google/genai@1.52.0",
+      "bom-ref": "cogseed@1.0.2|@google/genai@1.52.0",
       "licenses": [
         {
           "license": {
@@ -2842,7 +2842,7 @@
       "name": "mistralai",
       "group": "@mistralai",
       "version": "2.2.6",
-      "bom-ref": "cogseed@0.9.0|@mistralai/mistralai@2.2.6",
+      "bom-ref": "cogseed@1.0.2|@mistralai/mistralai@2.2.6",
       "author": "Mistral AI",
       "description": "TypeScript client library for the Mistral AI API",
       "licenses": [
@@ -2894,7 +2894,7 @@
       "name": "api",
       "group": "@opentelemetry",
       "version": "1.9.0",
-      "bom-ref": "cogseed@0.9.0|@opentelemetry/api@1.9.0",
+      "bom-ref": "cogseed@1.0.2|@opentelemetry/api@1.9.0",
       "author": "OpenTelemetry Authors",
       "description": "Public API for OpenTelemetry",
       "licenses": [
@@ -2950,7 +2950,7 @@
       "name": "node-http-handler",
       "group": "@smithy",
       "version": "4.7.3",
-      "bom-ref": "cogseed@0.9.0|@smithy/node-http-handler@4.7.3",
+      "bom-ref": "cogseed@1.0.2|@smithy/node-http-handler@4.7.3",
       "author": "AWS SDK for JavaScript Team",
       "description": "Provides a way to make requests",
       "licenses": [
@@ -3005,7 +3005,7 @@
       "type": "library",
       "name": "http-proxy-agent",
       "version": "7.0.2",
-      "bom-ref": "cogseed@0.9.0|http-proxy-agent@7.0.2",
+      "bom-ref": "cogseed@1.0.2|http-proxy-agent@7.0.2",
       "author": "Nathan Rajlich",
       "description": "An HTTP(s) proxy `http.Agent` implementation for HTTP",
       "licenses": [
@@ -3060,7 +3060,7 @@
       "type": "library",
       "name": "https-proxy-agent",
       "version": "7.0.6",
-      "bom-ref": "cogseed@0.9.0|https-proxy-agent@7.0.6",
+      "bom-ref": "cogseed@1.0.2|https-proxy-agent@7.0.6",
       "author": "Nathan Rajlich",
       "description": "An HTTP(s) proxy `http.Agent` implementation for HTTPS",
       "licenses": [
@@ -3115,7 +3115,7 @@
       "type": "library",
       "name": "openai",
       "version": "6.26.0",
-      "bom-ref": "cogseed@0.9.0|openai@6.26.0",
+      "bom-ref": "cogseed@1.0.2|openai@6.26.0",
       "author": "OpenAI",
       "description": "The official TypeScript library for the OpenAI API",
       "licenses": [
@@ -3166,7 +3166,7 @@
       "type": "library",
       "name": "partial-json",
       "version": "0.1.7",
-      "bom-ref": "cogseed@0.9.0|partial-json@0.1.7",
+      "bom-ref": "cogseed@1.0.2|partial-json@0.1.7",
       "author": "Muspi Merol",
       "description": "Parse partial JSON generated by LLM",
       "licenses": [
@@ -3217,7 +3217,7 @@
       "type": "library",
       "name": "typebox",
       "version": "1.1.38",
-      "bom-ref": "cogseed@0.9.0|typebox@1.1.38",
+      "bom-ref": "cogseed@1.0.2|typebox@1.1.38",
       "author": "sinclairzx81",
       "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
       "licenses": [
@@ -3269,7 +3269,7 @@
       "name": "cross-spawn-promise",
       "group": "@malept",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|@malept/cross-spawn-promise@2.0.0",
+      "bom-ref": "cogseed@1.0.2|@malept/cross-spawn-promise@2.0.0",
       "author": "Mark Lee",
       "description": "Promisified version of cross-spawn",
       "licenses": [
@@ -3328,7 +3328,7 @@
       "type": "library",
       "name": "debug",
       "version": "4.4.3",
-      "bom-ref": "cogseed@0.9.0|debug@4.4.3",
+      "bom-ref": "cogseed@1.0.2|debug@4.4.3",
       "author": "Josh Junon",
       "description": "Lightweight debugging utility for Node.js and the browser",
       "licenses": [
@@ -3372,7 +3372,7 @@
       "type": "library",
       "name": "node-api-version",
       "version": "0.2.1",
-      "bom-ref": "cogseed@0.9.0|node-api-version@0.2.1",
+      "bom-ref": "cogseed@1.0.2|node-api-version@0.2.1",
       "author": "Tim Fish",
       "description": "Gets the supported Node-API version for a specific node or electron version",
       "licenses": [
@@ -3427,7 +3427,7 @@
       "type": "library",
       "name": "node-gyp",
       "version": "12.4.0",
-      "bom-ref": "cogseed@0.9.0|node-gyp@12.4.0",
+      "bom-ref": "cogseed@1.0.2|node-gyp@12.4.0",
       "author": "Nathan Rajlich",
       "description": "Node.js native addon build tool",
       "licenses": [
@@ -3486,7 +3486,7 @@
           "type": "library",
           "name": "undici",
           "version": "6.28.0",
-          "bom-ref": "cogseed@0.9.0|node-gyp@12.4.0|undici@6.28.0",
+          "bom-ref": "cogseed@1.0.2|node-gyp@12.4.0|undici@6.28.0",
           "description": "An HTTP/1.1 client, written from scratch for Node.js",
           "licenses": [
             {
@@ -3544,7 +3544,7 @@
           "type": "library",
           "name": "which",
           "version": "6.0.1",
-          "bom-ref": "cogseed@0.9.0|node-gyp@12.4.0|which@6.0.1",
+          "bom-ref": "cogseed@1.0.2|node-gyp@12.4.0|which@6.0.1",
           "author": "GitHub Inc.",
           "description": "Like which(1) unix command. Find the first instance of an executable in the PATH.",
           "licenses": [
@@ -3603,7 +3603,7 @@
           "type": "library",
           "name": "isexe",
           "version": "4.0.0",
-          "bom-ref": "cogseed@0.9.0|node-gyp@12.4.0|isexe@4.0.0",
+          "bom-ref": "cogseed@1.0.2|node-gyp@12.4.0|isexe@4.0.0",
           "author": "Isaac Z. Schlueter",
           "description": "Minimal module to check if a file is executable.",
           "licenses": [
@@ -3664,7 +3664,7 @@
       "type": "library",
       "name": "read-binary-file-arch",
       "version": "1.0.6",
-      "bom-ref": "cogseed@0.9.0|read-binary-file-arch@1.0.6",
+      "bom-ref": "cogseed@1.0.2|read-binary-file-arch@1.0.6",
       "author": "Samuel Maddock",
       "description": "Reads a binary file to determine its CPU architecture.",
       "licenses": [
@@ -3719,7 +3719,7 @@
       "type": "library",
       "name": "wasm-feature-detect",
       "version": "1.9.0",
-      "bom-ref": "cogseed@0.9.0|wasm-feature-detect@1.9.0",
+      "bom-ref": "cogseed@1.0.2|wasm-feature-detect@1.9.0",
       "author": "Surma",
       "description": "A small library to detect which features of WebAssembly are supported in your current browser.",
       "licenses": [
@@ -3770,7 +3770,7 @@
       "type": "library",
       "name": "axios",
       "version": "1.19.0",
-      "bom-ref": "cogseed@0.9.0|axios@1.19.0",
+      "bom-ref": "cogseed@1.0.2|axios@1.19.0",
       "author": "Matt Zabriskie",
       "description": "Promise based HTTP client for the browser and node.js",
       "licenses": [
@@ -3821,7 +3821,7 @@
           "type": "library",
           "name": "https-proxy-agent",
           "version": "5.0.1",
-          "bom-ref": "cogseed@0.9.0|axios@1.19.0|https-proxy-agent@5.0.1",
+          "bom-ref": "cogseed@1.0.2|axios@1.19.0|https-proxy-agent@5.0.1",
           "author": "Nathan Rajlich",
           "description": "An HTTP(s) proxy `http.Agent` implementation for HTTPS",
           "licenses": [
@@ -3876,7 +3876,7 @@
           "type": "library",
           "name": "agent-base",
           "version": "6.0.2",
-          "bom-ref": "cogseed@0.9.0|axios@1.19.0|agent-base@6.0.2",
+          "bom-ref": "cogseed@1.0.2|axios@1.19.0|agent-base@6.0.2",
           "author": "Nathan Rajlich",
           "description": "Turn a function into an `http.Agent` instance",
           "licenses": [
@@ -3933,7 +3933,7 @@
       "type": "library",
       "name": "lodash.identity",
       "version": "3.0.0",
-      "bom-ref": "cogseed@0.9.0|lodash.identity@3.0.0",
+      "bom-ref": "cogseed@1.0.2|lodash.identity@3.0.0",
       "author": "John-David Dalton",
       "description": "The modern build of lodash’s `_.identity` as a module.",
       "licenses": [
@@ -3984,7 +3984,7 @@
       "type": "library",
       "name": "lodash.merge",
       "version": "4.6.2",
-      "bom-ref": "cogseed@0.9.0|lodash.merge@4.6.2",
+      "bom-ref": "cogseed@1.0.2|lodash.merge@4.6.2",
       "author": "John-David Dalton",
       "description": "The Lodash method `_.merge` exported as a module.",
       "licenses": [
@@ -4035,7 +4035,7 @@
       "type": "library",
       "name": "lodash.pickby",
       "version": "4.6.0",
-      "bom-ref": "cogseed@0.9.0|lodash.pickby@4.6.0",
+      "bom-ref": "cogseed@1.0.2|lodash.pickby@4.6.0",
       "author": "John-David Dalton",
       "description": "The lodash method `_.pickBy` exported as a module.",
       "licenses": [
@@ -4086,7 +4086,7 @@
       "type": "library",
       "name": "protobufjs",
       "version": "7.6.5",
-      "bom-ref": "cogseed@0.9.0|protobufjs@7.6.5",
+      "bom-ref": "cogseed@1.0.2|protobufjs@7.6.5",
       "author": "Daniel Wirtz",
       "description": "Protocol Buffers for JavaScript (& TypeScript).",
       "licenses": [
@@ -4141,7 +4141,7 @@
       "type": "library",
       "name": "qs",
       "version": "6.16.0",
-      "bom-ref": "cogseed@0.9.0|qs@6.16.0",
+      "bom-ref": "cogseed@1.0.2|qs@6.16.0",
       "description": "A querystring parser that supports nesting and arrays, with a depth limit",
       "licenses": [
         {
@@ -4196,7 +4196,7 @@
       "name": "node-server",
       "group": "@hono",
       "version": "1.19.17",
-      "bom-ref": "cogseed@0.9.0|@hono/node-server@1.19.17",
+      "bom-ref": "cogseed@1.0.2|@hono/node-server@1.19.17",
       "author": "Yusuke Wada",
       "description": "Node.js Adapter for Hono",
       "licenses": [
@@ -4251,7 +4251,7 @@
       "type": "library",
       "name": "ajv",
       "version": "8.20.0",
-      "bom-ref": "cogseed@0.9.0|ajv@8.20.0",
+      "bom-ref": "cogseed@1.0.2|ajv@8.20.0",
       "author": "Evgeny Poberezkin",
       "description": "Another JSON Schema Validator",
       "licenses": [
@@ -4302,7 +4302,7 @@
       "type": "library",
       "name": "content-type",
       "version": "1.0.5",
-      "bom-ref": "cogseed@0.9.0|content-type@1.0.5",
+      "bom-ref": "cogseed@1.0.2|content-type@1.0.5",
       "author": "Douglas Christopher Wilson",
       "description": "Create and parse HTTP Content-Type header",
       "licenses": [
@@ -4357,7 +4357,7 @@
       "type": "library",
       "name": "cors",
       "version": "2.8.6",
-      "bom-ref": "cogseed@0.9.0|cors@2.8.6",
+      "bom-ref": "cogseed@1.0.2|cors@2.8.6",
       "author": "Troy Goode",
       "description": "Node.js CORS middleware",
       "licenses": [
@@ -4412,7 +4412,7 @@
       "type": "library",
       "name": "cross-spawn",
       "version": "7.0.6",
-      "bom-ref": "cogseed@0.9.0|cross-spawn@7.0.6",
+      "bom-ref": "cogseed@1.0.2|cross-spawn@7.0.6",
       "author": "André Cruz",
       "description": "Cross platform child_process#spawn and child_process#spawnSync",
       "licenses": [
@@ -4467,7 +4467,7 @@
       "type": "library",
       "name": "eventsource-parser",
       "version": "3.0.8",
-      "bom-ref": "cogseed@0.9.0|eventsource-parser@3.0.8",
+      "bom-ref": "cogseed@1.0.2|eventsource-parser@3.0.8",
       "author": "Espen Hovlandsdal",
       "description": "Streaming, source-agnostic EventSource/Server-Sent Events parser",
       "licenses": [
@@ -4522,7 +4522,7 @@
       "type": "library",
       "name": "eventsource",
       "version": "3.0.7",
-      "bom-ref": "cogseed@0.9.0|eventsource@3.0.7",
+      "bom-ref": "cogseed@1.0.2|eventsource@3.0.7",
       "author": "Espen Hovlandsdal",
       "description": "WhatWG/W3C compliant EventSource client for Node.js and browsers",
       "licenses": [
@@ -4577,7 +4577,7 @@
       "type": "library",
       "name": "express-rate-limit",
       "version": "8.5.1",
-      "bom-ref": "cogseed@0.9.0|express-rate-limit@8.5.1",
+      "bom-ref": "cogseed@1.0.2|express-rate-limit@8.5.1",
       "author": "Nathan Friedly",
       "description": "Basic IP rate-limiting middleware for Express. Use to limit repeated requests to public APIs and/or endpoints such as password reset.",
       "licenses": [
@@ -4632,7 +4632,7 @@
       "type": "library",
       "name": "express",
       "version": "5.2.1",
-      "bom-ref": "cogseed@0.9.0|express@5.2.1",
+      "bom-ref": "cogseed@1.0.2|express@5.2.1",
       "author": "TJ Holowaychuk",
       "description": "Fast, unopinionated, minimalist web framework",
       "licenses": [
@@ -4687,7 +4687,7 @@
           "type": "library",
           "name": "mime-types",
           "version": "3.0.2",
-          "bom-ref": "cogseed@0.9.0|express@5.2.1|mime-types@3.0.2",
+          "bom-ref": "cogseed@1.0.2|express@5.2.1|mime-types@3.0.2",
           "description": "The ultimate javascript content-type utility.",
           "licenses": [
             {
@@ -4741,7 +4741,7 @@
           "type": "library",
           "name": "mime-db",
           "version": "1.54.0",
-          "bom-ref": "cogseed@0.9.0|express@5.2.1|mime-db@1.54.0",
+          "bom-ref": "cogseed@1.0.2|express@5.2.1|mime-db@1.54.0",
           "description": "Media Type Database",
           "licenses": [
             {
@@ -4797,7 +4797,7 @@
       "type": "library",
       "name": "hono",
       "version": "4.13.7",
-      "bom-ref": "cogseed@0.9.0|hono@4.13.7",
+      "bom-ref": "cogseed@1.0.2|hono@4.13.7",
       "author": "Yusuke Wada",
       "description": "Web framework built on Web Standards",
       "licenses": [
@@ -4852,7 +4852,7 @@
       "type": "library",
       "name": "jose",
       "version": "6.2.3",
-      "bom-ref": "cogseed@0.9.0|jose@6.2.3",
+      "bom-ref": "cogseed@1.0.2|jose@6.2.3",
       "author": "Filip Skokan",
       "description": "JWA, JWS, JWE, JWT, JWK, JWKS for Node.js, Browser, Cloudflare Workers, Deno, Bun, and other Web-interoperable runtimes",
       "licenses": [
@@ -4903,7 +4903,7 @@
       "type": "library",
       "name": "pkce-challenge",
       "version": "5.0.1",
-      "bom-ref": "cogseed@0.9.0|pkce-challenge@5.0.1",
+      "bom-ref": "cogseed@1.0.2|pkce-challenge@5.0.1",
       "author": "crouchcd",
       "description": "Generate or verify a Proof Key for Code Exchange (PKCE) challenge pair",
       "licenses": [
@@ -4958,7 +4958,7 @@
       "type": "library",
       "name": "raw-body",
       "version": "3.0.2",
-      "bom-ref": "cogseed@0.9.0|raw-body@3.0.2",
+      "bom-ref": "cogseed@1.0.2|raw-body@3.0.2",
       "author": "Jonathan Ong",
       "description": "Get and validate the raw body of a readable stream.",
       "licenses": [
@@ -5013,7 +5013,7 @@
       "type": "library",
       "name": "zod-to-json-schema",
       "version": "3.25.2",
-      "bom-ref": "cogseed@0.9.0|zod-to-json-schema@3.25.2",
+      "bom-ref": "cogseed@1.0.2|zod-to-json-schema@3.25.2",
       "author": "Stefan Terdell",
       "description": "Converts Zod schemas to Json Schemas",
       "licenses": [
@@ -5054,7 +5054,7 @@
       "name": "v8-coverage",
       "group": "@bcoe",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|@bcoe/v8-coverage@1.0.2",
+      "bom-ref": "cogseed@1.0.2|@bcoe/v8-coverage@1.0.2",
       "author": "Charles Samborski",
       "description": "Helper functions for V8 coverage files.",
       "licenses": [
@@ -5114,7 +5114,7 @@
       "name": "utils",
       "group": "@vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|@vitest/utils@4.1.11",
+      "bom-ref": "cogseed@1.0.2|@vitest/utils@4.1.11",
       "description": "Shared Vitest utility functions",
       "licenses": [
         {
@@ -5168,7 +5168,7 @@
       "type": "library",
       "name": "ast-v8-to-istanbul",
       "version": "1.0.5",
-      "bom-ref": "cogseed@0.9.0|ast-v8-to-istanbul@1.0.5",
+      "bom-ref": "cogseed@1.0.2|ast-v8-to-istanbul@1.0.5",
       "author": "Ari Perkkiö",
       "description": "AST-aware v8-to-istanbul",
       "licenses": [
@@ -5223,7 +5223,7 @@
       "type": "library",
       "name": "istanbul-lib-coverage",
       "version": "3.2.2",
-      "bom-ref": "cogseed@0.9.0|istanbul-lib-coverage@3.2.2",
+      "bom-ref": "cogseed@1.0.2|istanbul-lib-coverage@3.2.2",
       "author": "Krishnan Anantheswaran",
       "description": "Data library for istanbul coverage objects",
       "licenses": [
@@ -5282,7 +5282,7 @@
       "type": "library",
       "name": "istanbul-lib-report",
       "version": "3.0.1",
-      "bom-ref": "cogseed@0.9.0|istanbul-lib-report@3.0.1",
+      "bom-ref": "cogseed@1.0.2|istanbul-lib-report@3.0.1",
       "author": "Krishnan Anantheswaran",
       "description": "Base reporting library for istanbul",
       "licenses": [
@@ -5341,7 +5341,7 @@
       "type": "library",
       "name": "istanbul-reports",
       "version": "3.2.0",
-      "bom-ref": "cogseed@0.9.0|istanbul-reports@3.2.0",
+      "bom-ref": "cogseed@1.0.2|istanbul-reports@3.2.0",
       "author": "Krishnan Anantheswaran",
       "description": "istanbul reports",
       "licenses": [
@@ -5400,7 +5400,7 @@
       "type": "library",
       "name": "magicast",
       "version": "0.5.3",
-      "bom-ref": "cogseed@0.9.0|magicast@0.5.3",
+      "bom-ref": "cogseed@1.0.2|magicast@0.5.3",
       "description": "Modify a JS/TS file and write back magically just like JSON!",
       "licenses": [
         {
@@ -5454,7 +5454,7 @@
       "type": "library",
       "name": "obug",
       "version": "2.1.1",
-      "bom-ref": "cogseed@0.9.0|obug@2.1.1",
+      "bom-ref": "cogseed@1.0.2|obug@2.1.1",
       "author": "Kevin Deng",
       "description": "A lightweight JavaScript debugging utility, forked from debug, featuring TypeScript and ESM support.",
       "licenses": [
@@ -5498,7 +5498,7 @@
       "type": "library",
       "name": "std-env",
       "version": "4.2.0",
-      "bom-ref": "cogseed@0.9.0|std-env@4.2.0",
+      "bom-ref": "cogseed@1.0.2|std-env@4.2.0",
       "description": "Runtime agnostic JS utils",
       "licenses": [
         {
@@ -5552,7 +5552,7 @@
       "type": "library",
       "name": "tinyrainbow",
       "version": "3.1.0",
-      "bom-ref": "cogseed@0.9.0|tinyrainbow@3.1.0",
+      "bom-ref": "cogseed@1.0.2|tinyrainbow@3.1.0",
       "description": "A small library to print colourful messages.",
       "licenses": [
         {
@@ -5610,7 +5610,7 @@
       "type": "library",
       "name": "eventemitter3",
       "version": "5.0.4",
-      "bom-ref": "cogseed@0.9.0|eventemitter3@5.0.4",
+      "bom-ref": "cogseed@1.0.2|eventemitter3@5.0.4",
       "author": "Arnout Kazemier",
       "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
       "licenses": [
@@ -5661,7 +5661,7 @@
       "type": "library",
       "name": "tslib",
       "version": "2.8.1",
-      "bom-ref": "cogseed@0.9.0|tslib@2.8.1",
+      "bom-ref": "cogseed@1.0.2|tslib@2.8.1",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -5701,7 +5701,7 @@
       "type": "library",
       "name": "bindings",
       "version": "1.5.0",
-      "bom-ref": "cogseed@0.9.0|bindings@1.5.0",
+      "bom-ref": "cogseed@1.0.2|bindings@1.5.0",
       "author": "Nathan Rajlich",
       "description": "Helper module for loading your native module's .node file",
       "licenses": [
@@ -5741,7 +5741,7 @@
       "type": "library",
       "name": "prebuild-install",
       "version": "7.1.3",
-      "bom-ref": "cogseed@0.9.0|prebuild-install@7.1.3",
+      "bom-ref": "cogseed@1.0.2|prebuild-install@7.1.3",
       "author": "Mathias Buus",
       "description": "A command line tool to easily install prebuilt binaries for multiple version of node/iojs on a specific platform",
       "licenses": [
@@ -5785,7 +5785,7 @@
       "type": "library",
       "name": "app-builder-lib",
       "version": "26.15.7",
-      "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7",
+      "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7",
       "author": "Vladimir Krivosheev",
       "description": "electron-builder lib",
       "licenses": [
@@ -5845,7 +5845,7 @@
           "name": "get",
           "group": "@electron",
           "version": "3.1.0",
-          "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0",
+          "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0",
           "author": "Samuel Attard",
           "description": "Utility for downloading artifacts from different versions of Electron",
           "licenses": [
@@ -5904,7 +5904,7 @@
               "type": "library",
               "name": "fs-extra",
               "version": "8.1.0",
-              "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0|fs-extra@8.1.0",
+              "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0|fs-extra@8.1.0",
               "author": "JP Richardson",
               "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as mkdir -p, cp -r, and rm -rf.",
               "licenses": [
@@ -5963,7 +5963,7 @@
               "type": "library",
               "name": "semver",
               "version": "6.3.1",
-              "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0|semver@6.3.1",
+              "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0|semver@6.3.1",
               "author": "GitHub Inc.",
               "description": "The semantic version parser used by npm.",
               "licenses": [
@@ -6020,7 +6020,7 @@
           "type": "library",
           "name": "ci-info",
           "version": "4.3.1",
-          "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|ci-info@4.3.1",
+          "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|ci-info@4.3.1",
           "author": "Thomas Watson Steen",
           "description": "Get details about the current Continuous Integration environment",
           "licenses": [
@@ -6079,7 +6079,7 @@
           "type": "library",
           "name": "semver",
           "version": "7.7.4",
-          "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|semver@7.7.4",
+          "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|semver@7.7.4",
           "author": "GitHub Inc.",
           "description": "The semantic version parser used by npm.",
           "licenses": [
@@ -6138,7 +6138,7 @@
           "type": "library",
           "name": "which",
           "version": "5.0.0",
-          "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|which@5.0.0",
+          "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|which@5.0.0",
           "author": "GitHub Inc.",
           "description": "Like which(1) unix command. Find the first instance of an executable in the PATH.",
           "licenses": [
@@ -6197,7 +6197,7 @@
           "type": "library",
           "name": "isexe",
           "version": "3.1.5",
-          "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|isexe@3.1.5",
+          "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|isexe@3.1.5",
           "author": "Isaac Z. Schlueter",
           "description": "Minimal module to check if a file is executable.",
           "licenses": [
@@ -6256,7 +6256,7 @@
           "type": "library",
           "name": "jsonfile",
           "version": "4.0.0",
-          "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|jsonfile@4.0.0",
+          "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|jsonfile@4.0.0",
           "author": "JP Richardson",
           "description": "Easily read/write JSON files.",
           "licenses": [
@@ -6311,7 +6311,7 @@
           "type": "library",
           "name": "universalify",
           "version": "0.1.2",
-          "bom-ref": "cogseed@0.9.0|app-builder-lib@26.15.7|universalify@0.1.2",
+          "bom-ref": "cogseed@1.0.2|app-builder-lib@26.15.7|universalify@0.1.2",
           "author": "Ryan Zimmerman",
           "description": "Make a callback- or promise-based function support both promises and callbacks.",
           "licenses": [
@@ -6372,7 +6372,7 @@
       "type": "library",
       "name": "builder-util-runtime",
       "version": "9.7.0",
-      "bom-ref": "cogseed@0.9.0|builder-util-runtime@9.7.0",
+      "bom-ref": "cogseed@1.0.2|builder-util-runtime@9.7.0",
       "author": "Vladimir Krivosheev",
       "licenses": [
         {
@@ -6430,7 +6430,7 @@
       "type": "library",
       "name": "builder-util",
       "version": "26.15.3",
-      "bom-ref": "cogseed@0.9.0|builder-util@26.15.3",
+      "bom-ref": "cogseed@1.0.2|builder-util@26.15.3",
       "author": "Vladimir Krivosheev",
       "licenses": [
         {
@@ -6488,7 +6488,7 @@
       "type": "library",
       "name": "chalk",
       "version": "4.1.2",
-      "bom-ref": "cogseed@0.9.0|chalk@4.1.2",
+      "bom-ref": "cogseed@1.0.2|chalk@4.1.2",
       "description": "Terminal string styling done right",
       "licenses": [
         {
@@ -6546,7 +6546,7 @@
       "type": "library",
       "name": "ci-info",
       "version": "4.4.0",
-      "bom-ref": "cogseed@0.9.0|ci-info@4.4.0",
+      "bom-ref": "cogseed@1.0.2|ci-info@4.4.0",
       "author": "Thomas Watson Steen",
       "description": "Get details about the current Continuous Integration environment",
       "licenses": [
@@ -6605,7 +6605,7 @@
       "type": "library",
       "name": "dmg-builder",
       "version": "26.15.7",
-      "bom-ref": "cogseed@0.9.0|dmg-builder@26.15.7",
+      "bom-ref": "cogseed@1.0.2|dmg-builder@26.15.7",
       "author": "Vladimir Krivosheev",
       "licenses": [
         {
@@ -6659,7 +6659,7 @@
       "type": "library",
       "name": "fs-extra",
       "version": "10.1.0",
-      "bom-ref": "cogseed@0.9.0|fs-extra@10.1.0",
+      "bom-ref": "cogseed@1.0.2|fs-extra@10.1.0",
       "author": "JP Richardson",
       "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.",
       "licenses": [
@@ -6718,7 +6718,7 @@
       "type": "library",
       "name": "lazy-val",
       "version": "1.0.5",
-      "bom-ref": "cogseed@0.9.0|lazy-val@1.0.5",
+      "bom-ref": "cogseed@1.0.2|lazy-val@1.0.5",
       "author": "Vladimir Krivosheev",
       "licenses": [
         {
@@ -6772,7 +6772,7 @@
       "type": "library",
       "name": "simple-update-notifier",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|simple-update-notifier@2.0.0",
+      "bom-ref": "cogseed@1.0.2|simple-update-notifier@2.0.0",
       "author": "alexbrazier",
       "description": "Simple update notifier to check for npm updates for cli applications",
       "licenses": [
@@ -6831,7 +6831,7 @@
       "type": "library",
       "name": "yargs",
       "version": "17.7.3",
-      "bom-ref": "cogseed@0.9.0|yargs@17.7.3",
+      "bom-ref": "cogseed@1.0.2|yargs@17.7.3",
       "description": "yargs the modern, pirate-themed, successor to optimist.",
       "licenses": [
         {
@@ -6890,7 +6890,7 @@
       "name": "extract-zip",
       "group": "@electron-internal",
       "version": "1.0.5",
-      "bom-ref": "cogseed@0.9.0|@electron-internal/extract-zip@1.0.5",
+      "bom-ref": "cogseed@1.0.2|@electron-internal/extract-zip@1.0.5",
       "description": "Fast, safe, native zip extraction for Node.js. Drop-in replacement for extract-zip.",
       "licenses": [
         {
@@ -6949,7 +6949,7 @@
       "name": "get",
       "group": "@electron",
       "version": "5.1.0",
-      "bom-ref": "cogseed@0.9.0|@electron/get@5.1.0",
+      "bom-ref": "cogseed@1.0.2|@electron/get@5.1.0",
       "author": "Samuel Attard",
       "description": "Utility for downloading artifacts from different versions of Electron",
       "licenses": [
@@ -7008,7 +7008,7 @@
           "type": "library",
           "name": "env-paths",
           "version": "3.0.0",
-          "bom-ref": "cogseed@0.9.0|@electron/get@5.1.0|env-paths@3.0.0",
+          "bom-ref": "cogseed@1.0.2|@electron/get@5.1.0|env-paths@3.0.0",
           "author": "Sindre Sorhus",
           "description": "Get paths for storing things like data, config, cache, etc",
           "licenses": [
@@ -7070,7 +7070,7 @@
       "name": "darwin-arm64",
       "group": "@esbuild",
       "version": "0.28.2",
-      "bom-ref": "cogseed@0.9.0|@esbuild/darwin-arm64@0.28.2",
+      "bom-ref": "cogseed@1.0.2|@esbuild/darwin-arm64@0.28.2",
       "description": "The macOS ARM 64-bit binary for esbuild, a JavaScript bundler.",
       "licenses": [
         {
@@ -7125,7 +7125,7 @@
       "name": "eslint-utils",
       "group": "@eslint-community",
       "version": "4.10.1",
-      "bom-ref": "cogseed@0.9.0|@eslint-community/eslint-utils@4.10.1",
+      "bom-ref": "cogseed@1.0.2|@eslint-community/eslint-utils@4.10.1",
       "author": "Toru Nagashima",
       "description": "Utilities for ESLint plugins.",
       "licenses": [
@@ -7184,7 +7184,7 @@
           "type": "library",
           "name": "eslint-visitor-keys",
           "version": "3.4.3",
-          "bom-ref": "cogseed@0.9.0|@eslint-community/eslint-utils@4.10.1|eslint-visitor-keys@3.4.3",
+          "bom-ref": "cogseed@1.0.2|@eslint-community/eslint-utils@4.10.1|eslint-visitor-keys@3.4.3",
           "author": "Toru Nagashima",
           "description": "Constants and utilities about visitor keys to traverse AST.",
           "licenses": [
@@ -7246,7 +7246,7 @@
       "name": "regexpp",
       "group": "@eslint-community",
       "version": "4.12.2",
-      "bom-ref": "cogseed@0.9.0|@eslint-community/regexpp@4.12.2",
+      "bom-ref": "cogseed@1.0.2|@eslint-community/regexpp@4.12.2",
       "author": "Toru Nagashima",
       "description": "Regular expression parser for ECMAScript.",
       "licenses": [
@@ -7306,7 +7306,7 @@
       "name": "config-array",
       "group": "@eslint",
       "version": "0.23.5",
-      "bom-ref": "cogseed@0.9.0|@eslint/config-array@0.23.5",
+      "bom-ref": "cogseed@1.0.2|@eslint/config-array@0.23.5",
       "author": "Nicholas C. Zakas",
       "description": "General purpose glob-based configuration matching.",
       "licenses": [
@@ -7366,7 +7366,7 @@
       "name": "config-helpers",
       "group": "@eslint",
       "version": "0.7.0",
-      "bom-ref": "cogseed@0.9.0|@eslint/config-helpers@0.7.0",
+      "bom-ref": "cogseed@1.0.2|@eslint/config-helpers@0.7.0",
       "description": "Helper utilities for creating ESLint configuration",
       "licenses": [
         {
@@ -7425,7 +7425,7 @@
       "name": "core",
       "group": "@eslint",
       "version": "1.2.1",
-      "bom-ref": "cogseed@0.9.0|@eslint/core@1.2.1",
+      "bom-ref": "cogseed@1.0.2|@eslint/core@1.2.1",
       "author": "Nicholas C. Zakas",
       "description": "Runtime-agnostic core of ESLint",
       "licenses": [
@@ -7485,7 +7485,7 @@
       "name": "plugin-kit",
       "group": "@eslint",
       "version": "0.7.2",
-      "bom-ref": "cogseed@0.9.0|@eslint/plugin-kit@0.7.2",
+      "bom-ref": "cogseed@1.0.2|@eslint/plugin-kit@0.7.2",
       "author": "Nicholas C. Zakas",
       "description": "Utilities for building ESLint plugins.",
       "licenses": [
@@ -7545,7 +7545,7 @@
       "name": "node",
       "group": "@humanfs",
       "version": "0.16.8",
-      "bom-ref": "cogseed@0.9.0|@humanfs/node@0.16.8",
+      "bom-ref": "cogseed@1.0.2|@humanfs/node@0.16.8",
       "author": "Nicholas C. Zakas",
       "description": "The Node.js bindings of the humanfs library.",
       "licenses": [
@@ -7605,7 +7605,7 @@
       "name": "module-importer",
       "group": "@humanwhocodes",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|@humanwhocodes/module-importer@1.0.1",
+      "bom-ref": "cogseed@1.0.2|@humanwhocodes/module-importer@1.0.1",
       "author": "Nicholas C. Zaks",
       "description": "Universal module importer for Node.js",
       "licenses": [
@@ -7665,7 +7665,7 @@
       "name": "retry",
       "group": "@humanwhocodes",
       "version": "0.4.3",
-      "bom-ref": "cogseed@0.9.0|@humanwhocodes/retry@0.4.3",
+      "bom-ref": "cogseed@1.0.2|@humanwhocodes/retry@0.4.3",
       "author": "Nicholas C. Zaks",
       "description": "A utility to retry failed async methods.",
       "licenses": [
@@ -7725,7 +7725,7 @@
       "name": "estree",
       "group": "@types",
       "version": "1.0.9",
-      "bom-ref": "cogseed@0.9.0|@types/estree@1.0.9",
+      "bom-ref": "cogseed@1.0.2|@types/estree@1.0.9",
       "description": "TypeScript definitions for estree",
       "licenses": [
         {
@@ -7779,7 +7779,7 @@
       "type": "library",
       "name": "escape-string-regexp",
       "version": "4.0.0",
-      "bom-ref": "cogseed@0.9.0|escape-string-regexp@4.0.0",
+      "bom-ref": "cogseed@1.0.2|escape-string-regexp@4.0.0",
       "author": "Sindre Sorhus",
       "description": "Escape RegExp special characters",
       "licenses": [
@@ -7823,7 +7823,7 @@
       "type": "library",
       "name": "eslint-scope",
       "version": "9.1.2",
-      "bom-ref": "cogseed@0.9.0|eslint-scope@9.1.2",
+      "bom-ref": "cogseed@1.0.2|eslint-scope@9.1.2",
       "description": "ECMAScript scope analyzer for ESLint",
       "licenses": [
         {
@@ -7881,7 +7881,7 @@
       "type": "library",
       "name": "eslint-visitor-keys",
       "version": "5.0.1",
-      "bom-ref": "cogseed@0.9.0|eslint-visitor-keys@5.0.1",
+      "bom-ref": "cogseed@1.0.2|eslint-visitor-keys@5.0.1",
       "author": "Toru Nagashima",
       "description": "Constants and utilities about visitor keys to traverse AST.",
       "licenses": [
@@ -7940,7 +7940,7 @@
       "type": "library",
       "name": "espree",
       "version": "11.2.0",
-      "bom-ref": "cogseed@0.9.0|espree@11.2.0",
+      "bom-ref": "cogseed@1.0.2|espree@11.2.0",
       "author": "Nicholas C. Zakas",
       "description": "An Esprima-compatible JavaScript parser built on Acorn",
       "licenses": [
@@ -7999,7 +7999,7 @@
       "type": "library",
       "name": "esquery",
       "version": "1.7.0",
-      "bom-ref": "cogseed@0.9.0|esquery@1.7.0",
+      "bom-ref": "cogseed@1.0.2|esquery@1.7.0",
       "author": "Joel Feenstra",
       "description": "A query library for ECMAScript AST using a CSS selector like query language.",
       "licenses": [
@@ -8058,7 +8058,7 @@
       "type": "library",
       "name": "esutils",
       "version": "2.0.3",
-      "bom-ref": "cogseed@0.9.0|esutils@2.0.3",
+      "bom-ref": "cogseed@1.0.2|esutils@2.0.3",
       "description": "utility box for ECMAScript language tools",
       "licenses": [
         {
@@ -8116,7 +8116,7 @@
       "type": "library",
       "name": "fast-deep-equal",
       "version": "3.1.3",
-      "bom-ref": "cogseed@0.9.0|fast-deep-equal@3.1.3",
+      "bom-ref": "cogseed@1.0.2|fast-deep-equal@3.1.3",
       "author": "Evgeny Poberezkin",
       "description": "Fast deep equal",
       "licenses": [
@@ -8167,7 +8167,7 @@
       "type": "library",
       "name": "file-entry-cache",
       "version": "8.0.0",
-      "bom-ref": "cogseed@0.9.0|file-entry-cache@8.0.0",
+      "bom-ref": "cogseed@1.0.2|file-entry-cache@8.0.0",
       "author": "Jared Wray",
       "description": "Super simple cache for file metadata, useful for process that work o a given series of files and that only need to repeat the job on the changed ones since the previous run of the process",
       "licenses": [
@@ -8226,7 +8226,7 @@
       "type": "library",
       "name": "find-up",
       "version": "5.0.0",
-      "bom-ref": "cogseed@0.9.0|find-up@5.0.0",
+      "bom-ref": "cogseed@1.0.2|find-up@5.0.0",
       "author": "Sindre Sorhus",
       "description": "Find a file or directory by walking up parent directories",
       "licenses": [
@@ -8285,7 +8285,7 @@
       "type": "library",
       "name": "glob-parent",
       "version": "6.0.2",
-      "bom-ref": "cogseed@0.9.0|glob-parent@6.0.2",
+      "bom-ref": "cogseed@1.0.2|glob-parent@6.0.2",
       "author": "Gulp Team",
       "description": "Extract the non-magic parent path from a glob string.",
       "licenses": [
@@ -8344,7 +8344,7 @@
       "type": "library",
       "name": "ignore",
       "version": "5.3.2",
-      "bom-ref": "cogseed@0.9.0|ignore@5.3.2",
+      "bom-ref": "cogseed@1.0.2|ignore@5.3.2",
       "author": "kael",
       "description": "Ignore is a manager and filter for .gitignore rules, the one used by eslint, gitbook and many others.",
       "licenses": [
@@ -8403,7 +8403,7 @@
       "type": "library",
       "name": "imurmurhash",
       "version": "0.1.4",
-      "bom-ref": "cogseed@0.9.0|imurmurhash@0.1.4",
+      "bom-ref": "cogseed@1.0.2|imurmurhash@0.1.4",
       "author": "Jens Taylor",
       "description": "An incremental implementation of MurmurHash3",
       "licenses": [
@@ -8462,7 +8462,7 @@
       "type": "library",
       "name": "is-glob",
       "version": "4.0.3",
-      "bom-ref": "cogseed@0.9.0|is-glob@4.0.3",
+      "bom-ref": "cogseed@1.0.2|is-glob@4.0.3",
       "author": "Jon Schlinkert",
       "description": "Returns `true` if the given string looks like a glob pattern or an extglob pattern. This makes it easy to create code that only uses external modules like node-glob when necessary, resulting in much faster code execution and initialization time, and a better user experience.",
       "licenses": [
@@ -8521,7 +8521,7 @@
       "type": "library",
       "name": "jiti",
       "version": "2.7.0",
-      "bom-ref": "cogseed@0.9.0|jiti@2.7.0",
+      "bom-ref": "cogseed@1.0.2|jiti@2.7.0",
       "description": "Runtime typescript and ESM support for Node.js",
       "licenses": [
         {
@@ -8575,7 +8575,7 @@
       "type": "library",
       "name": "json-stable-stringify-without-jsonify",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|json-stable-stringify-without-jsonify@1.0.1",
+      "bom-ref": "cogseed@1.0.2|json-stable-stringify-without-jsonify@1.0.1",
       "author": "James Halliday",
       "description": "deterministic JSON.stringify() with custom sorting to get deterministic hashes from stringified results, with no public domain dependencies",
       "licenses": [
@@ -8630,7 +8630,7 @@
       "type": "library",
       "name": "minimatch",
       "version": "10.2.6",
-      "bom-ref": "cogseed@0.9.0|minimatch@10.2.6",
+      "bom-ref": "cogseed@1.0.2|minimatch@10.2.6",
       "author": "Isaac Z. Schlueter",
       "description": "a glob matcher in javascript",
       "licenses": [
@@ -8689,7 +8689,7 @@
       "type": "library",
       "name": "natural-compare",
       "version": "1.4.0",
-      "bom-ref": "cogseed@0.9.0|natural-compare@1.4.0",
+      "bom-ref": "cogseed@1.0.2|natural-compare@1.4.0",
       "author": "Lauri Rooden",
       "description": "Compare strings containing a mix of letters and numbers in the way a human being would in sort order.",
       "licenses": [
@@ -8744,7 +8744,7 @@
       "type": "library",
       "name": "optionator",
       "version": "0.9.4",
-      "bom-ref": "cogseed@0.9.0|optionator@0.9.4",
+      "bom-ref": "cogseed@1.0.2|optionator@0.9.4",
       "author": "George Zahariev",
       "description": "option parsing and help generation",
       "licenses": [
@@ -8804,7 +8804,7 @@
       "name": "tokenizers",
       "group": "@anush008",
       "version": "0.0.0",
-      "bom-ref": "cogseed@0.9.0|@anush008/tokenizers@0.0.0",
+      "bom-ref": "cogseed@1.0.2|@anush008/tokenizers@0.0.0",
       "description": "Multi-arch builds of HuggingFace tokenizers",
       "licenses": [
         {
@@ -8859,7 +8859,7 @@
       "name": "hub",
       "group": "@huggingface",
       "version": "2.11.0",
-      "bom-ref": "cogseed@0.9.0|@huggingface/hub@2.11.0",
+      "bom-ref": "cogseed@1.0.2|@huggingface/hub@2.11.0",
       "author": "Hugging Face",
       "description": "Utilities to interact with the Hugging Face hub",
       "licenses": [
@@ -8914,7 +8914,7 @@
       "type": "library",
       "name": "onnxruntime-node",
       "version": "1.21.0",
-      "bom-ref": "cogseed@0.9.0|onnxruntime-node@1.21.0",
+      "bom-ref": "cogseed@1.0.2|onnxruntime-node@1.21.0",
       "author": "fs-eire",
       "description": "ONNXRuntime Node.js binding",
       "licenses": [
@@ -8965,7 +8965,7 @@
       "type": "library",
       "name": "progress",
       "version": "2.0.3",
-      "bom-ref": "cogseed@0.9.0|progress@2.0.3",
+      "bom-ref": "cogseed@1.0.2|progress@2.0.3",
       "author": "TJ Holowaychuk",
       "description": "Flexible ascii progress bar",
       "licenses": [
@@ -9010,7 +9010,7 @@
       "name": "core",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/core@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/core@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9065,7 +9065,7 @@
       "name": "diff",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/diff@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/diff@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9120,7 +9120,7 @@
       "name": "js-bmp",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/js-bmp@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/js-bmp@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9175,7 +9175,7 @@
       "name": "js-gif",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/js-gif@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/js-gif@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9230,7 +9230,7 @@
       "name": "js-jpeg",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/js-jpeg@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/js-jpeg@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9285,7 +9285,7 @@
       "name": "js-png",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/js-png@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/js-png@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9340,7 +9340,7 @@
       "name": "js-tiff",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/js-tiff@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/js-tiff@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9395,7 +9395,7 @@
       "name": "plugin-blit",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-blit@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-blit@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9450,7 +9450,7 @@
       "name": "plugin-blur",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-blur@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-blur@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9505,7 +9505,7 @@
       "name": "plugin-circle",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-circle@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-circle@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9560,7 +9560,7 @@
       "name": "plugin-color",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-color@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-color@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9615,7 +9615,7 @@
       "name": "plugin-contain",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-contain@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-contain@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9670,7 +9670,7 @@
       "name": "plugin-cover",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-cover@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-cover@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9725,7 +9725,7 @@
       "name": "plugin-crop",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-crop@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-crop@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9780,7 +9780,7 @@
       "name": "plugin-displace",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-displace@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-displace@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9835,7 +9835,7 @@
       "name": "plugin-dither",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-dither@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-dither@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9890,7 +9890,7 @@
       "name": "plugin-fisheye",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-fisheye@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-fisheye@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -9945,7 +9945,7 @@
       "name": "plugin-flip",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-flip@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-flip@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10000,7 +10000,7 @@
       "name": "plugin-hash",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-hash@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-hash@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10055,7 +10055,7 @@
       "name": "plugin-mask",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-mask@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-mask@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10110,7 +10110,7 @@
       "name": "plugin-print",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-print@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-print@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10165,7 +10165,7 @@
       "name": "plugin-quantize",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-quantize@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-quantize@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10220,7 +10220,7 @@
       "name": "plugin-resize",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-resize@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-resize@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10275,7 +10275,7 @@
       "name": "plugin-rotate",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-rotate@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-rotate@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10330,7 +10330,7 @@
       "name": "plugin-threshold",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/plugin-threshold@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/plugin-threshold@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10385,7 +10385,7 @@
       "name": "types",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/types@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/types@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10440,7 +10440,7 @@
       "name": "utils",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/utils@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/utils@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -10495,7 +10495,7 @@
       "name": "xmldom",
       "group": "@xmldom",
       "version": "0.8.15",
-      "bom-ref": "cogseed@0.9.0|@xmldom/xmldom@0.8.15",
+      "bom-ref": "cogseed@1.0.2|@xmldom/xmldom@0.8.15",
       "description": "A pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module.",
       "licenses": [
         {
@@ -10549,7 +10549,7 @@
       "type": "library",
       "name": "argparse",
       "version": "1.0.10",
-      "bom-ref": "cogseed@0.9.0|argparse@1.0.10",
+      "bom-ref": "cogseed@1.0.2|argparse@1.0.10",
       "description": "Very powerful CLI arguments parser. Native port of argparse - python's options parsing library",
       "licenses": [
         {
@@ -10599,7 +10599,7 @@
           "type": "library",
           "name": "sprintf-js",
           "version": "1.0.3",
-          "bom-ref": "cogseed@0.9.0|argparse@1.0.10|sprintf-js@1.0.3",
+          "bom-ref": "cogseed@1.0.2|argparse@1.0.10|sprintf-js@1.0.3",
           "author": "Alexandru Marasteanu",
           "description": "JavaScript sprintf implementation",
           "licenses": [
@@ -10652,7 +10652,7 @@
       "type": "library",
       "name": "base64-js",
       "version": "1.5.1",
-      "bom-ref": "cogseed@0.9.0|base64-js@1.5.1",
+      "bom-ref": "cogseed@1.0.2|base64-js@1.5.1",
       "author": "T. Jameson Little",
       "description": "Base64 encoding/decoding in pure JS",
       "licenses": [
@@ -10692,7 +10692,7 @@
       "type": "library",
       "name": "bluebird",
       "version": "3.4.7",
-      "bom-ref": "cogseed@0.9.0|bluebird@3.4.7",
+      "bom-ref": "cogseed@1.0.2|bluebird@3.4.7",
       "author": "Petka Antonov",
       "description": "Full featured Promises/A+ implementation with exceptionally good performance",
       "licenses": [
@@ -10743,7 +10743,7 @@
       "type": "library",
       "name": "dingbat-to-unicode",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|dingbat-to-unicode@1.0.1",
+      "bom-ref": "cogseed@1.0.2|dingbat-to-unicode@1.0.1",
       "author": "Michael Williamson",
       "description": "Mapping from Dingbat fonts, such as Symbol, Webdings and Wingdings, to Unicode code points",
       "licenses": [
@@ -10794,7 +10794,7 @@
       "type": "library",
       "name": "jszip",
       "version": "3.10.1",
-      "bom-ref": "cogseed@0.9.0|jszip@3.10.1",
+      "bom-ref": "cogseed@1.0.2|jszip@3.10.1",
       "author": "Stuart Knightley",
       "description": "Create, read and edit .zip files with JavaScript http://stuartk.com/jszip",
       "licenses": [
@@ -10843,7 +10843,7 @@
           "type": "library",
           "name": "readable-stream",
           "version": "2.3.8",
-          "bom-ref": "cogseed@0.9.0|jszip@3.10.1|readable-stream@2.3.8",
+          "bom-ref": "cogseed@1.0.2|jszip@3.10.1|readable-stream@2.3.8",
           "description": "Streams3, a user-land copy of the stream library from Node.js",
           "licenses": [
             {
@@ -10893,7 +10893,7 @@
           "type": "library",
           "name": "safe-buffer",
           "version": "5.1.2",
-          "bom-ref": "cogseed@0.9.0|jszip@3.10.1|safe-buffer@5.1.2",
+          "bom-ref": "cogseed@1.0.2|jszip@3.10.1|safe-buffer@5.1.2",
           "author": "Feross Aboukhadijeh",
           "description": "Safer Node.js Buffer API",
           "licenses": [
@@ -10944,7 +10944,7 @@
           "type": "library",
           "name": "string_decoder",
           "version": "1.1.1",
-          "bom-ref": "cogseed@0.9.0|jszip@3.10.1|string_decoder@1.1.1",
+          "bom-ref": "cogseed@1.0.2|jszip@3.10.1|string_decoder@1.1.1",
           "description": "The string_decoder module from Node core",
           "licenses": [
             {
@@ -10996,7 +10996,7 @@
       "type": "library",
       "name": "lop",
       "version": "0.4.2",
-      "bom-ref": "cogseed@0.9.0|lop@0.4.2",
+      "bom-ref": "cogseed@1.0.2|lop@0.4.2",
       "author": "Michael Williamson",
       "description": "Create parsers using parser combinators with helpful error messages",
       "licenses": [
@@ -11047,7 +11047,7 @@
       "type": "library",
       "name": "path-is-absolute",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|path-is-absolute@1.0.1",
+      "bom-ref": "cogseed@1.0.2|path-is-absolute@1.0.1",
       "author": "Sindre Sorhus",
       "description": "Node.js 0.12 path.isAbsolute() ponyfill",
       "licenses": [
@@ -11102,7 +11102,7 @@
       "type": "library",
       "name": "underscore",
       "version": "1.13.8",
-      "bom-ref": "cogseed@0.9.0|underscore@1.13.8",
+      "bom-ref": "cogseed@1.0.2|underscore@1.13.8",
       "author": "Jeremy Ashkenas",
       "description": "JavaScript's functional programming helper library.",
       "licenses": [
@@ -11153,7 +11153,7 @@
       "type": "library",
       "name": "xmlbuilder",
       "version": "10.1.1",
-      "bom-ref": "cogseed@0.9.0|xmlbuilder@10.1.1",
+      "bom-ref": "cogseed@1.0.2|xmlbuilder@10.1.1",
       "author": "Ozgur Ozcitak",
       "description": "An XML builder for node.js",
       "licenses": [
@@ -11208,7 +11208,7 @@
       "type": "library",
       "name": "node-addon-api",
       "version": "7.1.1",
-      "bom-ref": "cogseed@0.9.0|node-addon-api@7.1.1",
+      "bom-ref": "cogseed@1.0.2|node-addon-api@7.1.1",
       "description": "Node.js API (Node-API)",
       "licenses": [
         {
@@ -11259,7 +11259,7 @@
       "name": "canvas",
       "group": "@napi-rs",
       "version": "1.0.7",
-      "bom-ref": "cogseed@0.9.0|@napi-rs/canvas@1.0.7",
+      "bom-ref": "cogseed@1.0.2|@napi-rs/canvas@1.0.7",
       "description": "Canvas for Node.js with skia backend",
       "licenses": [
         {
@@ -11313,7 +11313,7 @@
       "type": "library",
       "name": "sherpa-onnx-darwin-arm64",
       "version": "1.13.6",
-      "bom-ref": "cogseed@0.9.0|sherpa-onnx-darwin-arm64@1.13.6",
+      "bom-ref": "cogseed@1.0.2|sherpa-onnx-darwin-arm64@1.13.6",
       "author": "The next-gen Kaldi team",
       "description": "Speech-to-text, text-to-speech, speaker diarization, and speech enhancement using Next-gen Kaldi without internet connection",
       "licenses": [
@@ -11364,7 +11364,7 @@
       "type": "library",
       "name": "agent-base",
       "version": "7.1.4",
-      "bom-ref": "cogseed@0.9.0|agent-base@7.1.4",
+      "bom-ref": "cogseed@1.0.2|agent-base@7.1.4",
       "author": "Nathan Rajlich",
       "description": "Turn a function into an `http.Agent` instance",
       "licenses": [
@@ -11419,7 +11419,7 @@
       "type": "library",
       "name": "socks",
       "version": "2.8.9",
-      "bom-ref": "cogseed@0.9.0|socks@2.8.9",
+      "bom-ref": "cogseed@1.0.2|socks@2.8.9",
       "author": "Josh Glazebrook",
       "description": "Fully featured SOCKS proxy client supporting SOCKSv4, SOCKSv4a, and SOCKSv5. Includes Bind and Associate functionality.",
       "licenses": [
@@ -11478,7 +11478,7 @@
       "type": "library",
       "name": "sqlite-vec-darwin-arm64",
       "version": "0.1.9",
-      "bom-ref": "cogseed@0.9.0|sqlite-vec-darwin-arm64@0.1.9",
+      "bom-ref": "cogseed@1.0.2|sqlite-vec-darwin-arm64@0.1.9",
       "author": "Alex Garcia",
       "description": "A vector search SQLite extension.",
       "licenses": [
@@ -11530,7 +11530,7 @@
       "name": "fs-minipass",
       "group": "@isaacs",
       "version": "4.0.1",
-      "bom-ref": "cogseed@0.9.0|@isaacs/fs-minipass@4.0.1",
+      "bom-ref": "cogseed@1.0.2|@isaacs/fs-minipass@4.0.1",
       "author": "Isaac Z. Schlueter",
       "description": "fs read and write streams based on minipass",
       "licenses": [
@@ -11585,7 +11585,7 @@
       "type": "library",
       "name": "minipass",
       "version": "7.1.3",
-      "bom-ref": "cogseed@0.9.0|minipass@7.1.3",
+      "bom-ref": "cogseed@1.0.2|minipass@7.1.3",
       "author": "Isaac Z. Schlueter",
       "description": "minimal implementation of a PassThrough stream",
       "licenses": [
@@ -11640,7 +11640,7 @@
       "type": "library",
       "name": "minizlib",
       "version": "3.1.0",
-      "bom-ref": "cogseed@0.9.0|minizlib@3.1.0",
+      "bom-ref": "cogseed@1.0.2|minizlib@3.1.0",
       "author": "Isaac Z. Schlueter",
       "description": "A small fast zlib stream built on [minipass](http://npm.im/minipass) and Node.js's zlib binding.",
       "licenses": [
@@ -11695,7 +11695,7 @@
       "type": "library",
       "name": "yallist",
       "version": "5.0.0",
-      "bom-ref": "cogseed@0.9.0|yallist@5.0.0",
+      "bom-ref": "cogseed@1.0.2|yallist@5.0.0",
       "author": "Isaac Z. Schlueter",
       "description": "Yet Another Linked List",
       "licenses": [
@@ -11750,7 +11750,7 @@
       "type": "library",
       "name": "fsevents",
       "version": "2.3.3",
-      "bom-ref": "cogseed@0.9.0|fsevents@2.3.3",
+      "bom-ref": "cogseed@1.0.2|fsevents@2.3.3",
       "description": "Native Access to MacOS FSEvents",
       "licenses": [
         {
@@ -11794,7 +11794,7 @@
       "name": "eslint-plugin",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/eslint-plugin@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/eslint-plugin@8.67.0",
       "description": "TypeScript plugin for ESLint",
       "licenses": [
         {
@@ -11852,7 +11852,7 @@
           "type": "library",
           "name": "ignore",
           "version": "7.0.6",
-          "bom-ref": "cogseed@0.9.0|@typescript-eslint/eslint-plugin@8.67.0|ignore@7.0.6",
+          "bom-ref": "cogseed@1.0.2|@typescript-eslint/eslint-plugin@8.67.0|ignore@7.0.6",
           "author": "kael",
           "description": "Ignore is a manager and filter for .gitignore rules, the one used by eslint, gitbook and many others.",
           "licenses": [
@@ -11914,7 +11914,7 @@
       "name": "parser",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/parser@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/parser@8.67.0",
       "description": "An ESLint custom parser which leverages TypeScript ESTree",
       "licenses": [
         {
@@ -11973,7 +11973,7 @@
       "name": "typescript-estree",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/typescript-estree@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/typescript-estree@8.67.0",
       "description": "A parser that converts TypeScript source code into an ESTree compatible form",
       "licenses": [
         {
@@ -12032,7 +12032,7 @@
       "name": "utils",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/utils@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/utils@8.67.0",
       "description": "Utilities for working with TypeScript + ESLint together",
       "licenses": [
         {
@@ -12091,7 +12091,7 @@
       "name": "expect",
       "group": "@vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|@vitest/expect@4.1.11",
+      "bom-ref": "cogseed@1.0.2|@vitest/expect@4.1.11",
       "description": "Jest's expect matchers as a Chai plugin",
       "licenses": [
         {
@@ -12146,7 +12146,7 @@
       "name": "mocker",
       "group": "@vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|@vitest/mocker@4.1.11",
+      "bom-ref": "cogseed@1.0.2|@vitest/mocker@4.1.11",
       "description": "Vitest module mocker implementation",
       "licenses": [
         {
@@ -12201,7 +12201,7 @@
       "name": "pretty-format",
       "group": "@vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|@vitest/pretty-format@4.1.11",
+      "bom-ref": "cogseed@1.0.2|@vitest/pretty-format@4.1.11",
       "description": "Fork of pretty-format with support for ESM",
       "licenses": [
         {
@@ -12256,7 +12256,7 @@
       "name": "runner",
       "group": "@vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|@vitest/runner@4.1.11",
+      "bom-ref": "cogseed@1.0.2|@vitest/runner@4.1.11",
       "description": "Vitest test runner",
       "licenses": [
         {
@@ -12311,7 +12311,7 @@
       "name": "snapshot",
       "group": "@vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|@vitest/snapshot@4.1.11",
+      "bom-ref": "cogseed@1.0.2|@vitest/snapshot@4.1.11",
       "description": "Vitest snapshot manager",
       "licenses": [
         {
@@ -12366,7 +12366,7 @@
       "name": "spy",
       "group": "@vitest",
       "version": "4.1.11",
-      "bom-ref": "cogseed@0.9.0|@vitest/spy@4.1.11",
+      "bom-ref": "cogseed@1.0.2|@vitest/spy@4.1.11",
       "description": "Lightweight Jest compatible spy implementation",
       "licenses": [
         {
@@ -12420,7 +12420,7 @@
       "type": "library",
       "name": "expect-type",
       "version": "1.3.0",
-      "bom-ref": "cogseed@0.9.0|expect-type@1.3.0",
+      "bom-ref": "cogseed@1.0.2|expect-type@1.3.0",
       "licenses": [
         {
           "license": {
@@ -12466,7 +12466,7 @@
       "type": "library",
       "name": "magic-string",
       "version": "0.30.21",
-      "bom-ref": "cogseed@0.9.0|magic-string@0.30.21",
+      "bom-ref": "cogseed@1.0.2|magic-string@0.30.21",
       "author": "Rich Harris",
       "description": "Modify strings, generate sourcemaps",
       "licenses": [
@@ -12521,7 +12521,7 @@
       "type": "library",
       "name": "pathe",
       "version": "2.0.3",
-      "bom-ref": "cogseed@0.9.0|pathe@2.0.3",
+      "bom-ref": "cogseed@1.0.2|pathe@2.0.3",
       "description": "Universal filesystem path utils",
       "licenses": [
         {
@@ -12575,7 +12575,7 @@
       "type": "library",
       "name": "picomatch",
       "version": "4.0.5",
-      "bom-ref": "cogseed@0.9.0|picomatch@4.0.5",
+      "bom-ref": "cogseed@1.0.2|picomatch@4.0.5",
       "author": "Jon Schlinkert",
       "description": "Blazing fast and accurate glob matcher written in JavaScript, with no dependencies and full support for standard and extended Bash glob features, including braces, extglobs, POSIX brackets, and regular expressions.",
       "licenses": [
@@ -12634,7 +12634,7 @@
       "type": "library",
       "name": "tinybench",
       "version": "2.9.0",
-      "bom-ref": "cogseed@0.9.0|tinybench@2.9.0",
+      "bom-ref": "cogseed@1.0.2|tinybench@2.9.0",
       "licenses": [
         {
           "license": {
@@ -12676,7 +12676,7 @@
       "type": "library",
       "name": "tinyglobby",
       "version": "0.2.17",
-      "bom-ref": "cogseed@0.9.0|tinyglobby@0.2.17",
+      "bom-ref": "cogseed@1.0.2|tinyglobby@0.2.17",
       "author": "Superchupu",
       "description": "A fast and minimal alternative to globby and fast-glob",
       "licenses": [
@@ -12735,7 +12735,7 @@
       "type": "library",
       "name": "vite",
       "version": "8.2.2",
-      "bom-ref": "cogseed@0.9.0|vite@8.2.2",
+      "bom-ref": "cogseed@1.0.2|vite@8.2.2",
       "author": "Evan You",
       "description": "Native-ESM powered web dev build tool",
       "licenses": [
@@ -12794,7 +12794,7 @@
       "type": "library",
       "name": "why-is-node-running",
       "version": "2.3.0",
-      "bom-ref": "cogseed@0.9.0|why-is-node-running@2.3.0",
+      "bom-ref": "cogseed@1.0.2|why-is-node-running@2.3.0",
       "author": "Mathias Buus",
       "description": "Node is running but you don't know why? why-is-node-running is here to help you.",
       "licenses": [
@@ -12842,7 +12842,7 @@
       "type": "library",
       "name": "json-schema-to-ts",
       "version": "3.1.1",
-      "bom-ref": "cogseed@0.9.0|json-schema-to-ts@3.1.1",
+      "bom-ref": "cogseed@1.0.2|json-schema-to-ts@3.1.1",
       "author": "Thomas Aribart",
       "description": "Infer typescript types from your JSON schemas!",
       "licenses": [
@@ -12898,7 +12898,7 @@
       "name": "sha256-browser",
       "group": "@aws-crypto",
       "version": "5.2.0",
-      "bom-ref": "cogseed@0.9.0|@aws-crypto/sha256-browser@5.2.0",
+      "bom-ref": "cogseed@1.0.2|@aws-crypto/sha256-browser@5.2.0",
       "author": "AWS Crypto Tools Team",
       "licenses": [
         {
@@ -12949,7 +12949,7 @@
       "name": "sha256-js",
       "group": "@aws-crypto",
       "version": "5.2.0",
-      "bom-ref": "cogseed@0.9.0|@aws-crypto/sha256-js@5.2.0",
+      "bom-ref": "cogseed@1.0.2|@aws-crypto/sha256-js@5.2.0",
       "author": "AWS Crypto Tools Team",
       "licenses": [
         {
@@ -13004,7 +13004,7 @@
       "name": "core",
       "group": "@aws-sdk",
       "version": "3.974.15",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/core@3.974.15",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/core@3.974.15",
       "author": "AWS SDK for JavaScript Team",
       "description": "Core functions & classes shared by multiple AWS SDK clients.",
       "licenses": [
@@ -13060,7 +13060,7 @@
       "name": "credential-provider-node",
       "group": "@aws-sdk",
       "version": "3.972.47",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-node@3.972.47",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-node@3.972.47",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider that sources credentials from a Node.JS environment. ",
       "licenses": [
@@ -13116,7 +13116,7 @@
       "name": "eventstream-handler-node",
       "group": "@aws-sdk",
       "version": "3.972.18",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/eventstream-handler-node@3.972.18",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/eventstream-handler-node@3.972.18",
       "author": "AWS SDK for JavaScript Team",
       "licenses": [
         {
@@ -13171,7 +13171,7 @@
       "name": "middleware-eventstream",
       "group": "@aws-sdk",
       "version": "3.972.14",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/middleware-eventstream@3.972.14",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/middleware-eventstream@3.972.14",
       "author": "AWS SDK for JavaScript Team",
       "licenses": [
         {
@@ -13226,7 +13226,7 @@
       "name": "middleware-websocket",
       "group": "@aws-sdk",
       "version": "3.972.23",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/middleware-websocket@3.972.23",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/middleware-websocket@3.972.23",
       "author": "AWS SDK for JavaScript Team",
       "licenses": [
         {
@@ -13281,7 +13281,7 @@
       "name": "token-providers",
       "group": "@aws-sdk",
       "version": "3.1048.0",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/token-providers@3.1048.0",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/token-providers@3.1048.0",
       "author": "AWS SDK for JavaScript Team",
       "description": "A collection of token providers",
       "licenses": [
@@ -13337,7 +13337,7 @@
       "name": "types",
       "group": "@aws-sdk",
       "version": "3.973.9",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/types@3.973.9",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/types@3.973.9",
       "author": "AWS SDK for JavaScript Team",
       "description": "Types for the AWS SDK",
       "licenses": [
@@ -13393,7 +13393,7 @@
       "name": "core",
       "group": "@smithy",
       "version": "3.24.5",
-      "bom-ref": "cogseed@0.9.0|@smithy/core@3.24.5",
+      "bom-ref": "cogseed@1.0.2|@smithy/core@3.24.5",
       "author": "AWS Smithy Team",
       "licenses": [
         {
@@ -13448,7 +13448,7 @@
       "name": "fetch-http-handler",
       "group": "@smithy",
       "version": "5.4.5",
-      "bom-ref": "cogseed@0.9.0|@smithy/fetch-http-handler@5.4.5",
+      "bom-ref": "cogseed@1.0.2|@smithy/fetch-http-handler@5.4.5",
       "author": "AWS SDK for JavaScript Team",
       "description": "Provides a way to make requests",
       "licenses": [
@@ -13504,7 +13504,7 @@
       "name": "types",
       "group": "@smithy",
       "version": "4.14.2",
-      "bom-ref": "cogseed@0.9.0|@smithy/types@4.14.2",
+      "bom-ref": "cogseed@1.0.2|@smithy/types@4.14.2",
       "author": "AWS Smithy Team",
       "licenses": [
         {
@@ -13558,7 +13558,7 @@
       "type": "library",
       "name": "google-auth-library",
       "version": "10.6.2",
-      "bom-ref": "cogseed@0.9.0|google-auth-library@10.6.2",
+      "bom-ref": "cogseed@1.0.2|google-auth-library@10.6.2",
       "author": "Google Inc.",
       "description": "Google APIs Authentication Client Library for Node.js",
       "licenses": [
@@ -13613,7 +13613,7 @@
       "type": "library",
       "name": "p-retry",
       "version": "4.6.2",
-      "bom-ref": "cogseed@0.9.0|p-retry@4.6.2",
+      "bom-ref": "cogseed@1.0.2|p-retry@4.6.2",
       "author": "Sindre Sorhus",
       "description": "Retry a promise-returning or async function",
       "licenses": [
@@ -13669,7 +13669,7 @@
       "name": "semantic-conventions",
       "group": "@opentelemetry",
       "version": "1.41.1",
-      "bom-ref": "cogseed@0.9.0|@opentelemetry/semantic-conventions@1.41.1",
+      "bom-ref": "cogseed@1.0.2|@opentelemetry/semantic-conventions@1.41.1",
       "author": "OpenTelemetry Authors",
       "description": "OpenTelemetry semantic conventions",
       "licenses": [
@@ -13724,7 +13724,7 @@
       "type": "library",
       "name": "ms",
       "version": "2.1.3",
-      "bom-ref": "cogseed@0.9.0|ms@2.1.3",
+      "bom-ref": "cogseed@1.0.2|ms@2.1.3",
       "description": "Tiny millisecond conversion utility",
       "licenses": [
         {
@@ -13763,7 +13763,7 @@
       "type": "library",
       "name": "semver",
       "version": "7.8.5",
-      "bom-ref": "cogseed@0.9.0|semver@7.8.5",
+      "bom-ref": "cogseed@1.0.2|semver@7.8.5",
       "author": "GitHub Inc.",
       "description": "The semantic version parser used by npm.",
       "licenses": [
@@ -13818,7 +13818,7 @@
       "type": "library",
       "name": "env-paths",
       "version": "2.2.1",
-      "bom-ref": "cogseed@0.9.0|env-paths@2.2.1",
+      "bom-ref": "cogseed@1.0.2|env-paths@2.2.1",
       "author": "Sindre Sorhus",
       "description": "Get paths for storing things like data, config, cache, etc",
       "licenses": [
@@ -13866,7 +13866,7 @@
       "type": "library",
       "name": "exponential-backoff",
       "version": "3.1.3",
-      "bom-ref": "cogseed@0.9.0|exponential-backoff@3.1.3",
+      "bom-ref": "cogseed@1.0.2|exponential-backoff@3.1.3",
       "author": "Sami Sayegh",
       "description": "A utility that allows retrying a function with an exponential delay between attempts.",
       "licenses": [
@@ -13921,7 +13921,7 @@
       "type": "library",
       "name": "graceful-fs",
       "version": "4.2.11",
-      "bom-ref": "cogseed@0.9.0|graceful-fs@4.2.11",
+      "bom-ref": "cogseed@1.0.2|graceful-fs@4.2.11",
       "description": "A drop-in replacement for fs, making various improvements.",
       "licenses": [
         {
@@ -13964,7 +13964,7 @@
       "type": "library",
       "name": "nopt",
       "version": "9.0.0",
-      "bom-ref": "cogseed@0.9.0|nopt@9.0.0",
+      "bom-ref": "cogseed@1.0.2|nopt@9.0.0",
       "author": "GitHub Inc.",
       "description": "Option parsing for Node, supporting types, shorthands, etc. Used by npm.",
       "licenses": [
@@ -14023,7 +14023,7 @@
       "type": "library",
       "name": "proc-log",
       "version": "6.1.0",
-      "bom-ref": "cogseed@0.9.0|proc-log@6.1.0",
+      "bom-ref": "cogseed@1.0.2|proc-log@6.1.0",
       "author": "GitHub Inc.",
       "description": "just emit 'log' events on the process object",
       "licenses": [
@@ -14082,7 +14082,7 @@
       "type": "library",
       "name": "follow-redirects",
       "version": "1.16.0",
-      "bom-ref": "cogseed@0.9.0|follow-redirects@1.16.0",
+      "bom-ref": "cogseed@1.0.2|follow-redirects@1.16.0",
       "author": "Ruben Verborgh",
       "description": "HTTP and HTTPS modules that follow redirects.",
       "licenses": [
@@ -14137,7 +14137,7 @@
       "type": "library",
       "name": "form-data",
       "version": "4.0.6",
-      "bom-ref": "cogseed@0.9.0|form-data@4.0.6",
+      "bom-ref": "cogseed@1.0.2|form-data@4.0.6",
       "author": "Felix Geisendörfer",
       "description": "A library to create readable \"multipart/form-data\" streams. Can be used to submit forms and file uploads to other web applications.",
       "licenses": [
@@ -14192,7 +14192,7 @@
       "type": "library",
       "name": "proxy-from-env",
       "version": "2.1.0",
-      "bom-ref": "cogseed@0.9.0|proxy-from-env@2.1.0",
+      "bom-ref": "cogseed@1.0.2|proxy-from-env@2.1.0",
       "author": "Rob Wu",
       "description": "Offers getProxyForUrl to get the proxy URL for a URL, respecting the *_PROXY (e.g. HTTP_PROXY) and NO_PROXY environment variables.",
       "licenses": [
@@ -14248,7 +14248,7 @@
       "name": "aspromise",
       "group": "@protobufjs",
       "version": "1.1.2",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/aspromise@1.1.2",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/aspromise@1.1.2",
       "author": "Daniel Wirtz",
       "description": "Returns a promise from a node-style callback function.",
       "licenses": [
@@ -14300,7 +14300,7 @@
       "name": "base64",
       "group": "@protobufjs",
       "version": "1.1.2",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/base64@1.1.2",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/base64@1.1.2",
       "author": "Daniel Wirtz",
       "description": "A minimal base64 implementation for number arrays.",
       "licenses": [
@@ -14352,7 +14352,7 @@
       "name": "codegen",
       "group": "@protobufjs",
       "version": "2.0.5",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/codegen@2.0.5",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/codegen@2.0.5",
       "author": "Daniel Wirtz",
       "description": "A minimalistic code generation utility.",
       "licenses": [
@@ -14404,7 +14404,7 @@
       "name": "eventemitter",
       "group": "@protobufjs",
       "version": "1.1.1",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/eventemitter@1.1.1",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/eventemitter@1.1.1",
       "author": "Daniel Wirtz",
       "description": "A minimal event emitter.",
       "licenses": [
@@ -14456,7 +14456,7 @@
       "name": "fetch",
       "group": "@protobufjs",
       "version": "1.1.1",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/fetch@1.1.1",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/fetch@1.1.1",
       "author": "Daniel Wirtz",
       "description": "Fetches the contents of a file accross node and browsers.",
       "licenses": [
@@ -14508,7 +14508,7 @@
       "name": "float",
       "group": "@protobufjs",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/float@1.0.2",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/float@1.0.2",
       "author": "Daniel Wirtz",
       "description": "Reads / writes floats / doubles from / to buffers in both modern and ancient browsers.",
       "licenses": [
@@ -14560,7 +14560,7 @@
       "name": "path",
       "group": "@protobufjs",
       "version": "1.1.2",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/path@1.1.2",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/path@1.1.2",
       "author": "Daniel Wirtz",
       "description": "A minimal path module to resolve Unix, Windows and URL paths alike.",
       "licenses": [
@@ -14612,7 +14612,7 @@
       "name": "pool",
       "group": "@protobufjs",
       "version": "1.1.0",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/pool@1.1.0",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/pool@1.1.0",
       "author": "Daniel Wirtz",
       "description": "A general purpose buffer pool.",
       "licenses": [
@@ -14664,7 +14664,7 @@
       "name": "utf8",
       "group": "@protobufjs",
       "version": "1.1.1",
-      "bom-ref": "cogseed@0.9.0|@protobufjs/utf8@1.1.1",
+      "bom-ref": "cogseed@1.0.2|@protobufjs/utf8@1.1.1",
       "author": "Daniel Wirtz",
       "description": "A minimal UTF8 implementation for number arrays.",
       "licenses": [
@@ -14715,7 +14715,7 @@
       "type": "library",
       "name": "long",
       "version": "5.3.2",
-      "bom-ref": "cogseed@0.9.0|long@5.3.2",
+      "bom-ref": "cogseed@1.0.2|long@5.3.2",
       "author": "Daniel Wirtz",
       "description": "A Long class for representing a 64-bit two's-complement integer value.",
       "licenses": [
@@ -14766,7 +14766,7 @@
       "type": "library",
       "name": "es-define-property",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|es-define-property@1.0.1",
+      "bom-ref": "cogseed@1.0.2|es-define-property@1.0.1",
       "author": "Jordan Harband",
       "description": "`Object.defineProperty`, but not IE 8's broken one.",
       "licenses": [
@@ -14810,7 +14810,7 @@
       "type": "library",
       "name": "side-channel",
       "version": "1.1.1",
-      "bom-ref": "cogseed@0.9.0|side-channel@1.1.1",
+      "bom-ref": "cogseed@1.0.2|side-channel@1.1.1",
       "author": "Jordan Harband",
       "description": "Store information about any JS value in a side channel. Uses WeakMap if available.",
       "licenses": [
@@ -14865,7 +14865,7 @@
       "type": "library",
       "name": "fast-uri",
       "version": "3.1.7",
-      "bom-ref": "cogseed@0.9.0|fast-uri@3.1.7",
+      "bom-ref": "cogseed@1.0.2|fast-uri@3.1.7",
       "author": "Vincent Le Goff",
       "description": "Dependency-free RFC 3986 URI toolbox",
       "licenses": [
@@ -14916,7 +14916,7 @@
       "type": "library",
       "name": "json-schema-traverse",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|json-schema-traverse@1.0.0",
+      "bom-ref": "cogseed@1.0.2|json-schema-traverse@1.0.0",
       "author": "Evgeny Poberezkin",
       "description": "Traverse JSON Schema passing each schema object to callback",
       "licenses": [
@@ -14967,7 +14967,7 @@
       "type": "library",
       "name": "require-from-string",
       "version": "2.0.2",
-      "bom-ref": "cogseed@0.9.0|require-from-string@2.0.2",
+      "bom-ref": "cogseed@1.0.2|require-from-string@2.0.2",
       "author": "Vsevolod Strukchinsky",
       "description": "Require module from string",
       "licenses": [
@@ -15022,7 +15022,7 @@
       "type": "library",
       "name": "object-assign",
       "version": "4.1.1",
-      "bom-ref": "cogseed@0.9.0|object-assign@4.1.1",
+      "bom-ref": "cogseed@1.0.2|object-assign@4.1.1",
       "author": "Sindre Sorhus",
       "description": "ES2015 `Object.assign()` ponyfill",
       "licenses": [
@@ -15077,7 +15077,7 @@
       "type": "library",
       "name": "vary",
       "version": "1.1.2",
-      "bom-ref": "cogseed@0.9.0|vary@1.1.2",
+      "bom-ref": "cogseed@1.0.2|vary@1.1.2",
       "author": "Douglas Christopher Wilson",
       "description": "Manipulate the HTTP Vary header",
       "licenses": [
@@ -15132,7 +15132,7 @@
       "type": "library",
       "name": "path-key",
       "version": "3.1.1",
-      "bom-ref": "cogseed@0.9.0|path-key@3.1.1",
+      "bom-ref": "cogseed@1.0.2|path-key@3.1.1",
       "author": "Sindre Sorhus",
       "description": "Get the PATH environment variable key cross-platform",
       "licenses": [
@@ -15187,7 +15187,7 @@
       "type": "library",
       "name": "shebang-command",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|shebang-command@2.0.0",
+      "bom-ref": "cogseed@1.0.2|shebang-command@2.0.0",
       "author": "Kevin Mårtensson",
       "description": "Get the command from a shebang",
       "licenses": [
@@ -15242,7 +15242,7 @@
       "type": "library",
       "name": "which",
       "version": "2.0.2",
-      "bom-ref": "cogseed@0.9.0|which@2.0.2",
+      "bom-ref": "cogseed@1.0.2|which@2.0.2",
       "author": "Isaac Z. Schlueter",
       "description": "Like which(1) unix command. Find the first instance of an executable in the PATH.",
       "licenses": [
@@ -15297,7 +15297,7 @@
       "type": "library",
       "name": "ip-address",
       "version": "10.5.0",
-      "bom-ref": "cogseed@0.9.0|ip-address@10.5.0",
+      "bom-ref": "cogseed@1.0.2|ip-address@10.5.0",
       "author": "Beau Gunderson",
       "description": "A library for parsing IPv4 and IPv6 IP addresses in node and the browser.",
       "licenses": [
@@ -15352,7 +15352,7 @@
       "type": "library",
       "name": "accepts",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|accepts@2.0.0",
+      "bom-ref": "cogseed@1.0.2|accepts@2.0.0",
       "description": "Higher-level content negotiation",
       "licenses": [
         {
@@ -15406,7 +15406,7 @@
           "type": "library",
           "name": "mime-types",
           "version": "3.0.2",
-          "bom-ref": "cogseed@0.9.0|accepts@2.0.0|mime-types@3.0.2",
+          "bom-ref": "cogseed@1.0.2|accepts@2.0.0|mime-types@3.0.2",
           "description": "The ultimate javascript content-type utility.",
           "licenses": [
             {
@@ -15460,7 +15460,7 @@
           "type": "library",
           "name": "mime-db",
           "version": "1.54.0",
-          "bom-ref": "cogseed@0.9.0|accepts@2.0.0|mime-db@1.54.0",
+          "bom-ref": "cogseed@1.0.2|accepts@2.0.0|mime-db@1.54.0",
           "description": "Media Type Database",
           "licenses": [
             {
@@ -15516,7 +15516,7 @@
       "type": "library",
       "name": "body-parser",
       "version": "2.3.0",
-      "bom-ref": "cogseed@0.9.0|body-parser@2.3.0",
+      "bom-ref": "cogseed@1.0.2|body-parser@2.3.0",
       "description": "Node.js body parsing middleware",
       "licenses": [
         {
@@ -15570,7 +15570,7 @@
           "type": "library",
           "name": "content-type",
           "version": "2.1.0",
-          "bom-ref": "cogseed@0.9.0|body-parser@2.3.0|content-type@2.1.0",
+          "bom-ref": "cogseed@1.0.2|body-parser@2.3.0|content-type@2.1.0",
           "author": "Douglas Christopher Wilson",
           "description": "Create and parse HTTP Content-Type header",
           "licenses": [
@@ -15627,7 +15627,7 @@
       "type": "library",
       "name": "content-disposition",
       "version": "1.1.0",
-      "bom-ref": "cogseed@0.9.0|content-disposition@1.1.0",
+      "bom-ref": "cogseed@1.0.2|content-disposition@1.1.0",
       "author": "Douglas Christopher Wilson",
       "description": "Create and parse Content-Disposition header",
       "licenses": [
@@ -15682,7 +15682,7 @@
       "type": "library",
       "name": "cookie-signature",
       "version": "1.2.2",
-      "bom-ref": "cogseed@0.9.0|cookie-signature@1.2.2",
+      "bom-ref": "cogseed@1.0.2|cookie-signature@1.2.2",
       "author": "TJ Holowaychuk",
       "description": "Sign and unsign cookies",
       "licenses": [
@@ -15737,7 +15737,7 @@
       "type": "library",
       "name": "cookie",
       "version": "0.7.2",
-      "bom-ref": "cogseed@0.9.0|cookie@0.7.2",
+      "bom-ref": "cogseed@1.0.2|cookie@0.7.2",
       "author": "Roman Shtylman",
       "description": "HTTP server cookie parsing and serialization",
       "licenses": [
@@ -15792,7 +15792,7 @@
       "type": "library",
       "name": "depd",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|depd@2.0.0",
+      "bom-ref": "cogseed@1.0.2|depd@2.0.0",
       "author": "Douglas Christopher Wilson",
       "description": "Deprecate all the things",
       "licenses": [
@@ -15847,7 +15847,7 @@
       "type": "library",
       "name": "encodeurl",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|encodeurl@2.0.0",
+      "bom-ref": "cogseed@1.0.2|encodeurl@2.0.0",
       "description": "Encode a URL to a percent-encoded form, excluding already-encoded sequences",
       "licenses": [
         {
@@ -15901,7 +15901,7 @@
       "type": "library",
       "name": "escape-html",
       "version": "1.0.3",
-      "bom-ref": "cogseed@0.9.0|escape-html@1.0.3",
+      "bom-ref": "cogseed@1.0.2|escape-html@1.0.3",
       "description": "Escape string for use in HTML",
       "licenses": [
         {
@@ -15951,7 +15951,7 @@
       "type": "library",
       "name": "etag",
       "version": "1.8.1",
-      "bom-ref": "cogseed@0.9.0|etag@1.8.1",
+      "bom-ref": "cogseed@1.0.2|etag@1.8.1",
       "description": "Create simple HTTP ETags",
       "licenses": [
         {
@@ -16005,7 +16005,7 @@
       "type": "library",
       "name": "finalhandler",
       "version": "2.1.1",
-      "bom-ref": "cogseed@0.9.0|finalhandler@2.1.1",
+      "bom-ref": "cogseed@1.0.2|finalhandler@2.1.1",
       "author": "Douglas Christopher Wilson",
       "description": "Node.js final http responder",
       "licenses": [
@@ -16060,7 +16060,7 @@
       "type": "library",
       "name": "fresh",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|fresh@2.0.0",
+      "bom-ref": "cogseed@1.0.2|fresh@2.0.0",
       "author": "TJ Holowaychuk",
       "description": "HTTP response freshness testing",
       "licenses": [
@@ -16115,7 +16115,7 @@
       "type": "library",
       "name": "http-errors",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|http-errors@2.0.1",
+      "bom-ref": "cogseed@1.0.2|http-errors@2.0.1",
       "author": "Jonathan Ong",
       "description": "Create HTTP error objects",
       "licenses": [
@@ -16170,7 +16170,7 @@
       "type": "library",
       "name": "merge-descriptors",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|merge-descriptors@2.0.0",
+      "bom-ref": "cogseed@1.0.2|merge-descriptors@2.0.0",
       "description": "Merge objects using their property descriptors",
       "licenses": [
         {
@@ -16224,7 +16224,7 @@
       "type": "library",
       "name": "on-finished",
       "version": "2.4.1",
-      "bom-ref": "cogseed@0.9.0|on-finished@2.4.1",
+      "bom-ref": "cogseed@1.0.2|on-finished@2.4.1",
       "description": "Execute a callback when a request closes, finishes, or errors",
       "licenses": [
         {
@@ -16278,7 +16278,7 @@
       "type": "library",
       "name": "once",
       "version": "1.4.0",
-      "bom-ref": "cogseed@0.9.0|once@1.4.0",
+      "bom-ref": "cogseed@1.0.2|once@1.4.0",
       "author": "Isaac Z. Schlueter",
       "description": "Run a function exactly one time",
       "licenses": [
@@ -16318,7 +16318,7 @@
       "type": "library",
       "name": "parseurl",
       "version": "1.3.3",
-      "bom-ref": "cogseed@0.9.0|parseurl@1.3.3",
+      "bom-ref": "cogseed@1.0.2|parseurl@1.3.3",
       "description": "parse a url with memoization",
       "licenses": [
         {
@@ -16372,7 +16372,7 @@
       "type": "library",
       "name": "proxy-addr",
       "version": "2.0.7",
-      "bom-ref": "cogseed@0.9.0|proxy-addr@2.0.7",
+      "bom-ref": "cogseed@1.0.2|proxy-addr@2.0.7",
       "author": "Douglas Christopher Wilson",
       "description": "Determine address of proxied request",
       "licenses": [
@@ -16427,7 +16427,7 @@
       "type": "library",
       "name": "range-parser",
       "version": "1.2.1",
-      "bom-ref": "cogseed@0.9.0|range-parser@1.2.1",
+      "bom-ref": "cogseed@1.0.2|range-parser@1.2.1",
       "author": "TJ Holowaychuk",
       "description": "Range header field string parser",
       "licenses": [
@@ -16482,7 +16482,7 @@
       "type": "library",
       "name": "router",
       "version": "2.2.0",
-      "bom-ref": "cogseed@0.9.0|router@2.2.0",
+      "bom-ref": "cogseed@1.0.2|router@2.2.0",
       "author": "Douglas Christopher Wilson",
       "description": "Simple middleware-style router",
       "licenses": [
@@ -16537,7 +16537,7 @@
       "type": "library",
       "name": "send",
       "version": "1.2.1",
-      "bom-ref": "cogseed@0.9.0|send@1.2.1",
+      "bom-ref": "cogseed@1.0.2|send@1.2.1",
       "author": "TJ Holowaychuk",
       "description": "Better streaming static file server with Range and conditional-GET support",
       "licenses": [
@@ -16592,7 +16592,7 @@
           "type": "library",
           "name": "mime-types",
           "version": "3.0.2",
-          "bom-ref": "cogseed@0.9.0|send@1.2.1|mime-types@3.0.2",
+          "bom-ref": "cogseed@1.0.2|send@1.2.1|mime-types@3.0.2",
           "description": "The ultimate javascript content-type utility.",
           "licenses": [
             {
@@ -16646,7 +16646,7 @@
           "type": "library",
           "name": "mime-db",
           "version": "1.54.0",
-          "bom-ref": "cogseed@0.9.0|send@1.2.1|mime-db@1.54.0",
+          "bom-ref": "cogseed@1.0.2|send@1.2.1|mime-db@1.54.0",
           "description": "Media Type Database",
           "licenses": [
             {
@@ -16702,7 +16702,7 @@
       "type": "library",
       "name": "serve-static",
       "version": "2.2.1",
-      "bom-ref": "cogseed@0.9.0|serve-static@2.2.1",
+      "bom-ref": "cogseed@1.0.2|serve-static@2.2.1",
       "author": "Douglas Christopher Wilson",
       "description": "Serve static files",
       "licenses": [
@@ -16757,7 +16757,7 @@
       "type": "library",
       "name": "statuses",
       "version": "2.0.2",
-      "bom-ref": "cogseed@0.9.0|statuses@2.0.2",
+      "bom-ref": "cogseed@1.0.2|statuses@2.0.2",
       "description": "HTTP status utility",
       "licenses": [
         {
@@ -16811,7 +16811,7 @@
       "type": "library",
       "name": "type-is",
       "version": "2.1.0",
-      "bom-ref": "cogseed@0.9.0|type-is@2.1.0",
+      "bom-ref": "cogseed@1.0.2|type-is@2.1.0",
       "description": "Infer the content-type of a request.",
       "licenses": [
         {
@@ -16865,7 +16865,7 @@
           "type": "library",
           "name": "content-type",
           "version": "2.0.0",
-          "bom-ref": "cogseed@0.9.0|type-is@2.1.0|content-type@2.0.0",
+          "bom-ref": "cogseed@1.0.2|type-is@2.1.0|content-type@2.0.0",
           "author": "Douglas Christopher Wilson",
           "description": "Create and parse HTTP Content-Type header",
           "licenses": [
@@ -16920,7 +16920,7 @@
           "type": "library",
           "name": "mime-types",
           "version": "3.0.2",
-          "bom-ref": "cogseed@0.9.0|type-is@2.1.0|mime-types@3.0.2",
+          "bom-ref": "cogseed@1.0.2|type-is@2.1.0|mime-types@3.0.2",
           "description": "The ultimate javascript content-type utility.",
           "licenses": [
             {
@@ -16974,7 +16974,7 @@
           "type": "library",
           "name": "mime-db",
           "version": "1.54.0",
-          "bom-ref": "cogseed@0.9.0|type-is@2.1.0|mime-db@1.54.0",
+          "bom-ref": "cogseed@1.0.2|type-is@2.1.0|mime-db@1.54.0",
           "description": "Media Type Database",
           "licenses": [
             {
@@ -17030,7 +17030,7 @@
       "type": "library",
       "name": "bytes",
       "version": "3.1.2",
-      "bom-ref": "cogseed@0.9.0|bytes@3.1.2",
+      "bom-ref": "cogseed@1.0.2|bytes@3.1.2",
       "author": "TJ Holowaychuk",
       "description": "Utility to parse a string bytes to bytes and vice-versa",
       "licenses": [
@@ -17085,7 +17085,7 @@
       "type": "library",
       "name": "iconv-lite",
       "version": "0.7.2",
-      "bom-ref": "cogseed@0.9.0|iconv-lite@0.7.2",
+      "bom-ref": "cogseed@1.0.2|iconv-lite@0.7.2",
       "author": "Alexander Shtuchkin",
       "description": "Convert character encodings in pure javascript.",
       "licenses": [
@@ -17140,7 +17140,7 @@
       "type": "library",
       "name": "unpipe",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|unpipe@1.0.0",
+      "bom-ref": "cogseed@1.0.2|unpipe@1.0.0",
       "author": "Douglas Christopher Wilson",
       "description": "Unpipe a stream from all destinations",
       "licenses": [
@@ -17195,7 +17195,7 @@
       "type": "library",
       "name": "convert-source-map",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|convert-source-map@2.0.0",
+      "bom-ref": "cogseed@1.0.2|convert-source-map@2.0.0",
       "author": "Thorsten Lorenz",
       "description": "Converts a source-map from/to  different formats and allows adding/changing properties.",
       "licenses": [
@@ -17251,7 +17251,7 @@
       "name": "trace-mapping",
       "group": "@jridgewell",
       "version": "0.3.31",
-      "bom-ref": "cogseed@0.9.0|@jridgewell/trace-mapping@0.3.31",
+      "bom-ref": "cogseed@1.0.2|@jridgewell/trace-mapping@0.3.31",
       "author": "Justin Ridgewell",
       "description": "Trace the original position through a source map",
       "licenses": [
@@ -17306,7 +17306,7 @@
       "type": "library",
       "name": "estree-walker",
       "version": "3.0.3",
-      "bom-ref": "cogseed@0.9.0|estree-walker@3.0.3",
+      "bom-ref": "cogseed@1.0.2|estree-walker@3.0.3",
       "author": "Rich Harris",
       "description": "Traverse an ESTree-compliant AST",
       "licenses": [
@@ -17361,7 +17361,7 @@
       "type": "library",
       "name": "js-tokens",
       "version": "10.0.0",
-      "bom-ref": "cogseed@0.9.0|js-tokens@10.0.0",
+      "bom-ref": "cogseed@1.0.2|js-tokens@10.0.0",
       "author": "Simon Lydell",
       "description": "Tiny JavaScript tokenizer.",
       "licenses": [
@@ -17416,7 +17416,7 @@
       "type": "library",
       "name": "make-dir",
       "version": "4.0.0",
-      "bom-ref": "cogseed@0.9.0|make-dir@4.0.0",
+      "bom-ref": "cogseed@1.0.2|make-dir@4.0.0",
       "author": "Sindre Sorhus",
       "description": "Make a directory and its parents if needed - Think `mkdir -p`",
       "licenses": [
@@ -17475,7 +17475,7 @@
       "type": "library",
       "name": "supports-color",
       "version": "7.2.0",
-      "bom-ref": "cogseed@0.9.0|supports-color@7.2.0",
+      "bom-ref": "cogseed@1.0.2|supports-color@7.2.0",
       "author": "Sindre Sorhus",
       "description": "Detect whether a terminal supports color",
       "licenses": [
@@ -17534,7 +17534,7 @@
       "type": "library",
       "name": "html-escaper",
       "version": "2.0.2",
-      "bom-ref": "cogseed@0.9.0|html-escaper@2.0.2",
+      "bom-ref": "cogseed@1.0.2|html-escaper@2.0.2",
       "author": "Andrea Giammarchi",
       "description": "fast and safe way to escape and unescape &<>'\" chars",
       "licenses": [
@@ -17590,7 +17590,7 @@
       "name": "parser",
       "group": "@babel",
       "version": "7.29.7",
-      "bom-ref": "cogseed@0.9.0|@babel/parser@7.29.7",
+      "bom-ref": "cogseed@1.0.2|@babel/parser@7.29.7",
       "author": "The Babel Team",
       "description": "A JavaScript parser",
       "licenses": [
@@ -17650,7 +17650,7 @@
       "name": "types",
       "group": "@babel",
       "version": "7.29.7",
-      "bom-ref": "cogseed@0.9.0|@babel/types@7.29.7",
+      "bom-ref": "cogseed@1.0.2|@babel/types@7.29.7",
       "author": "The Babel Team",
       "description": "Babel Types is a Lodash-esque utility library for AST nodes",
       "licenses": [
@@ -17709,7 +17709,7 @@
       "type": "library",
       "name": "source-map-js",
       "version": "1.2.1",
-      "bom-ref": "cogseed@0.9.0|source-map-js@1.2.1",
+      "bom-ref": "cogseed@1.0.2|source-map-js@1.2.1",
       "author": "Valentin 7rulnik Semirulnik",
       "description": "Generates and consumes source maps",
       "licenses": [
@@ -17768,7 +17768,7 @@
       "type": "library",
       "name": "file-uri-to-path",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|file-uri-to-path@1.0.0",
+      "bom-ref": "cogseed@1.0.2|file-uri-to-path@1.0.0",
       "author": "Nathan Rajlich",
       "description": "Convert a file: URI to a file path",
       "licenses": [
@@ -17808,7 +17808,7 @@
       "type": "library",
       "name": "detect-libc",
       "version": "2.1.2",
-      "bom-ref": "cogseed@0.9.0|detect-libc@2.1.2",
+      "bom-ref": "cogseed@1.0.2|detect-libc@2.1.2",
       "author": "Lovell Fuller",
       "description": "Node.js module to detect the C standard library (libc) implementation family and version",
       "licenses": [
@@ -17852,7 +17852,7 @@
       "type": "library",
       "name": "expand-template",
       "version": "2.0.3",
-      "bom-ref": "cogseed@0.9.0|expand-template@2.0.3",
+      "bom-ref": "cogseed@1.0.2|expand-template@2.0.3",
       "author": "LM",
       "description": "Expand placeholders in a template string",
       "licenses": [
@@ -17894,7 +17894,7 @@
       "type": "library",
       "name": "github-from-package",
       "version": "0.0.0",
-      "bom-ref": "cogseed@0.9.0|github-from-package@0.0.0",
+      "bom-ref": "cogseed@1.0.2|github-from-package@0.0.0",
       "author": "James Halliday",
       "description": "return the github url from a package.json file",
       "licenses": [
@@ -17934,7 +17934,7 @@
       "type": "library",
       "name": "minimist",
       "version": "1.2.8",
-      "bom-ref": "cogseed@0.9.0|minimist@1.2.8",
+      "bom-ref": "cogseed@1.0.2|minimist@1.2.8",
       "author": "James Halliday",
       "description": "parse argument options",
       "licenses": [
@@ -17974,7 +17974,7 @@
       "type": "library",
       "name": "mkdirp-classic",
       "version": "0.5.3",
-      "bom-ref": "cogseed@0.9.0|mkdirp-classic@0.5.3",
+      "bom-ref": "cogseed@1.0.2|mkdirp-classic@0.5.3",
       "author": "Mathias Buus",
       "description": "Mirror of mkdirp 0.5.2",
       "licenses": [
@@ -18014,7 +18014,7 @@
       "type": "library",
       "name": "napi-build-utils",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|napi-build-utils@2.0.0",
+      "bom-ref": "cogseed@1.0.2|napi-build-utils@2.0.0",
       "author": "Jim Schlight",
       "description": "A set of utilities to assist developers of tools that build N-API native add-ons",
       "licenses": [
@@ -18054,7 +18054,7 @@
       "type": "library",
       "name": "node-abi",
       "version": "3.89.0",
-      "bom-ref": "cogseed@0.9.0|node-abi@3.89.0",
+      "bom-ref": "cogseed@1.0.2|node-abi@3.89.0",
       "author": "Lukas Geiger",
       "description": "Get the Node ABI for a given target and runtime, and vice versa.",
       "licenses": [
@@ -18098,7 +18098,7 @@
       "type": "library",
       "name": "pump",
       "version": "3.0.4",
-      "bom-ref": "cogseed@0.9.0|pump@3.0.4",
+      "bom-ref": "cogseed@1.0.2|pump@3.0.4",
       "author": "Mathias Buus Madsen",
       "description": "pipe streams together and close all of them if one of them closes",
       "licenses": [
@@ -18138,7 +18138,7 @@
       "type": "library",
       "name": "rc",
       "version": "1.2.8",
-      "bom-ref": "cogseed@0.9.0|rc@1.2.8",
+      "bom-ref": "cogseed@1.0.2|rc@1.2.8",
       "author": "Dominic Tarr",
       "description": "hardwired configuration loader",
       "licenses": [
@@ -18176,7 +18176,7 @@
       "type": "library",
       "name": "simple-get",
       "version": "4.0.1",
-      "bom-ref": "cogseed@0.9.0|simple-get@4.0.1",
+      "bom-ref": "cogseed@1.0.2|simple-get@4.0.1",
       "author": "Feross Aboukhadijeh",
       "description": "Simplest way to make http get requests. Supports HTTPS, redirects, gzip/deflate, streams in < 100 lines.",
       "licenses": [
@@ -18216,7 +18216,7 @@
       "type": "library",
       "name": "tar-fs",
       "version": "2.1.4",
-      "bom-ref": "cogseed@0.9.0|tar-fs@2.1.4",
+      "bom-ref": "cogseed@1.0.2|tar-fs@2.1.4",
       "author": "Mathias Buus",
       "description": "filesystem bindings for tar-stream",
       "licenses": [
@@ -18256,7 +18256,7 @@
       "type": "library",
       "name": "tunnel-agent",
       "version": "0.6.0",
-      "bom-ref": "cogseed@0.9.0|tunnel-agent@0.6.0",
+      "bom-ref": "cogseed@1.0.2|tunnel-agent@0.6.0",
       "author": "Mikeal Rogers",
       "description": "HTTP proxy tunneling agent. Formerly part of mikeal/request, now a standalone module.",
       "licenses": [
@@ -18301,7 +18301,7 @@
       "name": "asar",
       "group": "@electron",
       "version": "3.4.1",
-      "bom-ref": "cogseed@0.9.0|@electron/asar@3.4.1",
+      "bom-ref": "cogseed@1.0.2|@electron/asar@3.4.1",
       "description": "Creating Electron app packages",
       "licenses": [
         {
@@ -18359,7 +18359,7 @@
           "type": "library",
           "name": "minimatch",
           "version": "3.1.5",
-          "bom-ref": "cogseed@0.9.0|@electron/asar@3.4.1|minimatch@3.1.5",
+          "bom-ref": "cogseed@1.0.2|@electron/asar@3.4.1|minimatch@3.1.5",
           "author": "Isaac Z. Schlueter",
           "description": "a glob matcher in javascript",
           "licenses": [
@@ -18418,7 +18418,7 @@
           "type": "library",
           "name": "brace-expansion",
           "version": "1.1.18",
-          "bom-ref": "cogseed@0.9.0|@electron/asar@3.4.1|brace-expansion@1.1.18",
+          "bom-ref": "cogseed@1.0.2|@electron/asar@3.4.1|brace-expansion@1.1.18",
           "author": "Julian Gruber",
           "description": "Brace expansion as known from sh/bash",
           "licenses": [
@@ -18473,7 +18473,7 @@
           "type": "library",
           "name": "balanced-match",
           "version": "1.0.2",
-          "bom-ref": "cogseed@0.9.0|@electron/asar@3.4.1|balanced-match@1.0.2",
+          "bom-ref": "cogseed@1.0.2|@electron/asar@3.4.1|balanced-match@1.0.2",
           "author": "Julian Gruber",
           "description": "Match balanced character pairs, like \"{\" and \"}\"",
           "licenses": [
@@ -18531,7 +18531,7 @@
       "name": "fuses",
       "group": "@electron",
       "version": "1.8.0",
-      "bom-ref": "cogseed@0.9.0|@electron/fuses@1.8.0",
+      "bom-ref": "cogseed@1.0.2|@electron/fuses@1.8.0",
       "author": "Electron Community",
       "description": "Flip Electron Fuses and customize your packaged build of Electron",
       "licenses": [
@@ -18586,7 +18586,7 @@
           "type": "library",
           "name": "fs-extra",
           "version": "9.1.0",
-          "bom-ref": "cogseed@0.9.0|@electron/fuses@1.8.0|fs-extra@9.1.0",
+          "bom-ref": "cogseed@1.0.2|@electron/fuses@1.8.0|fs-extra@9.1.0",
           "author": "JP Richardson",
           "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.",
           "licenses": [
@@ -18648,7 +18648,7 @@
       "name": "notarize",
       "group": "@electron",
       "version": "2.5.0",
-      "bom-ref": "cogseed@0.9.0|@electron/notarize@2.5.0",
+      "bom-ref": "cogseed@1.0.2|@electron/notarize@2.5.0",
       "author": "Samuel Attard",
       "description": "Notarize your Electron app",
       "licenses": [
@@ -18707,7 +18707,7 @@
           "type": "library",
           "name": "fs-extra",
           "version": "9.1.0",
-          "bom-ref": "cogseed@0.9.0|@electron/notarize@2.5.0|fs-extra@9.1.0",
+          "bom-ref": "cogseed@1.0.2|@electron/notarize@2.5.0|fs-extra@9.1.0",
           "author": "JP Richardson",
           "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.",
           "licenses": [
@@ -18769,7 +18769,7 @@
       "name": "osx-sign",
       "group": "@electron",
       "version": "1.3.3",
-      "bom-ref": "cogseed@0.9.0|@electron/osx-sign@1.3.3",
+      "bom-ref": "cogseed@1.0.2|@electron/osx-sign@1.3.3",
       "author": "electron",
       "description": "Codesign Electron macOS apps",
       "licenses": [
@@ -18828,7 +18828,7 @@
           "type": "library",
           "name": "isbinaryfile",
           "version": "4.0.10",
-          "bom-ref": "cogseed@0.9.0|@electron/osx-sign@1.3.3|isbinaryfile@4.0.10",
+          "bom-ref": "cogseed@1.0.2|@electron/osx-sign@1.3.3|isbinaryfile@4.0.10",
           "description": "Detects if a file is binary in Node.js. Similar to Perl's -B.",
           "licenses": [
             {
@@ -18889,7 +18889,7 @@
       "name": "universal",
       "group": "@electron",
       "version": "2.0.3",
-      "bom-ref": "cogseed@0.9.0|@electron/universal@2.0.3",
+      "bom-ref": "cogseed@1.0.2|@electron/universal@2.0.3",
       "author": "Samuel Attard",
       "description": "Utility for creating Universal macOS applications from two x64 and arm64 Electron applications",
       "licenses": [
@@ -18948,7 +18948,7 @@
           "type": "library",
           "name": "fs-extra",
           "version": "11.4.0",
-          "bom-ref": "cogseed@0.9.0|@electron/universal@2.0.3|fs-extra@11.4.0",
+          "bom-ref": "cogseed@1.0.2|@electron/universal@2.0.3|fs-extra@11.4.0",
           "author": "JP Richardson",
           "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.",
           "licenses": [
@@ -19007,7 +19007,7 @@
           "type": "library",
           "name": "minimatch",
           "version": "9.0.9",
-          "bom-ref": "cogseed@0.9.0|@electron/universal@2.0.3|minimatch@9.0.9",
+          "bom-ref": "cogseed@1.0.2|@electron/universal@2.0.3|minimatch@9.0.9",
           "author": "Isaac Z. Schlueter",
           "description": "a glob matcher in javascript",
           "licenses": [
@@ -19066,7 +19066,7 @@
           "type": "library",
           "name": "brace-expansion",
           "version": "2.1.4",
-          "bom-ref": "cogseed@0.9.0|@electron/universal@2.0.3|brace-expansion@2.1.4",
+          "bom-ref": "cogseed@1.0.2|@electron/universal@2.0.3|brace-expansion@2.1.4",
           "author": "Julian Gruber",
           "description": "Brace expansion as known from sh/bash",
           "licenses": [
@@ -19121,7 +19121,7 @@
           "type": "library",
           "name": "balanced-match",
           "version": "1.0.2",
-          "bom-ref": "cogseed@0.9.0|@electron/universal@2.0.3|balanced-match@1.0.2",
+          "bom-ref": "cogseed@1.0.2|@electron/universal@2.0.3|balanced-match@1.0.2",
           "author": "Julian Gruber",
           "description": "Match balanced character pairs, like \"{\" and \"}\"",
           "licenses": [
@@ -19179,7 +19179,7 @@
       "name": "flatpak-bundler",
       "group": "@malept",
       "version": "0.4.0",
-      "bom-ref": "cogseed@0.9.0|@malept/flatpak-bundler@0.4.0",
+      "bom-ref": "cogseed@1.0.2|@malept/flatpak-bundler@0.4.0",
       "author": "Matt Watson",
       "description": "A small utility for packing files in a flatpak.",
       "licenses": [
@@ -19238,7 +19238,7 @@
           "type": "library",
           "name": "fs-extra",
           "version": "9.1.0",
-          "bom-ref": "cogseed@0.9.0|@malept/flatpak-bundler@0.4.0|fs-extra@9.1.0",
+          "bom-ref": "cogseed@1.0.2|@malept/flatpak-bundler@0.4.0|fs-extra@9.1.0",
           "author": "JP Richardson",
           "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.",
           "licenses": [
@@ -19300,7 +19300,7 @@
       "name": "hashes",
       "group": "@noble",
       "version": "2.3.0",
-      "bom-ref": "cogseed@0.9.0|@noble/hashes@2.3.0",
+      "bom-ref": "cogseed@1.0.2|@noble/hashes@2.3.0",
       "author": "Paul Miller",
       "description": "Audited & minimal 0-dependency JS implementation of SHA, RIPEMD, BLAKE, HMAC, HKDF, PBKDF & Scrypt",
       "licenses": [
@@ -19360,7 +19360,7 @@
       "name": "webcrypto",
       "group": "@peculiar",
       "version": "1.7.1",
-      "bom-ref": "cogseed@0.9.0|@peculiar/webcrypto@1.7.1",
+      "bom-ref": "cogseed@1.0.2|@peculiar/webcrypto@1.7.1",
       "author": "PeculiarVentures",
       "description": "A WebCrypto Polyfill for NodeJS",
       "licenses": [
@@ -19420,7 +19420,7 @@
       "name": "fs-extra",
       "group": "@types",
       "version": "9.0.13",
-      "bom-ref": "cogseed@0.9.0|@types/fs-extra@9.0.13",
+      "bom-ref": "cogseed@1.0.2|@types/fs-extra@9.0.13",
       "description": "TypeScript definitions for fs-extra",
       "licenses": [
         {
@@ -19474,7 +19474,7 @@
       "type": "library",
       "name": "asn1js",
       "version": "3.0.10",
-      "bom-ref": "cogseed@0.9.0|asn1js@3.0.10",
+      "bom-ref": "cogseed@1.0.2|asn1js@3.0.10",
       "author": "Yury Strozhevsky",
       "description": "asn1js is a pure JavaScript library implementing this standard. ASN.1 is the basis of all X.509 related data structures and numerous other protocols used on the web",
       "licenses": [
@@ -19533,7 +19533,7 @@
       "type": "library",
       "name": "async-exit-hook",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|async-exit-hook@2.0.1",
+      "bom-ref": "cogseed@1.0.2|async-exit-hook@2.0.1",
       "author": "Tapani Moilanen",
       "description": "Run some code when the process exits (supports async hooks and pm2 clustering)",
       "licenses": [
@@ -19592,7 +19592,7 @@
       "type": "library",
       "name": "chromium-pickle-js",
       "version": "0.2.0",
-      "bom-ref": "cogseed@0.9.0|chromium-pickle-js@0.2.0",
+      "bom-ref": "cogseed@1.0.2|chromium-pickle-js@0.2.0",
       "description": "Binary value packing and unpacking",
       "licenses": [
         {
@@ -19646,7 +19646,7 @@
       "type": "library",
       "name": "dotenv-expand",
       "version": "11.0.7",
-      "bom-ref": "cogseed@0.9.0|dotenv-expand@11.0.7",
+      "bom-ref": "cogseed@1.0.2|dotenv-expand@11.0.7",
       "author": "motdotla",
       "description": "Expand environment variables using dotenv",
       "licenses": [
@@ -19705,7 +19705,7 @@
       "type": "library",
       "name": "dotenv",
       "version": "16.6.1",
-      "bom-ref": "cogseed@0.9.0|dotenv@16.6.1",
+      "bom-ref": "cogseed@1.0.2|dotenv@16.6.1",
       "description": "Loads environment variables from .env file",
       "licenses": [
         {
@@ -19763,7 +19763,7 @@
       "type": "library",
       "name": "ejs",
       "version": "3.1.10",
-      "bom-ref": "cogseed@0.9.0|ejs@3.1.10",
+      "bom-ref": "cogseed@1.0.2|ejs@3.1.10",
       "author": "Matthew Eernisse",
       "description": "Embedded JavaScript templates",
       "licenses": [
@@ -19822,7 +19822,7 @@
       "type": "library",
       "name": "electron-builder-squirrel-windows",
       "version": "26.15.7",
-      "bom-ref": "cogseed@0.9.0|electron-builder-squirrel-windows@26.15.7",
+      "bom-ref": "cogseed@1.0.2|electron-builder-squirrel-windows@26.15.7",
       "author": "Vladimir Krivosheev",
       "licenses": [
         {
@@ -19876,7 +19876,7 @@
       "type": "library",
       "name": "electron-publish",
       "version": "26.15.3",
-      "bom-ref": "cogseed@0.9.0|electron-publish@26.15.3",
+      "bom-ref": "cogseed@1.0.2|electron-publish@26.15.3",
       "author": "Vladimir Krivosheev",
       "licenses": [
         {
@@ -19930,7 +19930,7 @@
           "type": "library",
           "name": "mime",
           "version": "2.6.0",
-          "bom-ref": "cogseed@0.9.0|electron-publish@26.15.3|mime@2.6.0",
+          "bom-ref": "cogseed@1.0.2|electron-publish@26.15.3|mime@2.6.0",
           "author": "Robert Kieffer",
           "description": "A comprehensive library for mime-type mapping",
           "licenses": [
@@ -19991,7 +19991,7 @@
       "type": "library",
       "name": "hosted-git-info",
       "version": "4.1.0",
-      "bom-ref": "cogseed@0.9.0|hosted-git-info@4.1.0",
+      "bom-ref": "cogseed@1.0.2|hosted-git-info@4.1.0",
       "author": "Rebecca Turner",
       "description": "Provides metadata and conversions from repository urls for GitHub, Bitbucket and GitLab",
       "licenses": [
@@ -20050,7 +20050,7 @@
       "type": "library",
       "name": "isbinaryfile",
       "version": "5.0.7",
-      "bom-ref": "cogseed@0.9.0|isbinaryfile@5.0.7",
+      "bom-ref": "cogseed@1.0.2|isbinaryfile@5.0.7",
       "description": "Detects if a file is binary in Node.js. Similar to Perl's -B.",
       "licenses": [
         {
@@ -20108,7 +20108,7 @@
       "type": "library",
       "name": "js-yaml",
       "version": "4.3.2",
-      "bom-ref": "cogseed@0.9.0|js-yaml@4.3.2",
+      "bom-ref": "cogseed@1.0.2|js-yaml@4.3.2",
       "author": "Vladimir Zapparov",
       "description": "YAML 1.2 parser and serializer",
       "licenses": [
@@ -20163,7 +20163,7 @@
           "type": "library",
           "name": "argparse",
           "version": "2.0.1",
-          "bom-ref": "cogseed@0.9.0|js-yaml@4.3.2|argparse@2.0.1",
+          "bom-ref": "cogseed@1.0.2|js-yaml@4.3.2|argparse@2.0.1",
           "description": "CLI arguments parser. Native port of python's argparse.",
           "licenses": [
             {
@@ -20219,7 +20219,7 @@
       "type": "library",
       "name": "json5",
       "version": "2.2.3",
-      "bom-ref": "cogseed@0.9.0|json5@2.2.3",
+      "bom-ref": "cogseed@1.0.2|json5@2.2.3",
       "author": "Aseem Kishore",
       "description": "JSON for Humans",
       "licenses": [
@@ -20278,7 +20278,7 @@
       "type": "library",
       "name": "pkijs",
       "version": "3.4.0",
-      "bom-ref": "cogseed@0.9.0|pkijs@3.4.0",
+      "bom-ref": "cogseed@1.0.2|pkijs@3.4.0",
       "author": "Yury Strozhevsky",
       "description": "Public Key Infrastructure (PKI) is the basis of how identity and key management is performed on the web today. PKIjs is a pure JavaScript library implementing the formats that are used in PKI applications. It is built on WebCrypto and aspires to make it possible to build native web applications that utilize X.509 and the related formats on the web without plug-ins",
       "licenses": [
@@ -20338,7 +20338,7 @@
           "name": "hashes",
           "group": "@noble",
           "version": "1.4.0",
-          "bom-ref": "cogseed@0.9.0|pkijs@3.4.0|@noble/hashes@1.4.0",
+          "bom-ref": "cogseed@1.0.2|pkijs@3.4.0|@noble/hashes@1.4.0",
           "author": "Paul Miller",
           "description": "Audited & minimal 0-dependency JS implementation of SHA, RIPEMD, BLAKE, HMAC, HKDF, PBKDF & Scrypt",
           "licenses": [
@@ -20399,7 +20399,7 @@
       "type": "library",
       "name": "plist",
       "version": "3.1.0",
-      "bom-ref": "cogseed@0.9.0|plist@3.1.0",
+      "bom-ref": "cogseed@1.0.2|plist@3.1.0",
       "author": "Nathan Rajlich",
       "description": "Apple's property list parser/builder for Node.js and browsers",
       "licenses": [
@@ -20458,7 +20458,7 @@
           "type": "library",
           "name": "xmlbuilder",
           "version": "15.1.1",
-          "bom-ref": "cogseed@0.9.0|plist@3.1.0|xmlbuilder@15.1.1",
+          "bom-ref": "cogseed@1.0.2|plist@3.1.0|xmlbuilder@15.1.1",
           "author": "Ozgur Ozcitak",
           "description": "An XML builder for node.js",
           "licenses": [
@@ -20519,7 +20519,7 @@
       "type": "library",
       "name": "proper-lockfile",
       "version": "4.1.2",
-      "bom-ref": "cogseed@0.9.0|proper-lockfile@4.1.2",
+      "bom-ref": "cogseed@1.0.2|proper-lockfile@4.1.2",
       "author": "André Cruz",
       "description": "A inter-process and inter-machine lockfile utility that works on a local or network file system",
       "licenses": [
@@ -20574,7 +20574,7 @@
           "type": "library",
           "name": "retry",
           "version": "0.12.0",
-          "bom-ref": "cogseed@0.9.0|proper-lockfile@4.1.2|retry@0.12.0",
+          "bom-ref": "cogseed@1.0.2|proper-lockfile@4.1.2|retry@0.12.0",
           "author": "Tim Koschützki",
           "description": "Abstraction for exponential and custom retry strategies for failed operations.",
           "licenses": [
@@ -20635,7 +20635,7 @@
       "type": "library",
       "name": "resedit",
       "version": "1.7.2",
-      "bom-ref": "cogseed@0.9.0|resedit@1.7.2",
+      "bom-ref": "cogseed@1.0.2|resedit@1.7.2",
       "author": "jet",
       "description": "Node.js library editing Windows Resource data",
       "licenses": [
@@ -20698,7 +20698,7 @@
       "type": "library",
       "name": "temp-file",
       "version": "3.4.0",
-      "bom-ref": "cogseed@0.9.0|temp-file@3.4.0",
+      "bom-ref": "cogseed@1.0.2|temp-file@3.4.0",
       "author": "Vladimir Krivosheev",
       "licenses": [
         {
@@ -20752,7 +20752,7 @@
       "type": "library",
       "name": "tiny-async-pool",
       "version": "1.3.0",
-      "bom-ref": "cogseed@0.9.0|tiny-async-pool@1.3.0",
+      "bom-ref": "cogseed@1.0.2|tiny-async-pool@1.3.0",
       "author": "Rafael Xavier de Souza",
       "description": "Run multiple promise-returning & async functions with limited concurrency using native ES6/ES7",
       "licenses": [
@@ -20807,7 +20807,7 @@
           "type": "library",
           "name": "semver",
           "version": "5.7.2",
-          "bom-ref": "cogseed@0.9.0|tiny-async-pool@1.3.0|semver@5.7.2",
+          "bom-ref": "cogseed@1.0.2|tiny-async-pool@1.3.0|semver@5.7.2",
           "author": "GitHub Inc.",
           "description": "The semantic version parser used by npm.",
           "licenses": [
@@ -20864,7 +20864,7 @@
       "type": "library",
       "name": "unzipper",
       "version": "0.12.5",
-      "bom-ref": "cogseed@0.9.0|unzipper@0.12.5",
+      "bom-ref": "cogseed@1.0.2|unzipper@0.12.5",
       "author": "Ziggy Jonsson",
       "description": "Unzip cross-platform streaming API ",
       "licenses": [
@@ -20919,7 +20919,7 @@
           "type": "library",
           "name": "bluebird",
           "version": "3.7.2",
-          "bom-ref": "cogseed@0.9.0|unzipper@0.12.5|bluebird@3.7.2",
+          "bom-ref": "cogseed@1.0.2|unzipper@0.12.5|bluebird@3.7.2",
           "author": "Petka Antonov",
           "description": "Full featured Promises/A+ implementation with exceptionally good performance",
           "licenses": [
@@ -20974,7 +20974,7 @@
           "type": "library",
           "name": "fs-extra",
           "version": "11.3.1",
-          "bom-ref": "cogseed@0.9.0|unzipper@0.12.5|fs-extra@11.3.1",
+          "bom-ref": "cogseed@1.0.2|unzipper@0.12.5|fs-extra@11.3.1",
           "author": "JP Richardson",
           "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.",
           "licenses": [
@@ -21035,7 +21035,7 @@
       "type": "library",
       "name": "sax",
       "version": "1.6.0",
-      "bom-ref": "cogseed@0.9.0|sax@1.6.0",
+      "bom-ref": "cogseed@1.0.2|sax@1.6.0",
       "author": "Isaac Z. Schlueter",
       "description": "An evented streaming XML parser in JavaScript",
       "licenses": [
@@ -21091,7 +21091,7 @@
       "name": "debug",
       "group": "@types",
       "version": "4.1.13",
-      "bom-ref": "cogseed@0.9.0|@types/debug@4.1.13",
+      "bom-ref": "cogseed@1.0.2|@types/debug@4.1.13",
       "description": "TypeScript definitions for debug",
       "licenses": [
         {
@@ -21145,7 +21145,7 @@
       "type": "library",
       "name": "sanitize-filename",
       "version": "1.6.4",
-      "bom-ref": "cogseed@0.9.0|sanitize-filename@1.6.4",
+      "bom-ref": "cogseed@1.0.2|sanitize-filename@1.6.4",
       "author": "Parsha Pourkhomami",
       "description": "Sanitize a string for use as a filename",
       "licenses": [
@@ -21198,7 +21198,7 @@
       "type": "library",
       "name": "source-map-support",
       "version": "0.5.21",
-      "bom-ref": "cogseed@0.9.0|source-map-support@0.5.21",
+      "bom-ref": "cogseed@1.0.2|source-map-support@0.5.21",
       "description": "Fixes stack traces for files with source maps",
       "licenses": [
         {
@@ -21252,7 +21252,7 @@
       "type": "library",
       "name": "stat-mode",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|stat-mode@1.0.0",
+      "bom-ref": "cogseed@1.0.2|stat-mode@1.0.0",
       "author": "Nathan Rajlich",
       "description": "Offers convenient getters and setters for the stat `mode`",
       "licenses": [
@@ -21311,7 +21311,7 @@
       "type": "library",
       "name": "ansi-styles",
       "version": "4.3.0",
-      "bom-ref": "cogseed@0.9.0|ansi-styles@4.3.0",
+      "bom-ref": "cogseed@1.0.2|ansi-styles@4.3.0",
       "author": "Sindre Sorhus",
       "description": "ANSI escape codes for styling strings in the terminal",
       "licenses": [
@@ -21370,7 +21370,7 @@
       "type": "library",
       "name": "jsonfile",
       "version": "6.2.1",
-      "bom-ref": "cogseed@0.9.0|jsonfile@6.2.1",
+      "bom-ref": "cogseed@1.0.2|jsonfile@6.2.1",
       "author": "JP Richardson",
       "description": "Easily read/write JSON files.",
       "licenses": [
@@ -21425,7 +21425,7 @@
       "type": "library",
       "name": "universalify",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|universalify@2.0.1",
+      "bom-ref": "cogseed@1.0.2|universalify@2.0.1",
       "author": "Ryan Zimmerman",
       "description": "Make a callback- or promise-based function support both promises and callbacks.",
       "licenses": [
@@ -21484,7 +21484,7 @@
       "type": "library",
       "name": "cliui",
       "version": "8.0.1",
-      "bom-ref": "cogseed@0.9.0|cliui@8.0.1",
+      "bom-ref": "cogseed@1.0.2|cliui@8.0.1",
       "author": "Ben Coe",
       "description": "easily create complex multi-column command-line-interfaces",
       "licenses": [
@@ -21543,7 +21543,7 @@
       "type": "library",
       "name": "escalade",
       "version": "3.2.0",
-      "bom-ref": "cogseed@0.9.0|escalade@3.2.0",
+      "bom-ref": "cogseed@1.0.2|escalade@3.2.0",
       "author": "Luke Edwards",
       "description": "A tiny (183B to 210B) and fast utility to ascend parent directories",
       "licenses": [
@@ -21602,7 +21602,7 @@
       "type": "library",
       "name": "get-caller-file",
       "version": "2.0.5",
-      "bom-ref": "cogseed@0.9.0|get-caller-file@2.0.5",
+      "bom-ref": "cogseed@1.0.2|get-caller-file@2.0.5",
       "author": "Stefan Penner",
       "licenses": [
         {
@@ -21660,7 +21660,7 @@
       "type": "library",
       "name": "require-directory",
       "version": "2.1.1",
-      "bom-ref": "cogseed@0.9.0|require-directory@2.1.1",
+      "bom-ref": "cogseed@1.0.2|require-directory@2.1.1",
       "author": "Troy Goode",
       "description": "Recursively iterates over specified directory, require()'ing each file, and returning a nested hash structure containing those modules.",
       "licenses": [
@@ -21719,7 +21719,7 @@
       "type": "library",
       "name": "string-width",
       "version": "4.2.3",
-      "bom-ref": "cogseed@0.9.0|string-width@4.2.3",
+      "bom-ref": "cogseed@1.0.2|string-width@4.2.3",
       "author": "Sindre Sorhus",
       "description": "Get the visual width of a string - the number of columns required to display it",
       "licenses": [
@@ -21774,7 +21774,7 @@
       "type": "library",
       "name": "y18n",
       "version": "5.0.8",
-      "bom-ref": "cogseed@0.9.0|y18n@5.0.8",
+      "bom-ref": "cogseed@1.0.2|y18n@5.0.8",
       "author": "Ben Coe",
       "description": "the bare-bones internationalization library used by yargs",
       "licenses": [
@@ -21833,7 +21833,7 @@
       "type": "library",
       "name": "yargs-parser",
       "version": "21.1.1",
-      "bom-ref": "cogseed@0.9.0|yargs-parser@21.1.1",
+      "bom-ref": "cogseed@1.0.2|yargs-parser@21.1.1",
       "author": "Ben Coe",
       "description": "the mighty option parser used by yargs",
       "licenses": [
@@ -21892,7 +21892,7 @@
       "type": "library",
       "name": "sumchecker",
       "version": "3.0.1",
-      "bom-ref": "cogseed@0.9.0|sumchecker@3.0.1",
+      "bom-ref": "cogseed@1.0.2|sumchecker@3.0.1",
       "author": "Mark Lee",
       "description": "Checksum validator",
       "licenses": [
@@ -21951,7 +21951,7 @@
       "type": "library",
       "name": "undici-types",
       "version": "7.16.0",
-      "bom-ref": "cogseed@0.9.0|undici-types@7.16.0",
+      "bom-ref": "cogseed@1.0.2|undici-types@7.16.0",
       "description": "A stand-alone types package for Undici",
       "licenses": [
         {
@@ -22006,7 +22006,7 @@
       "name": "object-schema",
       "group": "@eslint",
       "version": "3.0.5",
-      "bom-ref": "cogseed@0.9.0|@eslint/object-schema@3.0.5",
+      "bom-ref": "cogseed@1.0.2|@eslint/object-schema@3.0.5",
       "author": "Nicholas C. Zakas",
       "description": "An object schema merger/validator",
       "licenses": [
@@ -22066,7 +22066,7 @@
       "name": "json-schema",
       "group": "@types",
       "version": "7.0.15",
-      "bom-ref": "cogseed@0.9.0|@types/json-schema@7.0.15",
+      "bom-ref": "cogseed@1.0.2|@types/json-schema@7.0.15",
       "description": "TypeScript definitions for json-schema",
       "licenses": [
         {
@@ -22120,7 +22120,7 @@
       "type": "library",
       "name": "levn",
       "version": "0.4.1",
-      "bom-ref": "cogseed@0.9.0|levn@0.4.1",
+      "bom-ref": "cogseed@1.0.2|levn@0.4.1",
       "author": "George Zahariev",
       "description": "Light ECMAScript (JavaScript) Value Notation - human written, concise, typed, flexible",
       "licenses": [
@@ -22180,7 +22180,7 @@
       "name": "core",
       "group": "@humanfs",
       "version": "0.19.2",
-      "bom-ref": "cogseed@0.9.0|@humanfs/core@0.19.2",
+      "bom-ref": "cogseed@1.0.2|@humanfs/core@0.19.2",
       "author": "Nicholas C. Zakas",
       "description": "The core of the humanfs library.",
       "licenses": [
@@ -22240,7 +22240,7 @@
       "name": "types",
       "group": "@humanfs",
       "version": "0.15.0",
-      "bom-ref": "cogseed@0.9.0|@humanfs/types@0.15.0",
+      "bom-ref": "cogseed@1.0.2|@humanfs/types@0.15.0",
       "author": "Nicholas C. Zakas",
       "description": "The TypeScript types for the hfs project.",
       "licenses": [
@@ -22299,7 +22299,7 @@
       "type": "library",
       "name": "fast-json-stable-stringify",
       "version": "2.1.0",
-      "bom-ref": "cogseed@0.9.0|fast-json-stable-stringify@2.1.0",
+      "bom-ref": "cogseed@1.0.2|fast-json-stable-stringify@2.1.0",
       "author": "James Halliday",
       "description": "deterministic `JSON.stringify()` - a faster version of substack's json-stable-strigify without jsonify",
       "licenses": [
@@ -22354,7 +22354,7 @@
       "type": "library",
       "name": "uri-js",
       "version": "4.4.1",
-      "bom-ref": "cogseed@0.9.0|uri-js@4.4.1",
+      "bom-ref": "cogseed@1.0.2|uri-js@4.4.1",
       "author": "Gary Court",
       "description": "An RFC 3986/3987 compliant, scheme extendable URI/IRI parsing/validating/resolving library for JavaScript.",
       "licenses": [
@@ -22410,7 +22410,7 @@
       "name": "esrecurse",
       "group": "@types",
       "version": "4.3.1",
-      "bom-ref": "cogseed@0.9.0|@types/esrecurse@4.3.1",
+      "bom-ref": "cogseed@1.0.2|@types/esrecurse@4.3.1",
       "description": "TypeScript definitions for esrecurse",
       "licenses": [
         {
@@ -22464,7 +22464,7 @@
       "type": "library",
       "name": "esrecurse",
       "version": "4.3.0",
-      "bom-ref": "cogseed@0.9.0|esrecurse@4.3.0",
+      "bom-ref": "cogseed@1.0.2|esrecurse@4.3.0",
       "description": "ECMAScript AST recursive visitor",
       "licenses": [
         {
@@ -22522,7 +22522,7 @@
       "type": "library",
       "name": "estraverse",
       "version": "5.3.0",
-      "bom-ref": "cogseed@0.9.0|estraverse@5.3.0",
+      "bom-ref": "cogseed@1.0.2|estraverse@5.3.0",
       "description": "ECMAScript JS AST traversal functions",
       "licenses": [
         {
@@ -22580,7 +22580,7 @@
       "type": "library",
       "name": "acorn-jsx",
       "version": "5.3.2",
-      "bom-ref": "cogseed@0.9.0|acorn-jsx@5.3.2",
+      "bom-ref": "cogseed@1.0.2|acorn-jsx@5.3.2",
       "description": "Modern, fast React.js JSX parser",
       "licenses": [
         {
@@ -22634,7 +22634,7 @@
       "type": "library",
       "name": "acorn",
       "version": "8.18.0",
-      "bom-ref": "cogseed@0.9.0|acorn@8.18.0",
+      "bom-ref": "cogseed@1.0.2|acorn@8.18.0",
       "description": "ECMAScript parser",
       "licenses": [
         {
@@ -22692,7 +22692,7 @@
       "type": "library",
       "name": "flat-cache",
       "version": "4.0.1",
-      "bom-ref": "cogseed@0.9.0|flat-cache@4.0.1",
+      "bom-ref": "cogseed@1.0.2|flat-cache@4.0.1",
       "author": "Jared Wray",
       "description": "A stupidly simple key/value storage using files to persist some data",
       "licenses": [
@@ -22751,7 +22751,7 @@
       "type": "library",
       "name": "locate-path",
       "version": "6.0.0",
-      "bom-ref": "cogseed@0.9.0|locate-path@6.0.0",
+      "bom-ref": "cogseed@1.0.2|locate-path@6.0.0",
       "author": "Sindre Sorhus",
       "description": "Get the first path that exists on disk of multiple paths",
       "licenses": [
@@ -22810,7 +22810,7 @@
       "type": "library",
       "name": "path-exists",
       "version": "4.0.0",
-      "bom-ref": "cogseed@0.9.0|path-exists@4.0.0",
+      "bom-ref": "cogseed@1.0.2|path-exists@4.0.0",
       "author": "Sindre Sorhus",
       "description": "Check if a path exists",
       "licenses": [
@@ -22869,7 +22869,7 @@
       "type": "library",
       "name": "is-extglob",
       "version": "2.1.1",
-      "bom-ref": "cogseed@0.9.0|is-extglob@2.1.1",
+      "bom-ref": "cogseed@1.0.2|is-extglob@2.1.1",
       "author": "Jon Schlinkert",
       "description": "Returns true if a string has an extglob.",
       "licenses": [
@@ -22928,7 +22928,7 @@
       "type": "library",
       "name": "brace-expansion",
       "version": "5.0.9",
-      "bom-ref": "cogseed@0.9.0|brace-expansion@5.0.9",
+      "bom-ref": "cogseed@1.0.2|brace-expansion@5.0.9",
       "description": "Brace expansion as known from sh/bash",
       "licenses": [
         {
@@ -22986,7 +22986,7 @@
       "type": "library",
       "name": "deep-is",
       "version": "0.1.4",
-      "bom-ref": "cogseed@0.9.0|deep-is@0.1.4",
+      "bom-ref": "cogseed@1.0.2|deep-is@0.1.4",
       "author": "Thorsten Lorenz",
       "description": "node's assert.deepEqual algorithm except for NaN being equal to NaN",
       "licenses": [
@@ -23041,7 +23041,7 @@
       "type": "library",
       "name": "fast-levenshtein",
       "version": "2.0.6",
-      "bom-ref": "cogseed@0.9.0|fast-levenshtein@2.0.6",
+      "bom-ref": "cogseed@1.0.2|fast-levenshtein@2.0.6",
       "author": "Ramesh Nair",
       "description": "Efficient implementation of Levenshtein algorithm  with locale-specific collator support.",
       "licenses": [
@@ -23096,7 +23096,7 @@
       "type": "library",
       "name": "prelude-ls",
       "version": "1.2.1",
-      "bom-ref": "cogseed@0.9.0|prelude-ls@1.2.1",
+      "bom-ref": "cogseed@1.0.2|prelude-ls@1.2.1",
       "author": "George Zahariev",
       "description": "prelude.ls is a functionally oriented utility library. It is powerful and flexible. Almost all of its functions are curried. It is written in, and is the recommended base library for, LiveScript.",
       "licenses": [
@@ -23155,7 +23155,7 @@
       "type": "library",
       "name": "type-check",
       "version": "0.4.0",
-      "bom-ref": "cogseed@0.9.0|type-check@0.4.0",
+      "bom-ref": "cogseed@1.0.2|type-check@0.4.0",
       "author": "George Zahariev",
       "description": "type-check allows you to check the types of JavaScript values at runtime with a Haskell like type syntax.",
       "licenses": [
@@ -23214,7 +23214,7 @@
       "type": "library",
       "name": "word-wrap",
       "version": "1.2.5",
-      "bom-ref": "cogseed@0.9.0|word-wrap@1.2.5",
+      "bom-ref": "cogseed@1.0.2|word-wrap@1.2.5",
       "author": "Jon Schlinkert",
       "description": "Wrap words to a specified length.",
       "licenses": [
@@ -23274,7 +23274,7 @@
       "name": "tokenizers-darwin-universal",
       "group": "@anush008",
       "version": "0.0.0",
-      "bom-ref": "cogseed@0.9.0|@anush008/tokenizers-darwin-universal@0.0.0",
+      "bom-ref": "cogseed@1.0.2|@anush008/tokenizers-darwin-universal@0.0.0",
       "description": "Multi-arch builds of HuggingFace tokenizers",
       "licenses": [
         {
@@ -23329,7 +23329,7 @@
       "name": "tasks",
       "group": "@huggingface",
       "version": "0.19.90",
-      "bom-ref": "cogseed@0.9.0|@huggingface/tasks@0.19.90",
+      "bom-ref": "cogseed@1.0.2|@huggingface/tasks@0.19.90",
       "author": "Hugging Face",
       "description": "List of ML tasks for huggingface.co/tasks",
       "licenses": [
@@ -23380,7 +23380,7 @@
       "type": "library",
       "name": "cli-progress",
       "version": "3.12.0",
-      "bom-ref": "cogseed@0.9.0|cli-progress@3.12.0",
+      "bom-ref": "cogseed@1.0.2|cli-progress@3.12.0",
       "author": "Andi Dittrich",
       "description": "easy to use progress-bar for command-line/terminal applications",
       "licenses": [
@@ -23435,7 +23435,7 @@
       "type": "library",
       "name": "global-agent",
       "version": "3.0.0",
-      "bom-ref": "cogseed@0.9.0|global-agent@3.0.0",
+      "bom-ref": "cogseed@1.0.2|global-agent@3.0.0",
       "author": "Gajus Kuizinas",
       "description": "Global HTTP/HTTPS proxy configurable using environment variables.",
       "licenses": [
@@ -23479,7 +23479,7 @@
       "type": "library",
       "name": "onnxruntime-common",
       "version": "1.21.0",
-      "bom-ref": "cogseed@0.9.0|onnxruntime-common@1.21.0",
+      "bom-ref": "cogseed@1.0.2|onnxruntime-common@1.21.0",
       "author": "fs-eire",
       "description": "ONNXRuntime JavaScript API library",
       "licenses": [
@@ -23531,7 +23531,7 @@
       "name": "file-ops",
       "group": "@jimp",
       "version": "1.6.1",
-      "bom-ref": "cogseed@0.9.0|@jimp/file-ops@1.6.1",
+      "bom-ref": "cogseed@1.0.2|@jimp/file-ops@1.6.1",
       "author": "Andrew Lisowski",
       "licenses": [
         {
@@ -23585,7 +23585,7 @@
       "type": "library",
       "name": "await-to-js",
       "version": "3.0.0",
-      "bom-ref": "cogseed@0.9.0|await-to-js@3.0.0",
+      "bom-ref": "cogseed@1.0.2|await-to-js@3.0.0",
       "author": "Dima Grossman",
       "description": "Async/await wrapper for easy error handling in js",
       "licenses": [
@@ -23640,7 +23640,7 @@
       "type": "library",
       "name": "exif-parser",
       "version": "0.1.12",
-      "bom-ref": "cogseed@0.9.0|exif-parser@0.1.12",
+      "bom-ref": "cogseed@1.0.2|exif-parser@0.1.12",
       "author": "Bruno Windels",
       "description": "A javascript library to extract Exif metadata from images, in node and in the browser.",
       "purl": "pkg:npm/exif-parser@0.1.12",
@@ -23683,7 +23683,7 @@
       "type": "library",
       "name": "file-type",
       "version": "21.3.4",
-      "bom-ref": "cogseed@0.9.0|file-type@21.3.4",
+      "bom-ref": "cogseed@1.0.2|file-type@21.3.4",
       "author": "Sindre Sorhus",
       "description": "Detect the file type of a file, stream, or data",
       "licenses": [
@@ -23738,7 +23738,7 @@
       "type": "library",
       "name": "mime",
       "version": "3.0.0",
-      "bom-ref": "cogseed@0.9.0|mime@3.0.0",
+      "bom-ref": "cogseed@1.0.2|mime@3.0.0",
       "author": "Robert Kieffer",
       "description": "A comprehensive library for mime-type mapping",
       "licenses": [
@@ -23793,7 +23793,7 @@
       "type": "library",
       "name": "pixelmatch",
       "version": "5.3.0",
-      "bom-ref": "cogseed@0.9.0|pixelmatch@5.3.0",
+      "bom-ref": "cogseed@1.0.2|pixelmatch@5.3.0",
       "author": "Vladimir Agafonkin",
       "description": "The smallest and fastest pixel-level image comparison library.",
       "licenses": [
@@ -23844,7 +23844,7 @@
           "type": "library",
           "name": "pngjs",
           "version": "6.0.0",
-          "bom-ref": "cogseed@0.9.0|pixelmatch@5.3.0|pngjs@6.0.0",
+          "bom-ref": "cogseed@1.0.2|pixelmatch@5.3.0|pngjs@6.0.0",
           "description": "PNG encoder/decoder in pure JS, supporting any bit size & interlace, async & sync with full test suite.",
           "licenses": [
             {
@@ -23900,7 +23900,7 @@
       "type": "library",
       "name": "bmp-ts",
       "version": "1.0.9",
-      "bom-ref": "cogseed@0.9.0|bmp-ts@1.0.9",
+      "bom-ref": "cogseed@1.0.2|bmp-ts@1.0.9",
       "author": "Andrew lisowski",
       "description": "A pure typescript BMP encoder and decoder",
       "licenses": [
@@ -23951,7 +23951,7 @@
       "type": "library",
       "name": "gifwrap",
       "version": "0.10.1",
-      "bom-ref": "cogseed@0.9.0|gifwrap@0.10.1",
+      "bom-ref": "cogseed@1.0.2|gifwrap@0.10.1",
       "author": "Joseph T. Lapp",
       "description": "A Jimp-compatible library for working with GIFs",
       "licenses": [
@@ -24002,7 +24002,7 @@
       "type": "library",
       "name": "omggif",
       "version": "1.0.10",
-      "bom-ref": "cogseed@0.9.0|omggif@1.0.10",
+      "bom-ref": "cogseed@1.0.2|omggif@1.0.10",
       "author": "Dean McNamee",
       "licenses": [
         {
@@ -24052,7 +24052,7 @@
       "type": "library",
       "name": "jpeg-js",
       "version": "0.4.4",
-      "bom-ref": "cogseed@0.9.0|jpeg-js@0.4.4",
+      "bom-ref": "cogseed@1.0.2|jpeg-js@0.4.4",
       "author": "Eugene Ware",
       "description": "A pure javascript JPEG encoder and decoder",
       "licenses": [
@@ -24103,7 +24103,7 @@
       "type": "library",
       "name": "pngjs",
       "version": "7.0.0",
-      "bom-ref": "cogseed@0.9.0|pngjs@7.0.0",
+      "bom-ref": "cogseed@1.0.2|pngjs@7.0.0",
       "description": "PNG encoder/decoder in pure JS, supporting any bit size & interlace, async & sync with full test suite.",
       "licenses": [
         {
@@ -24157,7 +24157,7 @@
       "type": "library",
       "name": "utif2",
       "version": "4.1.0",
-      "bom-ref": "cogseed@0.9.0|utif2@4.1.0",
+      "bom-ref": "cogseed@1.0.2|utif2@4.1.0",
       "author": "photopea",
       "description": "Fast and advanced TIFF decoder",
       "licenses": [
@@ -24208,7 +24208,7 @@
       "type": "library",
       "name": "tinycolor2",
       "version": "1.6.0",
-      "bom-ref": "cogseed@0.9.0|tinycolor2@1.6.0",
+      "bom-ref": "cogseed@1.0.2|tinycolor2@1.6.0",
       "author": "Brian Grinstead",
       "description": "Fast Color Parsing and Manipulation",
       "licenses": [
@@ -24259,7 +24259,7 @@
       "type": "library",
       "name": "any-base",
       "version": "1.1.0",
-      "bom-ref": "cogseed@0.9.0|any-base@1.1.0",
+      "bom-ref": "cogseed@1.0.2|any-base@1.1.0",
       "author": "Kamil Harasimowicz",
       "description": "Converter from any base to other any base",
       "licenses": [
@@ -24310,7 +24310,7 @@
       "type": "library",
       "name": "parse-bmfont-ascii",
       "version": "1.0.6",
-      "bom-ref": "cogseed@0.9.0|parse-bmfont-ascii@1.0.6",
+      "bom-ref": "cogseed@1.0.2|parse-bmfont-ascii@1.0.6",
       "author": "Matt DesLauriers",
       "description": "parses ASCII BMFont files to a JavaScript object",
       "licenses": [
@@ -24361,7 +24361,7 @@
       "type": "library",
       "name": "parse-bmfont-binary",
       "version": "1.0.6",
-      "bom-ref": "cogseed@0.9.0|parse-bmfont-binary@1.0.6",
+      "bom-ref": "cogseed@1.0.2|parse-bmfont-binary@1.0.6",
       "author": "Matt DesLauriers",
       "description": "reads a BMFont binary in a Buffer into a JSON object",
       "licenses": [
@@ -24412,7 +24412,7 @@
       "type": "library",
       "name": "parse-bmfont-xml",
       "version": "1.1.6",
-      "bom-ref": "cogseed@0.9.0|parse-bmfont-xml@1.1.6",
+      "bom-ref": "cogseed@1.0.2|parse-bmfont-xml@1.1.6",
       "author": "Matt DesLauriers",
       "description": "parses XML BMFont files into a JavaScript object",
       "licenses": [
@@ -24463,7 +24463,7 @@
       "type": "library",
       "name": "simple-xml-to-json",
       "version": "1.2.7",
-      "bom-ref": "cogseed@0.9.0|simple-xml-to-json@1.2.7",
+      "bom-ref": "cogseed@1.0.2|simple-xml-to-json@1.2.7",
       "author": "Nir Moav",
       "description": "Convert XML to JSON - Fast & Simple",
       "licenses": [
@@ -24518,7 +24518,7 @@
       "type": "library",
       "name": "image-q",
       "version": "4.0.0",
-      "bom-ref": "cogseed@0.9.0|image-q@4.0.0",
+      "bom-ref": "cogseed@1.0.2|image-q@4.0.0",
       "description": "Image Quantization Library in **TypeScript** *(MIT Licensed)*",
       "licenses": [
         {
@@ -24569,7 +24569,7 @@
           "name": "node",
           "group": "@types",
           "version": "16.9.1",
-          "bom-ref": "cogseed@0.9.0|image-q@4.0.0|@types/node@16.9.1",
+          "bom-ref": "cogseed@1.0.2|image-q@4.0.0|@types/node@16.9.1",
           "description": "TypeScript definitions for Node.js",
           "licenses": [
             {
@@ -24621,7 +24621,7 @@
       "type": "library",
       "name": "lie",
       "version": "3.3.0",
-      "bom-ref": "cogseed@0.9.0|lie@3.3.0",
+      "bom-ref": "cogseed@1.0.2|lie@3.3.0",
       "description": "A basic but performant promise implementation",
       "licenses": [
         {
@@ -24671,7 +24671,7 @@
       "type": "library",
       "name": "pako",
       "version": "1.0.11",
-      "bom-ref": "cogseed@0.9.0|pako@1.0.11",
+      "bom-ref": "cogseed@1.0.2|pako@1.0.11",
       "description": "zlib port to javascript - fast, modularized, with browser support",
       "licenses": [
         {
@@ -24719,7 +24719,7 @@
       "type": "library",
       "name": "setimmediate",
       "version": "1.0.5",
-      "bom-ref": "cogseed@0.9.0|setimmediate@1.0.5",
+      "bom-ref": "cogseed@1.0.2|setimmediate@1.0.5",
       "author": "YuzuJS",
       "description": "A shim for the setImmediate efficient script yielding API",
       "licenses": [
@@ -24770,7 +24770,7 @@
       "type": "library",
       "name": "duck",
       "version": "0.1.12",
-      "bom-ref": "cogseed@0.9.0|duck@0.1.12",
+      "bom-ref": "cogseed@1.0.2|duck@0.1.12",
       "author": "Michael Williamson",
       "description": "Rich matchers inspired by Hamcrest. Useful for generating helpful assertion failure messages in tests.",
       "licenses": [
@@ -24821,7 +24821,7 @@
       "type": "library",
       "name": "option",
       "version": "0.2.4",
-      "bom-ref": "cogseed@0.9.0|option@0.2.4",
+      "bom-ref": "cogseed@1.0.2|option@0.2.4",
       "author": "Michael Williamson",
       "description": "The option type, also known as the maybe type, for JavaScript",
       "licenses": [
@@ -24873,7 +24873,7 @@
       "name": "canvas-darwin-arm64",
       "group": "@napi-rs",
       "version": "1.0.7",
-      "bom-ref": "cogseed@0.9.0|@napi-rs/canvas-darwin-arm64@1.0.7",
+      "bom-ref": "cogseed@1.0.2|@napi-rs/canvas-darwin-arm64@1.0.7",
       "description": "Canvas for Node.js with skia backend",
       "licenses": [
         {
@@ -24927,7 +24927,7 @@
       "type": "library",
       "name": "smart-buffer",
       "version": "4.2.0",
-      "bom-ref": "cogseed@0.9.0|smart-buffer@4.2.0",
+      "bom-ref": "cogseed@1.0.2|smart-buffer@4.2.0",
       "author": "Josh Glazebrook",
       "description": "smart-buffer is a Buffer wrapper that adds automatic read & write offset tracking, string operations, data insertions, and more.",
       "licenses": [
@@ -24987,7 +24987,7 @@
       "name": "scope-manager",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/scope-manager@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/scope-manager@8.67.0",
       "description": "TypeScript scope analyser for ESLint",
       "licenses": [
         {
@@ -25046,7 +25046,7 @@
       "name": "type-utils",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/type-utils@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/type-utils@8.67.0",
       "description": "Type utilities for working with TypeScript + ESLint together",
       "licenses": [
         {
@@ -25105,7 +25105,7 @@
       "name": "visitor-keys",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/visitor-keys@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/visitor-keys@8.67.0",
       "description": "Visitor keys used to help traverse the TypeScript-ESTree AST",
       "licenses": [
         {
@@ -25163,7 +25163,7 @@
       "type": "library",
       "name": "ts-api-utils",
       "version": "2.5.0",
-      "bom-ref": "cogseed@0.9.0|ts-api-utils@2.5.0",
+      "bom-ref": "cogseed@1.0.2|ts-api-utils@2.5.0",
       "author": "JoshuaKGoldberg",
       "description": "Utility functions for working with TypeScript's API. Successor to the wonderful tsutils. 🛠️️",
       "licenses": [
@@ -25223,7 +25223,7 @@
       "name": "types",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/types@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/types@8.67.0",
       "description": "Types for the TypeScript-ESTree AST spec",
       "licenses": [
         {
@@ -25282,7 +25282,7 @@
       "name": "project-service",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/project-service@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/project-service@8.67.0",
       "description": "Standalone TypeScript project service wrapper for linting.",
       "licenses": [
         {
@@ -25341,7 +25341,7 @@
       "name": "tsconfig-utils",
       "group": "@typescript-eslint",
       "version": "8.67.0",
-      "bom-ref": "cogseed@0.9.0|@typescript-eslint/tsconfig-utils@8.67.0",
+      "bom-ref": "cogseed@1.0.2|@typescript-eslint/tsconfig-utils@8.67.0",
       "description": "Utilities for collecting TSConfigs for linting scenarios.",
       "licenses": [
         {
@@ -25400,7 +25400,7 @@
       "name": "spec",
       "group": "@standard-schema",
       "version": "1.1.0",
-      "bom-ref": "cogseed@0.9.0|@standard-schema/spec@1.1.0",
+      "bom-ref": "cogseed@1.0.2|@standard-schema/spec@1.1.0",
       "author": "Colin McDonnell",
       "description": "A family of specs for interoperable TypeScript",
       "licenses": [
@@ -25456,7 +25456,7 @@
       "name": "chai",
       "group": "@types",
       "version": "5.2.3",
-      "bom-ref": "cogseed@0.9.0|@types/chai@5.2.3",
+      "bom-ref": "cogseed@1.0.2|@types/chai@5.2.3",
       "description": "TypeScript definitions for chai",
       "licenses": [
         {
@@ -25510,7 +25510,7 @@
       "type": "library",
       "name": "chai",
       "version": "6.2.2",
-      "bom-ref": "cogseed@0.9.0|chai@6.2.2",
+      "bom-ref": "cogseed@1.0.2|chai@6.2.2",
       "author": "Jake Luer",
       "description": "BDD/TDD assertion library for node.js and the browser. Test framework agnostic.",
       "licenses": [
@@ -25570,7 +25570,7 @@
       "name": "sourcemap-codec",
       "group": "@jridgewell",
       "version": "1.5.5",
-      "bom-ref": "cogseed@0.9.0|@jridgewell/sourcemap-codec@1.5.5",
+      "bom-ref": "cogseed@1.0.2|@jridgewell/sourcemap-codec@1.5.5",
       "author": "Justin Ridgewell",
       "description": "Encode/decode sourcemap mappings",
       "licenses": [
@@ -25625,7 +25625,7 @@
       "type": "library",
       "name": "fdir",
       "version": "6.5.0",
-      "bom-ref": "cogseed@0.9.0|fdir@6.5.0",
+      "bom-ref": "cogseed@1.0.2|fdir@6.5.0",
       "author": "thecodrr",
       "description": "The fastest directory crawler & globbing alternative to glob, fast-glob, & tiny-glob. Crawls 1m files in < 1s",
       "licenses": [
@@ -25684,7 +25684,7 @@
       "type": "library",
       "name": "lightningcss",
       "version": "1.33.0",
-      "bom-ref": "cogseed@0.9.0|lightningcss@1.33.0",
+      "bom-ref": "cogseed@1.0.2|lightningcss@1.33.0",
       "description": "A CSS parser, transformer, and minifier written in Rust",
       "licenses": [
         {
@@ -25742,7 +25742,7 @@
       "type": "library",
       "name": "postcss",
       "version": "8.5.26",
-      "bom-ref": "cogseed@0.9.0|postcss@8.5.26",
+      "bom-ref": "cogseed@1.0.2|postcss@8.5.26",
       "author": "Andrey Sitnik",
       "description": "Tool for transforming styles with JS plugins",
       "licenses": [
@@ -25801,7 +25801,7 @@
       "type": "library",
       "name": "rolldown",
       "version": "1.2.5",
-      "bom-ref": "cogseed@0.9.0|rolldown@1.2.5",
+      "bom-ref": "cogseed@1.0.2|rolldown@1.2.5",
       "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
       "licenses": [
         {
@@ -25859,7 +25859,7 @@
       "type": "library",
       "name": "siginfo",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|siginfo@2.0.0",
+      "bom-ref": "cogseed@1.0.2|siginfo@2.0.0",
       "author": "Emil Bay",
       "description": "Utility module to print pretty messages on SIGINFO/SIGUSR1",
       "licenses": [
@@ -25903,7 +25903,7 @@
       "type": "library",
       "name": "stackback",
       "version": "0.0.2",
-      "bom-ref": "cogseed@0.9.0|stackback@0.0.2",
+      "bom-ref": "cogseed@1.0.2|stackback@0.0.2",
       "author": "Roman Shtylman",
       "description": "return list of CallSite objects from a captured stacktrace",
       "licenses": [
@@ -25948,7 +25948,7 @@
       "name": "runtime",
       "group": "@babel",
       "version": "7.29.7",
-      "bom-ref": "cogseed@0.9.0|@babel/runtime@7.29.7",
+      "bom-ref": "cogseed@1.0.2|@babel/runtime@7.29.7",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -26003,7 +26003,7 @@
       "type": "library",
       "name": "ts-algebra",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|ts-algebra@2.0.0",
+      "bom-ref": "cogseed@1.0.2|ts-algebra@2.0.0",
       "author": "Thomas Aribart",
       "description": "Types on steroids 💊",
       "licenses": [
@@ -26055,7 +26055,7 @@
       "name": "supports-web-crypto",
       "group": "@aws-crypto",
       "version": "5.2.0",
-      "bom-ref": "cogseed@0.9.0|@aws-crypto/supports-web-crypto@5.2.0",
+      "bom-ref": "cogseed@1.0.2|@aws-crypto/supports-web-crypto@5.2.0",
       "author": "AWS Crypto Tools Team",
       "description": "Provides functions for detecting if the host environment supports the WebCrypto API",
       "licenses": [
@@ -26107,7 +26107,7 @@
       "name": "util",
       "group": "@aws-crypto",
       "version": "5.2.0",
-      "bom-ref": "cogseed@0.9.0|@aws-crypto/util@5.2.0",
+      "bom-ref": "cogseed@1.0.2|@aws-crypto/util@5.2.0",
       "author": "AWS Crypto Tools Team",
       "licenses": [
         {
@@ -26158,7 +26158,7 @@
       "name": "util-locate-window",
       "group": "@aws-sdk",
       "version": "3.965.5",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/util-locate-window@3.965.5",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/util-locate-window@3.965.5",
       "author": "AWS SDK for JavaScript Team",
       "licenses": [
         {
@@ -26213,7 +26213,7 @@
       "name": "util-utf8",
       "group": "@smithy",
       "version": "2.3.0",
-      "bom-ref": "cogseed@0.9.0|@smithy/util-utf8@2.3.0",
+      "bom-ref": "cogseed@1.0.2|@smithy/util-utf8@2.3.0",
       "author": "AWS SDK for JavaScript Team",
       "description": "A UTF-8 string <-> UInt8Array converter",
       "licenses": [
@@ -26269,7 +26269,7 @@
       "name": "xml-builder",
       "group": "@aws-sdk",
       "version": "3.972.26",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/xml-builder@3.972.26",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/xml-builder@3.972.26",
       "author": "AWS SDK for JavaScript Team",
       "description": "XML utilities for the AWS SDK",
       "licenses": [
@@ -26325,7 +26325,7 @@
       "name": "lambda-invoke-store",
       "group": "@aws",
       "version": "0.2.4",
-      "bom-ref": "cogseed@0.9.0|@aws/lambda-invoke-store@0.2.4",
+      "bom-ref": "cogseed@1.0.2|@aws/lambda-invoke-store@0.2.4",
       "author": "Amazon Web Services",
       "description": "Invoke scoped data storage for AWS Lambda Node.js Runtime Environment",
       "licenses": [
@@ -26381,7 +26381,7 @@
       "name": "signature-v4",
       "group": "@smithy",
       "version": "5.4.5",
-      "bom-ref": "cogseed@0.9.0|@smithy/signature-v4@5.4.5",
+      "bom-ref": "cogseed@1.0.2|@smithy/signature-v4@5.4.5",
       "author": "AWS SDK for JavaScript Team",
       "description": "A standalone implementation of the AWS Signature V4 request signing algorithm",
       "licenses": [
@@ -26436,7 +26436,7 @@
       "type": "library",
       "name": "bowser",
       "version": "2.14.1",
-      "bom-ref": "cogseed@0.9.0|bowser@2.14.1",
+      "bom-ref": "cogseed@1.0.2|bowser@2.14.1",
       "author": "Dustin Diaz",
       "description": "Lightweight browser detector",
       "licenses": [
@@ -26488,7 +26488,7 @@
       "name": "credential-provider-env",
       "group": "@aws-sdk",
       "version": "3.972.41",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-env@3.972.41",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-env@3.972.41",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider that sources credentials from known environment variables",
       "licenses": [
@@ -26544,7 +26544,7 @@
       "name": "credential-provider-http",
       "group": "@aws-sdk",
       "version": "3.972.43",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-http@3.972.43",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-http@3.972.43",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider for containers and HTTP sources",
       "licenses": [
@@ -26600,7 +26600,7 @@
           "name": "node-http-handler",
           "group": "@smithy",
           "version": "4.7.5",
-          "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-http@3.972.43|@smithy/node-http-handler@4.7.5",
+          "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-http@3.972.43|@smithy/node-http-handler@4.7.5",
           "author": "AWS SDK for JavaScript Team",
           "description": "Provides a way to make requests",
           "licenses": [
@@ -26658,7 +26658,7 @@
       "name": "credential-provider-ini",
       "group": "@aws-sdk",
       "version": "3.972.46",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-ini@3.972.46",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-ini@3.972.46",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider that sources credentials from ~/.aws/credentials and ~/.aws/config",
       "licenses": [
@@ -26714,7 +26714,7 @@
       "name": "credential-provider-process",
       "group": "@aws-sdk",
       "version": "3.972.41",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-process@3.972.41",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-process@3.972.41",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider that sources credential_process from ~/.aws/credentials and ~/.aws/config",
       "licenses": [
@@ -26770,7 +26770,7 @@
       "name": "credential-provider-sso",
       "group": "@aws-sdk",
       "version": "3.972.45",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-sso@3.972.45",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-sso@3.972.45",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider that exchanges a resolved SSO login token file for temporary AWS credentials",
       "licenses": [
@@ -26826,7 +26826,7 @@
           "name": "token-providers",
           "group": "@aws-sdk",
           "version": "3.1056.0",
-          "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-sso@3.972.45|@aws-sdk/token-providers@3.1056.0",
+          "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-sso@3.972.45|@aws-sdk/token-providers@3.1056.0",
           "author": "AWS SDK for JavaScript Team",
           "description": "A collection of token providers",
           "licenses": [
@@ -26884,7 +26884,7 @@
       "name": "credential-provider-web-identity",
       "group": "@aws-sdk",
       "version": "3.972.45",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-web-identity@3.972.45",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-web-identity@3.972.45",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider that calls STS assumeRole for temporary AWS credentials",
       "licenses": [
@@ -26940,7 +26940,7 @@
       "name": "credential-provider-imds",
       "group": "@smithy",
       "version": "4.3.6",
-      "bom-ref": "cogseed@0.9.0|@smithy/credential-provider-imds@4.3.6",
+      "bom-ref": "cogseed@1.0.2|@smithy/credential-provider-imds@4.3.6",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider that sources credentials from the EC2 instance metadata service and ECS container metadata service",
       "licenses": [
@@ -26996,7 +26996,7 @@
       "name": "nested-clients",
       "group": "@aws-sdk",
       "version": "3.997.13",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13",
       "author": "AWS SDK for JavaScript Team",
       "description": "Nested clients for AWS SDK packages.",
       "licenses": [
@@ -27052,7 +27052,7 @@
           "name": "node-http-handler",
           "group": "@smithy",
           "version": "4.7.5",
-          "bom-ref": "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13|@smithy/node-http-handler@4.7.5",
+          "bom-ref": "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13|@smithy/node-http-handler@4.7.5",
           "author": "AWS SDK for JavaScript Team",
           "description": "Provides a way to make requests",
           "licenses": [
@@ -27110,7 +27110,7 @@
       "name": "crc32",
       "group": "@aws-crypto",
       "version": "5.2.0",
-      "bom-ref": "cogseed@0.9.0|@aws-crypto/crc32@5.2.0",
+      "bom-ref": "cogseed@1.0.2|@aws-crypto/crc32@5.2.0",
       "author": "AWS Crypto Tools Team",
       "licenses": [
         {
@@ -27164,7 +27164,7 @@
       "type": "library",
       "name": "ecdsa-sig-formatter",
       "version": "1.0.11",
-      "bom-ref": "cogseed@0.9.0|ecdsa-sig-formatter@1.0.11",
+      "bom-ref": "cogseed@1.0.2|ecdsa-sig-formatter@1.0.11",
       "author": "D2L Corporation",
       "description": "Translate ECDSA signatures between ASN.1/DER and JOSE-style concatenation",
       "licenses": [
@@ -27215,7 +27215,7 @@
       "type": "library",
       "name": "gaxios",
       "version": "7.1.4",
-      "bom-ref": "cogseed@0.9.0|gaxios@7.1.4",
+      "bom-ref": "cogseed@1.0.2|gaxios@7.1.4",
       "author": "Google, LLC",
       "description": "A simple common HTTP client specifically for Google APIs and services.",
       "licenses": [
@@ -27270,7 +27270,7 @@
       "type": "library",
       "name": "gcp-metadata",
       "version": "8.1.2",
-      "bom-ref": "cogseed@0.9.0|gcp-metadata@8.1.2",
+      "bom-ref": "cogseed@1.0.2|gcp-metadata@8.1.2",
       "author": "Google LLC",
       "description": "Get the metadata from a Google Cloud Platform environment",
       "licenses": [
@@ -27325,7 +27325,7 @@
       "type": "library",
       "name": "google-logging-utils",
       "version": "1.1.3",
-      "bom-ref": "cogseed@0.9.0|google-logging-utils@1.1.3",
+      "bom-ref": "cogseed@1.0.2|google-logging-utils@1.1.3",
       "author": "Google API Authors",
       "description": "A debug logger package for other Google libraries",
       "licenses": [
@@ -27380,7 +27380,7 @@
       "type": "library",
       "name": "jws",
       "version": "4.0.1",
-      "bom-ref": "cogseed@0.9.0|jws@4.0.1",
+      "bom-ref": "cogseed@1.0.2|jws@4.0.1",
       "author": "Brian J Brennan",
       "description": "Implementation of JSON Web Signatures",
       "licenses": [
@@ -27432,7 +27432,7 @@
       "name": "retry",
       "group": "@types",
       "version": "0.12.0",
-      "bom-ref": "cogseed@0.9.0|@types/retry@0.12.0",
+      "bom-ref": "cogseed@1.0.2|@types/retry@0.12.0",
       "description": "TypeScript definitions for retry",
       "licenses": [
         {
@@ -27482,7 +27482,7 @@
       "type": "library",
       "name": "retry",
       "version": "0.13.1",
-      "bom-ref": "cogseed@0.9.0|retry@0.13.1",
+      "bom-ref": "cogseed@1.0.2|retry@0.13.1",
       "author": "Tim Koschützki",
       "description": "Abstraction for exponential and custom retry strategies for failed operations.",
       "licenses": [
@@ -27537,7 +27537,7 @@
       "type": "library",
       "name": "abbrev",
       "version": "4.0.0",
-      "bom-ref": "cogseed@0.9.0|abbrev@4.0.0",
+      "bom-ref": "cogseed@1.0.2|abbrev@4.0.0",
       "author": "GitHub Inc.",
       "description": "Like ruby's abbrev module, but in js",
       "licenses": [
@@ -27596,7 +27596,7 @@
       "type": "library",
       "name": "asynckit",
       "version": "0.4.0",
-      "bom-ref": "cogseed@0.9.0|asynckit@0.4.0",
+      "bom-ref": "cogseed@1.0.2|asynckit@0.4.0",
       "author": "Alex Indigo",
       "description": "Minimal async jobs utility library, with streams support",
       "licenses": [
@@ -27647,7 +27647,7 @@
       "type": "library",
       "name": "combined-stream",
       "version": "1.0.8",
-      "bom-ref": "cogseed@0.9.0|combined-stream@1.0.8",
+      "bom-ref": "cogseed@1.0.2|combined-stream@1.0.8",
       "author": "Felix Geisendörfer",
       "description": "A stream that emits multiple other streams one after another.",
       "licenses": [
@@ -27702,7 +27702,7 @@
       "type": "library",
       "name": "es-set-tostringtag",
       "version": "2.1.0",
-      "bom-ref": "cogseed@0.9.0|es-set-tostringtag@2.1.0",
+      "bom-ref": "cogseed@1.0.2|es-set-tostringtag@2.1.0",
       "author": "Jordan Harband",
       "description": "A helper to optimistically set Symbol.toStringTag, when possible.",
       "licenses": [
@@ -27757,7 +27757,7 @@
       "type": "library",
       "name": "hasown",
       "version": "2.0.4",
-      "bom-ref": "cogseed@0.9.0|hasown@2.0.4",
+      "bom-ref": "cogseed@1.0.2|hasown@2.0.4",
       "author": "Jordan Harband",
       "description": "A robust, ES3 compatible, \"has own property\" predicate.",
       "licenses": [
@@ -27812,7 +27812,7 @@
       "type": "library",
       "name": "mime-types",
       "version": "2.1.35",
-      "bom-ref": "cogseed@0.9.0|mime-types@2.1.35",
+      "bom-ref": "cogseed@1.0.2|mime-types@2.1.35",
       "description": "The ultimate javascript content-type utility.",
       "licenses": [
         {
@@ -27866,7 +27866,7 @@
       "type": "library",
       "name": "es-errors",
       "version": "1.3.0",
-      "bom-ref": "cogseed@0.9.0|es-errors@1.3.0",
+      "bom-ref": "cogseed@1.0.2|es-errors@1.3.0",
       "author": "Jordan Harband",
       "description": "A simple cache for a few of the JS Error constructors.",
       "licenses": [
@@ -27910,7 +27910,7 @@
       "type": "library",
       "name": "object-inspect",
       "version": "1.13.4",
-      "bom-ref": "cogseed@0.9.0|object-inspect@1.13.4",
+      "bom-ref": "cogseed@1.0.2|object-inspect@1.13.4",
       "author": "James Halliday",
       "description": "string representations of objects in node and the browser",
       "licenses": [
@@ -27965,7 +27965,7 @@
       "type": "library",
       "name": "side-channel-list",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|side-channel-list@1.0.1",
+      "bom-ref": "cogseed@1.0.2|side-channel-list@1.0.1",
       "author": "Jordan Harband",
       "description": "Store information about any JS value in a side channel, using a linked list",
       "licenses": [
@@ -28020,7 +28020,7 @@
       "type": "library",
       "name": "side-channel-map",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|side-channel-map@1.0.1",
+      "bom-ref": "cogseed@1.0.2|side-channel-map@1.0.1",
       "author": "Jordan Harband",
       "description": "Store information about any JS value in a side channel, using a Map",
       "licenses": [
@@ -28075,7 +28075,7 @@
       "type": "library",
       "name": "side-channel-weakmap",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|side-channel-weakmap@1.0.2",
+      "bom-ref": "cogseed@1.0.2|side-channel-weakmap@1.0.2",
       "author": "Jordan Harband",
       "description": "Store information about any JS value in a side channel. Uses WeakMap if available.",
       "licenses": [
@@ -28130,7 +28130,7 @@
       "type": "library",
       "name": "shebang-regex",
       "version": "3.0.0",
-      "bom-ref": "cogseed@0.9.0|shebang-regex@3.0.0",
+      "bom-ref": "cogseed@1.0.2|shebang-regex@3.0.0",
       "author": "Sindre Sorhus",
       "description": "Regular expression for matching a shebang line",
       "licenses": [
@@ -28185,7 +28185,7 @@
       "type": "library",
       "name": "isexe",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|isexe@2.0.0",
+      "bom-ref": "cogseed@1.0.2|isexe@2.0.0",
       "author": "Isaac Z. Schlueter",
       "description": "Minimal module to check if a file is executable.",
       "licenses": [
@@ -28236,7 +28236,7 @@
       "type": "library",
       "name": "negotiator",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|negotiator@1.0.0",
+      "bom-ref": "cogseed@1.0.2|negotiator@1.0.0",
       "description": "HTTP content negotiation",
       "licenses": [
         {
@@ -28290,7 +28290,7 @@
       "type": "library",
       "name": "inherits",
       "version": "2.0.4",
-      "bom-ref": "cogseed@0.9.0|inherits@2.0.4",
+      "bom-ref": "cogseed@1.0.2|inherits@2.0.4",
       "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
       "licenses": [
         {
@@ -28329,7 +28329,7 @@
       "type": "library",
       "name": "setprototypeof",
       "version": "1.2.0",
-      "bom-ref": "cogseed@0.9.0|setprototypeof@1.2.0",
+      "bom-ref": "cogseed@1.0.2|setprototypeof@1.2.0",
       "author": "Wes Todd",
       "description": "A small polyfill for Object.setprototypeof",
       "licenses": [
@@ -28380,7 +28380,7 @@
       "type": "library",
       "name": "toidentifier",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|toidentifier@1.0.1",
+      "bom-ref": "cogseed@1.0.2|toidentifier@1.0.1",
       "author": "Douglas Christopher Wilson",
       "description": "Convert a string of words to a JavaScript identifier",
       "licenses": [
@@ -28435,7 +28435,7 @@
       "type": "library",
       "name": "ee-first",
       "version": "1.1.1",
-      "bom-ref": "cogseed@0.9.0|ee-first@1.1.1",
+      "bom-ref": "cogseed@1.0.2|ee-first@1.1.1",
       "author": "Jonathan Ong",
       "description": "return the first event in a set of ee/event pairs",
       "licenses": [
@@ -28486,7 +28486,7 @@
       "type": "library",
       "name": "wrappy",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|wrappy@1.0.2",
+      "bom-ref": "cogseed@1.0.2|wrappy@1.0.2",
       "author": "Isaac Z. Schlueter",
       "description": "Callback wrapping utility",
       "licenses": [
@@ -28526,7 +28526,7 @@
       "type": "library",
       "name": "forwarded",
       "version": "0.2.0",
-      "bom-ref": "cogseed@0.9.0|forwarded@0.2.0",
+      "bom-ref": "cogseed@1.0.2|forwarded@0.2.0",
       "description": "Parse HTTP X-Forwarded-For header",
       "licenses": [
         {
@@ -28580,7 +28580,7 @@
       "type": "library",
       "name": "ipaddr.js",
       "version": "1.9.1",
-      "bom-ref": "cogseed@0.9.0|ipaddr.js@1.9.1",
+      "bom-ref": "cogseed@1.0.2|ipaddr.js@1.9.1",
       "author": "whitequark",
       "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
       "licenses": [
@@ -28635,7 +28635,7 @@
       "type": "library",
       "name": "is-promise",
       "version": "4.0.0",
-      "bom-ref": "cogseed@0.9.0|is-promise@4.0.0",
+      "bom-ref": "cogseed@1.0.2|is-promise@4.0.0",
       "author": "ForbesLindesay",
       "description": "Test whether an object looks like a promises-a+ promise",
       "licenses": [
@@ -28686,7 +28686,7 @@
       "type": "library",
       "name": "path-to-regexp",
       "version": "8.4.2",
-      "bom-ref": "cogseed@0.9.0|path-to-regexp@8.4.2",
+      "bom-ref": "cogseed@1.0.2|path-to-regexp@8.4.2",
       "description": "Express style path to RegExp utility",
       "licenses": [
         {
@@ -28736,7 +28736,7 @@
       "type": "library",
       "name": "media-typer",
       "version": "1.1.0",
-      "bom-ref": "cogseed@0.9.0|media-typer@1.1.0",
+      "bom-ref": "cogseed@1.0.2|media-typer@1.1.0",
       "author": "Douglas Christopher Wilson",
       "description": "Simple RFC 6838 media type parser and formatter",
       "licenses": [
@@ -28791,7 +28791,7 @@
       "type": "library",
       "name": "safer-buffer",
       "version": "2.1.2",
-      "bom-ref": "cogseed@0.9.0|safer-buffer@2.1.2",
+      "bom-ref": "cogseed@1.0.2|safer-buffer@2.1.2",
       "author": "Nikita Skovoroda",
       "description": "Modern Buffer API polyfill without footguns",
       "licenses": [
@@ -28843,7 +28843,7 @@
       "name": "resolve-uri",
       "group": "@jridgewell",
       "version": "3.1.2",
-      "bom-ref": "cogseed@0.9.0|@jridgewell/resolve-uri@3.1.2",
+      "bom-ref": "cogseed@1.0.2|@jridgewell/resolve-uri@3.1.2",
       "author": "Justin Ridgewell",
       "description": "Resolve a URI relative to an optional base URI",
       "licenses": [
@@ -28902,7 +28902,7 @@
       "type": "library",
       "name": "has-flag",
       "version": "4.0.0",
-      "bom-ref": "cogseed@0.9.0|has-flag@4.0.0",
+      "bom-ref": "cogseed@1.0.2|has-flag@4.0.0",
       "author": "Sindre Sorhus",
       "description": "Check if argv has a specific flag",
       "licenses": [
@@ -28962,7 +28962,7 @@
       "name": "helper-string-parser",
       "group": "@babel",
       "version": "7.29.7",
-      "bom-ref": "cogseed@0.9.0|@babel/helper-string-parser@7.29.7",
+      "bom-ref": "cogseed@1.0.2|@babel/helper-string-parser@7.29.7",
       "author": "The Babel Team",
       "description": "A utility package to parse strings",
       "licenses": [
@@ -29022,7 +29022,7 @@
       "name": "helper-validator-identifier",
       "group": "@babel",
       "version": "7.29.7",
-      "bom-ref": "cogseed@0.9.0|@babel/helper-validator-identifier@7.29.7",
+      "bom-ref": "cogseed@1.0.2|@babel/helper-validator-identifier@7.29.7",
       "author": "The Babel Team",
       "description": "Validate identifier/keywords name",
       "licenses": [
@@ -29081,7 +29081,7 @@
       "type": "library",
       "name": "end-of-stream",
       "version": "1.4.5",
-      "bom-ref": "cogseed@0.9.0|end-of-stream@1.4.5",
+      "bom-ref": "cogseed@1.0.2|end-of-stream@1.4.5",
       "author": "Mathias Buus",
       "description": "Call a callback when a readable/writable/duplex stream has completed or failed.",
       "licenses": [
@@ -29121,7 +29121,7 @@
       "type": "library",
       "name": "deep-extend",
       "version": "0.6.0",
-      "bom-ref": "cogseed@0.9.0|deep-extend@0.6.0",
+      "bom-ref": "cogseed@1.0.2|deep-extend@0.6.0",
       "author": "Viacheslav Lotsmanov",
       "description": "Recursive object extending",
       "licenses": [
@@ -29172,7 +29172,7 @@
       "type": "library",
       "name": "ini",
       "version": "1.3.8",
-      "bom-ref": "cogseed@0.9.0|ini@1.3.8",
+      "bom-ref": "cogseed@1.0.2|ini@1.3.8",
       "author": "Isaac Z. Schlueter",
       "description": "An ini encoder/decoder for node",
       "licenses": [
@@ -29212,7 +29212,7 @@
       "type": "library",
       "name": "strip-json-comments",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|strip-json-comments@2.0.1",
+      "bom-ref": "cogseed@1.0.2|strip-json-comments@2.0.1",
       "author": "Sindre Sorhus",
       "description": "Strip comments from JSON. Lets you use comments in your JSON files!",
       "licenses": [
@@ -29256,7 +29256,7 @@
       "type": "library",
       "name": "decompress-response",
       "version": "6.0.0",
-      "bom-ref": "cogseed@0.9.0|decompress-response@6.0.0",
+      "bom-ref": "cogseed@1.0.2|decompress-response@6.0.0",
       "author": "Sindre Sorhus",
       "description": "Decompress a HTTP response if needed",
       "licenses": [
@@ -29300,7 +29300,7 @@
           "type": "library",
           "name": "mimic-response",
           "version": "3.1.0",
-          "bom-ref": "cogseed@0.9.0|decompress-response@6.0.0|mimic-response@3.1.0",
+          "bom-ref": "cogseed@1.0.2|decompress-response@6.0.0|mimic-response@3.1.0",
           "author": "Sindre Sorhus",
           "description": "Mimic a Node.js HTTP response stream",
           "licenses": [
@@ -29346,7 +29346,7 @@
       "type": "library",
       "name": "simple-concat",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|simple-concat@1.0.1",
+      "bom-ref": "cogseed@1.0.2|simple-concat@1.0.1",
       "author": "Feross Aboukhadijeh",
       "description": "Super-minimalist version of `concat-stream`. Less than 15 lines!",
       "licenses": [
@@ -29386,7 +29386,7 @@
       "type": "library",
       "name": "chownr",
       "version": "1.1.4",
-      "bom-ref": "cogseed@0.9.0|chownr@1.1.4",
+      "bom-ref": "cogseed@1.0.2|chownr@1.1.4",
       "author": "Isaac Z. Schlueter",
       "description": "like `chown -R`",
       "licenses": [
@@ -29426,7 +29426,7 @@
       "type": "library",
       "name": "tar-stream",
       "version": "2.2.0",
-      "bom-ref": "cogseed@0.9.0|tar-stream@2.2.0",
+      "bom-ref": "cogseed@1.0.2|tar-stream@2.2.0",
       "author": "Mathias Buus",
       "description": "tar-stream is a streaming tar parser and generator and nothing else. It is streams2 and operates purely using streams which means you can easily extract/parse tarballs without ever hitting the file system.",
       "licenses": [
@@ -29470,7 +29470,7 @@
       "type": "library",
       "name": "safe-buffer",
       "version": "5.2.1",
-      "bom-ref": "cogseed@0.9.0|safe-buffer@5.2.1",
+      "bom-ref": "cogseed@1.0.2|safe-buffer@5.2.1",
       "author": "Feross Aboukhadijeh",
       "description": "Safer Node.js Buffer API",
       "licenses": [
@@ -29510,7 +29510,7 @@
       "type": "library",
       "name": "commander",
       "version": "5.1.0",
-      "bom-ref": "cogseed@0.9.0|commander@5.1.0",
+      "bom-ref": "cogseed@1.0.2|commander@5.1.0",
       "author": "TJ Holowaychuk",
       "description": "the complete solution for node.js command-line programs",
       "licenses": [
@@ -29569,7 +29569,7 @@
       "type": "library",
       "name": "glob",
       "version": "7.2.3",
-      "bom-ref": "cogseed@0.9.0|glob@7.2.3",
+      "bom-ref": "cogseed@1.0.2|glob@7.2.3",
       "author": "Isaac Z. Schlueter",
       "description": "a little globber",
       "licenses": [
@@ -29628,7 +29628,7 @@
           "type": "library",
           "name": "minimatch",
           "version": "3.1.5",
-          "bom-ref": "cogseed@0.9.0|glob@7.2.3|minimatch@3.1.5",
+          "bom-ref": "cogseed@1.0.2|glob@7.2.3|minimatch@3.1.5",
           "author": "Isaac Z. Schlueter",
           "description": "a glob matcher in javascript",
           "licenses": [
@@ -29687,7 +29687,7 @@
           "type": "library",
           "name": "brace-expansion",
           "version": "1.1.18",
-          "bom-ref": "cogseed@0.9.0|glob@7.2.3|brace-expansion@1.1.18",
+          "bom-ref": "cogseed@1.0.2|glob@7.2.3|brace-expansion@1.1.18",
           "author": "Julian Gruber",
           "description": "Brace expansion as known from sh/bash",
           "licenses": [
@@ -29742,7 +29742,7 @@
           "type": "library",
           "name": "balanced-match",
           "version": "1.0.2",
-          "bom-ref": "cogseed@0.9.0|glob@7.2.3|balanced-match@1.0.2",
+          "bom-ref": "cogseed@1.0.2|glob@7.2.3|balanced-match@1.0.2",
           "author": "Julian Gruber",
           "description": "Match balanced character pairs, like \"{\" and \"}\"",
           "licenses": [
@@ -29799,7 +29799,7 @@
       "type": "library",
       "name": "got",
       "version": "11.8.6",
-      "bom-ref": "cogseed@0.9.0|got@11.8.6",
+      "bom-ref": "cogseed@1.0.2|got@11.8.6",
       "description": "Human-friendly and powerful HTTP request library for Node.js",
       "licenses": [
         {
@@ -29857,7 +29857,7 @@
       "type": "library",
       "name": "promise-retry",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|promise-retry@2.0.1",
+      "bom-ref": "cogseed@1.0.2|promise-retry@2.0.1",
       "author": "IndigoUnited",
       "description": "Retries a function that returns a promise, leveraging the power of the retry module.",
       "licenses": [
@@ -29916,7 +29916,7 @@
           "type": "library",
           "name": "retry",
           "version": "0.12.0",
-          "bom-ref": "cogseed@0.9.0|promise-retry@2.0.1|retry@0.12.0",
+          "bom-ref": "cogseed@1.0.2|promise-retry@2.0.1|retry@0.12.0",
           "author": "Tim Koschützki",
           "description": "Abstraction for exponential and custom retry strategies for failed operations.",
           "licenses": [
@@ -29977,7 +29977,7 @@
       "type": "library",
       "name": "compare-version",
       "version": "0.1.2",
-      "bom-ref": "cogseed@0.9.0|compare-version@0.1.2",
+      "bom-ref": "cogseed@1.0.2|compare-version@0.1.2",
       "author": "Kevin Mårtensson",
       "description": "Compare semver version numbers",
       "licenses": [
@@ -30036,7 +30036,7 @@
       "type": "library",
       "name": "dir-compare",
       "version": "4.2.0",
-      "bom-ref": "cogseed@0.9.0|dir-compare@4.2.0",
+      "bom-ref": "cogseed@1.0.2|dir-compare@4.2.0",
       "author": "Liviu Grigorescu",
       "description": "Node JS directory compare",
       "licenses": [
@@ -30091,7 +30091,7 @@
           "type": "library",
           "name": "minimatch",
           "version": "3.1.5",
-          "bom-ref": "cogseed@0.9.0|dir-compare@4.2.0|minimatch@3.1.5",
+          "bom-ref": "cogseed@1.0.2|dir-compare@4.2.0|minimatch@3.1.5",
           "author": "Isaac Z. Schlueter",
           "description": "a glob matcher in javascript",
           "licenses": [
@@ -30150,7 +30150,7 @@
           "type": "library",
           "name": "brace-expansion",
           "version": "1.1.18",
-          "bom-ref": "cogseed@0.9.0|dir-compare@4.2.0|brace-expansion@1.1.18",
+          "bom-ref": "cogseed@1.0.2|dir-compare@4.2.0|brace-expansion@1.1.18",
           "author": "Julian Gruber",
           "description": "Brace expansion as known from sh/bash",
           "licenses": [
@@ -30205,7 +30205,7 @@
           "type": "library",
           "name": "balanced-match",
           "version": "1.0.2",
-          "bom-ref": "cogseed@0.9.0|dir-compare@4.2.0|balanced-match@1.0.2",
+          "bom-ref": "cogseed@1.0.2|dir-compare@4.2.0|balanced-match@1.0.2",
           "author": "Julian Gruber",
           "description": "Match balanced character pairs, like \"{\" and \"}\"",
           "licenses": [
@@ -30262,7 +30262,7 @@
       "type": "library",
       "name": "lodash",
       "version": "4.18.1",
-      "bom-ref": "cogseed@0.9.0|lodash@4.18.1",
+      "bom-ref": "cogseed@1.0.2|lodash@4.18.1",
       "author": "John-David Dalton",
       "description": "Lodash modular utilities.",
       "licenses": [
@@ -30317,7 +30317,7 @@
       "type": "library",
       "name": "tmp-promise",
       "version": "3.0.3",
-      "bom-ref": "cogseed@0.9.0|tmp-promise@3.0.3",
+      "bom-ref": "cogseed@1.0.2|tmp-promise@3.0.3",
       "author": "Benjamin Gruenbaum and Collaborators.",
       "description": "The tmp package with promises support and disposers.",
       "licenses": [
@@ -30373,7 +30373,7 @@
       "name": "asn1-schema",
       "group": "@peculiar",
       "version": "2.9.3",
-      "bom-ref": "cogseed@0.9.0|@peculiar/asn1-schema@2.9.3",
+      "bom-ref": "cogseed@1.0.2|@peculiar/asn1-schema@2.9.3",
       "author": "PeculiarVentures, LLC",
       "description": "Decorators and helper APIs for declaring ASN.1 schemas in TypeScript.",
       "licenses": [
@@ -30429,7 +30429,7 @@
       "name": "json-schema",
       "group": "@peculiar",
       "version": "1.1.12",
-      "bom-ref": "cogseed@0.9.0|@peculiar/json-schema@1.1.12",
+      "bom-ref": "cogseed@1.0.2|@peculiar/json-schema@1.1.12",
       "author": "PeculiarVentures, Inc",
       "description": "This package uses ES2015 decorators to simplify JSON schema creation and use",
       "licenses": [
@@ -30489,7 +30489,7 @@
       "name": "utils",
       "group": "@peculiar",
       "version": "2.0.3",
-      "bom-ref": "cogseed@0.9.0|@peculiar/utils@2.0.3",
+      "bom-ref": "cogseed@1.0.2|@peculiar/utils@2.0.3",
       "author": "PeculiarVentures",
       "description": "Modern byte, encoding, converter registry, and PEM utilities for TypeScript projects.",
       "licenses": [
@@ -30544,7 +30544,7 @@
       "type": "library",
       "name": "webcrypto-core",
       "version": "1.9.2",
-      "bom-ref": "cogseed@0.9.0|webcrypto-core@1.9.2",
+      "bom-ref": "cogseed@1.0.2|webcrypto-core@1.9.2",
       "author": "PeculiarVentures",
       "description": "Common layer to be used by crypto libraries based on WebCrypto API for input validation.",
       "licenses": [
@@ -30599,7 +30599,7 @@
       "type": "library",
       "name": "pvtsutils",
       "version": "1.3.6",
-      "bom-ref": "cogseed@0.9.0|pvtsutils@1.3.6",
+      "bom-ref": "cogseed@1.0.2|pvtsutils@1.3.6",
       "author": "PeculiarVentures",
       "description": "pvtsutils is a set of common utility functions used in various Peculiar Ventures TypeScript based projects.",
       "licenses": [
@@ -30654,7 +30654,7 @@
       "type": "library",
       "name": "pvutils",
       "version": "1.2.0",
-      "bom-ref": "cogseed@0.9.0|pvutils@1.2.0",
+      "bom-ref": "cogseed@1.0.2|pvutils@1.2.0",
       "author": "Yury Strozhevsky",
       "description": "Common utilities for products from Peculiar Ventures",
       "licenses": [
@@ -30713,7 +30713,7 @@
       "type": "library",
       "name": "jake",
       "version": "10.9.4",
-      "bom-ref": "cogseed@0.9.0|jake@10.9.4",
+      "bom-ref": "cogseed@1.0.2|jake@10.9.4",
       "author": "Matthew Eernisse",
       "description": "JavaScript build tool, similar to Make or Rake",
       "licenses": [
@@ -30772,7 +30772,7 @@
       "type": "library",
       "name": "electron-winstaller",
       "version": "5.4.0",
-      "bom-ref": "cogseed@0.9.0|electron-winstaller@5.4.0",
+      "bom-ref": "cogseed@1.0.2|electron-winstaller@5.4.0",
       "description": "Module to generate Windows installers for Electron apps",
       "licenses": [
         {
@@ -30830,7 +30830,7 @@
           "type": "library",
           "name": "fs-extra",
           "version": "7.0.1",
-          "bom-ref": "cogseed@0.9.0|electron-winstaller@5.4.0|fs-extra@7.0.1",
+          "bom-ref": "cogseed@1.0.2|electron-winstaller@5.4.0|fs-extra@7.0.1",
           "author": "JP Richardson",
           "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as mkdir -p, cp -r, and rm -rf.",
           "licenses": [
@@ -30889,7 +30889,7 @@
           "type": "library",
           "name": "jsonfile",
           "version": "4.0.0",
-          "bom-ref": "cogseed@0.9.0|electron-winstaller@5.4.0|jsonfile@4.0.0",
+          "bom-ref": "cogseed@1.0.2|electron-winstaller@5.4.0|jsonfile@4.0.0",
           "author": "JP Richardson",
           "description": "Easily read/write JSON files.",
           "licenses": [
@@ -30944,7 +30944,7 @@
           "type": "library",
           "name": "universalify",
           "version": "0.1.2",
-          "bom-ref": "cogseed@0.9.0|electron-winstaller@5.4.0|universalify@0.1.2",
+          "bom-ref": "cogseed@1.0.2|electron-winstaller@5.4.0|universalify@0.1.2",
           "author": "Ryan Zimmerman",
           "description": "Make a callback- or promise-based function support both promises and callbacks.",
           "licenses": [
@@ -31005,7 +31005,7 @@
       "type": "library",
       "name": "aws4",
       "version": "1.13.2",
-      "bom-ref": "cogseed@0.9.0|aws4@1.13.2",
+      "bom-ref": "cogseed@1.0.2|aws4@1.13.2",
       "author": "Michael Hart",
       "description": "Signs and prepares requests using AWS Signature Version 4",
       "licenses": [
@@ -31060,7 +31060,7 @@
       "type": "library",
       "name": "lru-cache",
       "version": "6.0.0",
-      "bom-ref": "cogseed@0.9.0|lru-cache@6.0.0",
+      "bom-ref": "cogseed@1.0.2|lru-cache@6.0.0",
       "author": "Isaac Z. Schlueter",
       "description": "A cache object that deletes the least-recently-used items.",
       "licenses": [
@@ -31119,7 +31119,7 @@
           "type": "library",
           "name": "yallist",
           "version": "4.0.0",
-          "bom-ref": "cogseed@0.9.0|lru-cache@6.0.0|yallist@4.0.0",
+          "bom-ref": "cogseed@1.0.2|lru-cache@6.0.0|yallist@4.0.0",
           "author": "Isaac Z. Schlueter",
           "description": "Yet Another Linked List",
           "licenses": [
@@ -31176,7 +31176,7 @@
       "type": "library",
       "name": "bytestreamjs",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|bytestreamjs@2.0.1",
+      "bom-ref": "cogseed@1.0.2|bytestreamjs@2.0.1",
       "author": "Yury Strozhevsky",
       "description": "ByteStream is a library making possible to manipulates single bytes and bits on pure JavaScript",
       "licenses": [
@@ -31235,7 +31235,7 @@
       "type": "library",
       "name": "signal-exit",
       "version": "3.0.7",
-      "bom-ref": "cogseed@0.9.0|signal-exit@3.0.7",
+      "bom-ref": "cogseed@1.0.2|signal-exit@3.0.7",
       "author": "Ben Coe",
       "description": "when you want to fire an event no matter how a process exits.",
       "licenses": [
@@ -31290,7 +31290,7 @@
       "type": "library",
       "name": "pe-library",
       "version": "0.4.1",
-      "bom-ref": "cogseed@0.9.0|pe-library@0.4.1",
+      "bom-ref": "cogseed@1.0.2|pe-library@0.4.1",
       "author": "jet",
       "description": "Node.js library for Portable Executable format",
       "licenses": [
@@ -31353,7 +31353,7 @@
       "type": "library",
       "name": "duplexer2",
       "version": "0.1.4",
-      "bom-ref": "cogseed@0.9.0|duplexer2@0.1.4",
+      "bom-ref": "cogseed@1.0.2|duplexer2@0.1.4",
       "author": "Conrad Pankoff",
       "description": "Like duplexer but using streams3",
       "licenses": [
@@ -31408,7 +31408,7 @@
           "type": "library",
           "name": "readable-stream",
           "version": "2.3.8",
-          "bom-ref": "cogseed@0.9.0|duplexer2@0.1.4|readable-stream@2.3.8",
+          "bom-ref": "cogseed@1.0.2|duplexer2@0.1.4|readable-stream@2.3.8",
           "description": "Streams3, a user-land copy of the stream library from Node.js",
           "licenses": [
             {
@@ -31462,7 +31462,7 @@
           "type": "library",
           "name": "safe-buffer",
           "version": "5.1.2",
-          "bom-ref": "cogseed@0.9.0|duplexer2@0.1.4|safe-buffer@5.1.2",
+          "bom-ref": "cogseed@1.0.2|duplexer2@0.1.4|safe-buffer@5.1.2",
           "author": "Feross Aboukhadijeh",
           "description": "Safer Node.js Buffer API",
           "licenses": [
@@ -31517,7 +31517,7 @@
           "type": "library",
           "name": "string_decoder",
           "version": "1.1.1",
-          "bom-ref": "cogseed@0.9.0|duplexer2@0.1.4|string_decoder@1.1.1",
+          "bom-ref": "cogseed@1.0.2|duplexer2@0.1.4|string_decoder@1.1.1",
           "description": "The string_decoder module from Node core",
           "licenses": [
             {
@@ -31573,7 +31573,7 @@
       "type": "library",
       "name": "node-int64",
       "version": "0.4.0",
-      "bom-ref": "cogseed@0.9.0|node-int64@0.4.0",
+      "bom-ref": "cogseed@1.0.2|node-int64@0.4.0",
       "author": "Robert Kieffer",
       "description": "Support for representing 64-bit integers in JavaScript",
       "licenses": [
@@ -31629,7 +31629,7 @@
       "name": "ms",
       "group": "@types",
       "version": "2.1.0",
-      "bom-ref": "cogseed@0.9.0|@types/ms@2.1.0",
+      "bom-ref": "cogseed@1.0.2|@types/ms@2.1.0",
       "description": "TypeScript definitions for ms",
       "licenses": [
         {
@@ -31683,7 +31683,7 @@
       "type": "library",
       "name": "truncate-utf8-bytes",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|truncate-utf8-bytes@1.0.2",
+      "bom-ref": "cogseed@1.0.2|truncate-utf8-bytes@1.0.2",
       "author": "Carl Xiong",
       "description": "Truncate string to given length in bytes",
       "licenses": [
@@ -31738,7 +31738,7 @@
       "type": "library",
       "name": "buffer-from",
       "version": "1.1.2",
-      "bom-ref": "cogseed@0.9.0|buffer-from@1.1.2",
+      "bom-ref": "cogseed@1.0.2|buffer-from@1.1.2",
       "licenses": [
         {
           "license": {
@@ -31791,7 +31791,7 @@
       "type": "library",
       "name": "source-map",
       "version": "0.6.1",
-      "bom-ref": "cogseed@0.9.0|source-map@0.6.1",
+      "bom-ref": "cogseed@1.0.2|source-map@0.6.1",
       "author": "Nick Fitzgerald",
       "description": "Generates and consumes source maps",
       "licenses": [
@@ -31850,7 +31850,7 @@
       "type": "library",
       "name": "color-convert",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|color-convert@2.0.1",
+      "bom-ref": "cogseed@1.0.2|color-convert@2.0.1",
       "author": "Heather Arthur",
       "description": "Plain color conversion functions",
       "licenses": [
@@ -31909,7 +31909,7 @@
       "type": "library",
       "name": "strip-ansi",
       "version": "6.0.1",
-      "bom-ref": "cogseed@0.9.0|strip-ansi@6.0.1",
+      "bom-ref": "cogseed@1.0.2|strip-ansi@6.0.1",
       "author": "Sindre Sorhus",
       "description": "Strip ANSI escape codes from a string",
       "licenses": [
@@ -31964,7 +31964,7 @@
       "type": "library",
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "bom-ref": "cogseed@0.9.0|wrap-ansi@7.0.0",
+      "bom-ref": "cogseed@1.0.2|wrap-ansi@7.0.0",
       "author": "Sindre Sorhus",
       "description": "Wordwrap a string with ANSI escape codes",
       "licenses": [
@@ -32023,7 +32023,7 @@
       "type": "library",
       "name": "emoji-regex",
       "version": "8.0.0",
-      "bom-ref": "cogseed@0.9.0|emoji-regex@8.0.0",
+      "bom-ref": "cogseed@1.0.2|emoji-regex@8.0.0",
       "author": "Mathias Bynens",
       "description": "A regular expression to match all Emoji-only symbols as per the Unicode Standard.",
       "licenses": [
@@ -32074,7 +32074,7 @@
       "type": "library",
       "name": "is-fullwidth-code-point",
       "version": "3.0.0",
-      "bom-ref": "cogseed@0.9.0|is-fullwidth-code-point@3.0.0",
+      "bom-ref": "cogseed@1.0.2|is-fullwidth-code-point@3.0.0",
       "author": "Sindre Sorhus",
       "description": "Check if the character represented by a given Unicode code point is fullwidth",
       "licenses": [
@@ -32129,7 +32129,7 @@
       "type": "library",
       "name": "punycode",
       "version": "2.3.1",
-      "bom-ref": "cogseed@0.9.0|punycode@2.3.1",
+      "bom-ref": "cogseed@1.0.2|punycode@2.3.1",
       "author": "Mathias Bynens",
       "description": "A robust Punycode converter that fully complies to RFC 3492 and RFC 5891, and works on nearly all JavaScript platforms.",
       "licenses": [
@@ -32188,7 +32188,7 @@
       "type": "library",
       "name": "flatted",
       "version": "3.4.4",
-      "bom-ref": "cogseed@0.9.0|flatted@3.4.4",
+      "bom-ref": "cogseed@1.0.2|flatted@3.4.4",
       "author": "Andrea Giammarchi",
       "description": "A super light and fast circular JSON parser.",
       "licenses": [
@@ -32243,7 +32243,7 @@
       "type": "library",
       "name": "keyv",
       "version": "4.5.4",
-      "bom-ref": "cogseed@0.9.0|keyv@4.5.4",
+      "bom-ref": "cogseed@1.0.2|keyv@4.5.4",
       "author": "Jared Wray",
       "description": "Simple key-value storage with support for multiple backends",
       "licenses": [
@@ -32298,7 +32298,7 @@
       "type": "library",
       "name": "p-locate",
       "version": "5.0.0",
-      "bom-ref": "cogseed@0.9.0|p-locate@5.0.0",
+      "bom-ref": "cogseed@1.0.2|p-locate@5.0.0",
       "author": "Sindre Sorhus",
       "description": "Get the first fulfilled promise that satisfies the provided testing function",
       "licenses": [
@@ -32357,7 +32357,7 @@
       "type": "library",
       "name": "balanced-match",
       "version": "4.0.4",
-      "bom-ref": "cogseed@0.9.0|balanced-match@4.0.4",
+      "bom-ref": "cogseed@1.0.2|balanced-match@4.0.4",
       "description": "Match balanced character pairs, like \"{\" and \"}\"",
       "licenses": [
         {
@@ -32415,7 +32415,7 @@
       "type": "library",
       "name": "boolean",
       "version": "3.2.0",
-      "bom-ref": "cogseed@0.9.0|boolean@3.2.0",
+      "bom-ref": "cogseed@1.0.2|boolean@3.2.0",
       "description": "boolean converts lots of things to boolean.",
       "licenses": [
         {
@@ -32454,7 +32454,7 @@
       "type": "library",
       "name": "es6-error",
       "version": "4.1.1",
-      "bom-ref": "cogseed@0.9.0|es6-error@4.1.1",
+      "bom-ref": "cogseed@1.0.2|es6-error@4.1.1",
       "author": "Ben Youngblood",
       "description": "Easily-extendable error for use with ES6 classes",
       "licenses": [
@@ -32494,7 +32494,7 @@
       "type": "library",
       "name": "matcher",
       "version": "3.0.0",
-      "bom-ref": "cogseed@0.9.0|matcher@3.0.0",
+      "bom-ref": "cogseed@1.0.2|matcher@3.0.0",
       "author": "Sindre Sorhus",
       "description": "Simple wildcard matching",
       "licenses": [
@@ -32538,7 +32538,7 @@
       "type": "library",
       "name": "roarr",
       "version": "2.15.4",
-      "bom-ref": "cogseed@0.9.0|roarr@2.15.4",
+      "bom-ref": "cogseed@1.0.2|roarr@2.15.4",
       "author": "Gajus Kuizinas",
       "description": "JSON logger for Node.js and browser.",
       "licenses": [
@@ -32582,7 +32582,7 @@
       "type": "library",
       "name": "serialize-error",
       "version": "7.0.1",
-      "bom-ref": "cogseed@0.9.0|serialize-error@7.0.1",
+      "bom-ref": "cogseed@1.0.2|serialize-error@7.0.1",
       "author": "Sindre Sorhus",
       "description": "Serialize/deserialize an error into a plain object",
       "licenses": [
@@ -32627,7 +32627,7 @@
       "name": "inflate",
       "group": "@tokenizer",
       "version": "0.4.1",
-      "bom-ref": "cogseed@0.9.0|@tokenizer/inflate@0.4.1",
+      "bom-ref": "cogseed@1.0.2|@tokenizer/inflate@0.4.1",
       "author": "Borewit",
       "description": "Tokenized zip support",
       "licenses": [
@@ -32682,7 +32682,7 @@
       "type": "library",
       "name": "strtok3",
       "version": "10.3.5",
-      "bom-ref": "cogseed@0.9.0|strtok3@10.3.5",
+      "bom-ref": "cogseed@1.0.2|strtok3@10.3.5",
       "author": "Borewit",
       "description": "A promise based streaming tokenizer",
       "licenses": [
@@ -32737,7 +32737,7 @@
       "type": "library",
       "name": "token-types",
       "version": "6.1.2",
-      "bom-ref": "cogseed@0.9.0|token-types@6.1.2",
+      "bom-ref": "cogseed@1.0.2|token-types@6.1.2",
       "author": "Borewit",
       "description": "Common token types for decoding and encoding numeric and string values",
       "licenses": [
@@ -32792,7 +32792,7 @@
       "type": "library",
       "name": "uint8array-extras",
       "version": "1.5.0",
-      "bom-ref": "cogseed@0.9.0|uint8array-extras@1.5.0",
+      "bom-ref": "cogseed@1.0.2|uint8array-extras@1.5.0",
       "author": "Sindre Sorhus",
       "description": "Useful utilities for working with Uint8Array (and Buffer)",
       "licenses": [
@@ -32847,7 +32847,7 @@
       "type": "library",
       "name": "xml-parse-from-string",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|xml-parse-from-string@1.0.1",
+      "bom-ref": "cogseed@1.0.2|xml-parse-from-string@1.0.1",
       "author": "Matt DesLauriers",
       "description": "DOMParser.parseFromString for XML with IE8 fallback",
       "licenses": [
@@ -32898,7 +32898,7 @@
       "type": "library",
       "name": "xml2js",
       "version": "0.5.0",
-      "bom-ref": "cogseed@0.9.0|xml2js@0.5.0",
+      "bom-ref": "cogseed@1.0.2|xml2js@0.5.0",
       "author": "Marek Kubica",
       "description": "Simple XML to JavaScript object converter.",
       "licenses": [
@@ -32953,7 +32953,7 @@
           "type": "library",
           "name": "xmlbuilder",
           "version": "11.0.1",
-          "bom-ref": "cogseed@0.9.0|xml2js@0.5.0|xmlbuilder@11.0.1",
+          "bom-ref": "cogseed@1.0.2|xml2js@0.5.0|xmlbuilder@11.0.1",
           "author": "Ozgur Ozcitak",
           "description": "An XML builder for node.js",
           "licenses": [
@@ -33010,7 +33010,7 @@
       "type": "library",
       "name": "immediate",
       "version": "3.0.6",
-      "bom-ref": "cogseed@0.9.0|immediate@3.0.6",
+      "bom-ref": "cogseed@1.0.2|immediate@3.0.6",
       "description": "A cross browser microtask library",
       "licenses": [
         {
@@ -33060,7 +33060,7 @@
       "type": "library",
       "name": "core-util-is",
       "version": "1.0.3",
-      "bom-ref": "cogseed@0.9.0|core-util-is@1.0.3",
+      "bom-ref": "cogseed@1.0.2|core-util-is@1.0.3",
       "author": "Isaac Z. Schlueter",
       "description": "The `util.is*` functions introduced in Node v0.12.",
       "licenses": [
@@ -33111,7 +33111,7 @@
       "type": "library",
       "name": "isarray",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|isarray@1.0.0",
+      "bom-ref": "cogseed@1.0.2|isarray@1.0.0",
       "author": "Julian Gruber",
       "description": "Array#isArray for older browsers",
       "licenses": [
@@ -33162,7 +33162,7 @@
       "type": "library",
       "name": "process-nextick-args",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|process-nextick-args@2.0.1",
+      "bom-ref": "cogseed@1.0.2|process-nextick-args@2.0.1",
       "description": "process.nextTick but always with args",
       "licenses": [
         {
@@ -33212,7 +33212,7 @@
       "type": "library",
       "name": "util-deprecate",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|util-deprecate@1.0.2",
+      "bom-ref": "cogseed@1.0.2|util-deprecate@1.0.2",
       "author": "Nathan Rajlich",
       "description": "The Node.js `util.deprecate()` function with browser support",
       "licenses": [
@@ -33253,7 +33253,7 @@
       "name": "deep-eql",
       "group": "@types",
       "version": "4.0.2",
-      "bom-ref": "cogseed@0.9.0|@types/deep-eql@4.0.2",
+      "bom-ref": "cogseed@1.0.2|@types/deep-eql@4.0.2",
       "description": "TypeScript definitions for deep-eql",
       "licenses": [
         {
@@ -33307,7 +33307,7 @@
       "type": "library",
       "name": "assertion-error",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|assertion-error@2.0.1",
+      "bom-ref": "cogseed@1.0.2|assertion-error@2.0.1",
       "author": "Jake Luer",
       "description": "Error constructor for test and validation frameworks that implements standardized AssertionError specification.",
       "licenses": [
@@ -33366,7 +33366,7 @@
       "type": "library",
       "name": "lightningcss-darwin-arm64",
       "version": "1.33.0",
-      "bom-ref": "cogseed@0.9.0|lightningcss-darwin-arm64@1.33.0",
+      "bom-ref": "cogseed@1.0.2|lightningcss-darwin-arm64@1.33.0",
       "description": "A CSS parser, transformer, and minifier written in Rust",
       "licenses": [
         {
@@ -33424,7 +33424,7 @@
       "type": "library",
       "name": "nanoid",
       "version": "3.3.18",
-      "bom-ref": "cogseed@0.9.0|nanoid@3.3.18",
+      "bom-ref": "cogseed@1.0.2|nanoid@3.3.18",
       "author": "Andrey Sitnik",
       "description": "A tiny (116 bytes), secure URL-friendly unique string ID generator",
       "licenses": [
@@ -33483,7 +33483,7 @@
       "type": "library",
       "name": "picocolors",
       "version": "1.1.1",
-      "bom-ref": "cogseed@0.9.0|picocolors@1.1.1",
+      "bom-ref": "cogseed@1.0.2|picocolors@1.1.1",
       "author": "Alexey Raspopov",
       "description": "The tiniest and the fastest library for terminal output formatting with ANSI colors",
       "licenses": [
@@ -33539,7 +33539,7 @@
       "name": "types",
       "group": "@oxc-project",
       "version": "0.146.0",
-      "bom-ref": "cogseed@0.9.0|@oxc-project/types@0.146.0",
+      "bom-ref": "cogseed@1.0.2|@oxc-project/types@0.146.0",
       "author": "Boshen and oxc contributors",
       "description": "Types for Oxc AST nodes",
       "licenses": [
@@ -33595,7 +33595,7 @@
       "name": "binding-darwin-arm64",
       "group": "@rolldown",
       "version": "1.2.5",
-      "bom-ref": "cogseed@0.9.0|@rolldown/binding-darwin-arm64@1.2.5",
+      "bom-ref": "cogseed@1.0.2|@rolldown/binding-darwin-arm64@1.2.5",
       "description": "Fast JavaScript/TypeScript bundler in Rust with Rollup-compatible API.",
       "licenses": [
         {
@@ -33654,7 +33654,7 @@
       "name": "pluginutils",
       "group": "@rolldown",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|@rolldown/pluginutils@1.0.1",
+      "bom-ref": "cogseed@1.0.2|@rolldown/pluginutils@1.0.1",
       "description": "Plugin utilities for Rolldown",
       "licenses": [
         {
@@ -33709,7 +33709,7 @@
       "name": "util-buffer-from",
       "group": "@smithy",
       "version": "2.2.0",
-      "bom-ref": "cogseed@0.9.0|@smithy/util-buffer-from@2.2.0",
+      "bom-ref": "cogseed@1.0.2|@smithy/util-buffer-from@2.2.0",
       "author": "AWS SDK for JavaScript Team",
       "licenses": [
         {
@@ -33763,7 +33763,7 @@
       "type": "library",
       "name": "fast-xml-parser",
       "version": "5.7.3",
-      "bom-ref": "cogseed@0.9.0|fast-xml-parser@5.7.3",
+      "bom-ref": "cogseed@1.0.2|fast-xml-parser@5.7.3",
       "author": "Amit Gupta",
       "description": "Validate XML, Parse XML, Build XML without C/C++ based libraries",
       "licenses": [
@@ -33815,7 +33815,7 @@
       "name": "credential-provider-login",
       "group": "@aws-sdk",
       "version": "3.972.45",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/credential-provider-login@3.972.45",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/credential-provider-login@3.972.45",
       "author": "AWS SDK for JavaScript Team",
       "description": "AWS credential provider that sources credentials from aws login cached tokens",
       "licenses": [
@@ -33871,7 +33871,7 @@
       "name": "signature-v4-multi-region",
       "group": "@aws-sdk",
       "version": "3.996.30",
-      "bom-ref": "cogseed@0.9.0|@aws-sdk/signature-v4-multi-region@3.996.30",
+      "bom-ref": "cogseed@1.0.2|@aws-sdk/signature-v4-multi-region@3.996.30",
       "author": "AWS SDK for JavaScript Team",
       "licenses": [
         {
@@ -33925,7 +33925,7 @@
       "type": "library",
       "name": "extend",
       "version": "3.0.2",
-      "bom-ref": "cogseed@0.9.0|extend@3.0.2",
+      "bom-ref": "cogseed@1.0.2|extend@3.0.2",
       "author": "Stefan Thomas",
       "description": "Port of jQuery.extend for node.js and the browser",
       "licenses": [
@@ -33965,7 +33965,7 @@
       "type": "library",
       "name": "node-fetch",
       "version": "3.3.2",
-      "bom-ref": "cogseed@0.9.0|node-fetch@3.3.2",
+      "bom-ref": "cogseed@1.0.2|node-fetch@3.3.2",
       "author": "David Frank",
       "description": "A light-weight module that brings Fetch API to node.js",
       "licenses": [
@@ -34020,7 +34020,7 @@
       "type": "library",
       "name": "json-bigint",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|json-bigint@1.0.0",
+      "bom-ref": "cogseed@1.0.2|json-bigint@1.0.0",
       "author": "Andrey Sidorov",
       "description": "JSON.parse with bigints support",
       "licenses": [
@@ -34071,7 +34071,7 @@
       "type": "library",
       "name": "jwa",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|jwa@2.0.1",
+      "bom-ref": "cogseed@1.0.2|jwa@2.0.1",
       "author": "Brian J. Brennan",
       "description": "JWA implementation (supports all JWS algorithms)",
       "licenses": [
@@ -34122,7 +34122,7 @@
       "type": "library",
       "name": "delayed-stream",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|delayed-stream@1.0.0",
+      "bom-ref": "cogseed@1.0.2|delayed-stream@1.0.0",
       "author": "Felix Geisendörfer",
       "description": "Buffers events from a stream until you are ready to handle them.",
       "licenses": [
@@ -34177,7 +34177,7 @@
       "type": "library",
       "name": "get-intrinsic",
       "version": "1.3.0",
-      "bom-ref": "cogseed@0.9.0|get-intrinsic@1.3.0",
+      "bom-ref": "cogseed@1.0.2|get-intrinsic@1.3.0",
       "author": "Jordan Harband",
       "description": "Get and robustly cache all JS language-level intrinsics at first require time",
       "licenses": [
@@ -34232,7 +34232,7 @@
       "type": "library",
       "name": "has-tostringtag",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|has-tostringtag@1.0.2",
+      "bom-ref": "cogseed@1.0.2|has-tostringtag@1.0.2",
       "author": "Jordan Harband",
       "description": "Determine if the JS environment has `Symbol.toStringTag` support. Supports spec, or shams.",
       "licenses": [
@@ -34287,7 +34287,7 @@
       "type": "library",
       "name": "function-bind",
       "version": "1.1.2",
-      "bom-ref": "cogseed@0.9.0|function-bind@1.1.2",
+      "bom-ref": "cogseed@1.0.2|function-bind@1.1.2",
       "author": "Raynos",
       "description": "Implementation of Function.prototype.bind",
       "licenses": [
@@ -34338,7 +34338,7 @@
       "type": "library",
       "name": "mime-db",
       "version": "1.52.0",
-      "bom-ref": "cogseed@0.9.0|mime-db@1.52.0",
+      "bom-ref": "cogseed@1.0.2|mime-db@1.52.0",
       "description": "Media Type Database",
       "licenses": [
         {
@@ -34392,7 +34392,7 @@
       "type": "library",
       "name": "call-bound",
       "version": "1.0.4",
-      "bom-ref": "cogseed@0.9.0|call-bound@1.0.4",
+      "bom-ref": "cogseed@1.0.2|call-bound@1.0.4",
       "author": "Jordan Harband",
       "description": "Robust call-bound JavaScript intrinsics, using `call-bind` and `get-intrinsic`.",
       "licenses": [
@@ -34447,7 +34447,7 @@
       "type": "library",
       "name": "bl",
       "version": "4.1.0",
-      "bom-ref": "cogseed@0.9.0|bl@4.1.0",
+      "bom-ref": "cogseed@1.0.2|bl@4.1.0",
       "description": "Buffer List: collect buffers and access with a standard readable Buffer interface, streamable too!",
       "licenses": [
         {
@@ -34486,7 +34486,7 @@
       "type": "library",
       "name": "fs-constants",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|fs-constants@1.0.0",
+      "bom-ref": "cogseed@1.0.2|fs-constants@1.0.0",
       "author": "Mathias Buus",
       "description": "Require constants across node and the browser",
       "licenses": [
@@ -34526,7 +34526,7 @@
       "type": "library",
       "name": "readable-stream",
       "version": "3.6.2",
-      "bom-ref": "cogseed@0.9.0|readable-stream@3.6.2",
+      "bom-ref": "cogseed@1.0.2|readable-stream@3.6.2",
       "description": "Streams3, a user-land copy of the stream library from Node.js",
       "licenses": [
         {
@@ -34569,7 +34569,7 @@
       "type": "library",
       "name": "fs.realpath",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|fs.realpath@1.0.0",
+      "bom-ref": "cogseed@1.0.2|fs.realpath@1.0.0",
       "author": "Isaac Z. Schlueter",
       "description": "Use node's fs.realpath, but fall back to the JS implementation if the native one fails",
       "licenses": [
@@ -34624,7 +34624,7 @@
       "type": "library",
       "name": "inflight",
       "version": "1.0.6",
-      "bom-ref": "cogseed@0.9.0|inflight@1.0.6",
+      "bom-ref": "cogseed@1.0.2|inflight@1.0.6",
       "author": "Isaac Z. Schlueter",
       "description": "Add callbacks to requests in flight to avoid async duplication",
       "licenses": [
@@ -34679,7 +34679,7 @@
       "type": "library",
       "name": "at-least-node",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|at-least-node@1.0.0",
+      "bom-ref": "cogseed@1.0.2|at-least-node@1.0.0",
       "author": "Ryan Zimmerman",
       "description": "Lightweight Node.js version sniffing/comparison",
       "licenses": [
@@ -34739,7 +34739,7 @@
       "name": "is",
       "group": "@sindresorhus",
       "version": "4.6.0",
-      "bom-ref": "cogseed@0.9.0|@sindresorhus/is@4.6.0",
+      "bom-ref": "cogseed@1.0.2|@sindresorhus/is@4.6.0",
       "author": "Sindre Sorhus",
       "description": "Type check values",
       "licenses": [
@@ -34799,7 +34799,7 @@
       "name": "http-timer",
       "group": "@szmarczak",
       "version": "4.0.6",
-      "bom-ref": "cogseed@0.9.0|@szmarczak/http-timer@4.0.6",
+      "bom-ref": "cogseed@1.0.2|@szmarczak/http-timer@4.0.6",
       "author": "Szymon Marczak",
       "description": "Timings for HTTP requests",
       "licenses": [
@@ -34859,7 +34859,7 @@
       "name": "cacheable-request",
       "group": "@types",
       "version": "6.0.3",
-      "bom-ref": "cogseed@0.9.0|@types/cacheable-request@6.0.3",
+      "bom-ref": "cogseed@1.0.2|@types/cacheable-request@6.0.3",
       "description": "TypeScript definitions for cacheable-request",
       "licenses": [
         {
@@ -34914,7 +34914,7 @@
       "name": "responselike",
       "group": "@types",
       "version": "1.0.3",
-      "bom-ref": "cogseed@0.9.0|@types/responselike@1.0.3",
+      "bom-ref": "cogseed@1.0.2|@types/responselike@1.0.3",
       "description": "TypeScript definitions for responselike",
       "licenses": [
         {
@@ -34968,7 +34968,7 @@
       "type": "library",
       "name": "cacheable-lookup",
       "version": "5.0.4",
-      "bom-ref": "cogseed@0.9.0|cacheable-lookup@5.0.4",
+      "bom-ref": "cogseed@1.0.2|cacheable-lookup@5.0.4",
       "author": "Szymon Marczak",
       "description": "A cacheable dns.lookup(…) that respects the TTL",
       "licenses": [
@@ -35027,7 +35027,7 @@
       "type": "library",
       "name": "cacheable-request",
       "version": "7.0.4",
-      "bom-ref": "cogseed@0.9.0|cacheable-request@7.0.4",
+      "bom-ref": "cogseed@1.0.2|cacheable-request@7.0.4",
       "author": "Luke Childs",
       "description": "Wrap native HTTP requests with RFC compliant cache support",
       "licenses": [
@@ -35086,7 +35086,7 @@
       "type": "library",
       "name": "http2-wrapper",
       "version": "1.0.3",
-      "bom-ref": "cogseed@0.9.0|http2-wrapper@1.0.3",
+      "bom-ref": "cogseed@1.0.2|http2-wrapper@1.0.3",
       "author": "Szymon Marczak",
       "description": "HTTP2 client, just with the familiar `https` API",
       "licenses": [
@@ -35145,7 +35145,7 @@
       "type": "library",
       "name": "lowercase-keys",
       "version": "2.0.0",
-      "bom-ref": "cogseed@0.9.0|lowercase-keys@2.0.0",
+      "bom-ref": "cogseed@1.0.2|lowercase-keys@2.0.0",
       "author": "Sindre Sorhus",
       "description": "Lowercase the keys of an object",
       "licenses": [
@@ -35204,7 +35204,7 @@
       "type": "library",
       "name": "p-cancelable",
       "version": "2.1.1",
-      "bom-ref": "cogseed@0.9.0|p-cancelable@2.1.1",
+      "bom-ref": "cogseed@1.0.2|p-cancelable@2.1.1",
       "author": "Sindre Sorhus",
       "description": "Create a promise that can be canceled",
       "licenses": [
@@ -35263,7 +35263,7 @@
       "type": "library",
       "name": "responselike",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|responselike@2.0.1",
+      "bom-ref": "cogseed@1.0.2|responselike@2.0.1",
       "author": "lukechilds",
       "description": "A response-like object for mocking a Node.js HTTP response stream",
       "licenses": [
@@ -35318,7 +35318,7 @@
       "type": "library",
       "name": "err-code",
       "version": "2.0.3",
-      "bom-ref": "cogseed@0.9.0|err-code@2.0.3",
+      "bom-ref": "cogseed@1.0.2|err-code@2.0.3",
       "author": "IndigoUnited",
       "description": "Create an error with a code",
       "licenses": [
@@ -35373,7 +35373,7 @@
       "type": "library",
       "name": "p-limit",
       "version": "3.1.0",
-      "bom-ref": "cogseed@0.9.0|p-limit@3.1.0",
+      "bom-ref": "cogseed@1.0.2|p-limit@3.1.0",
       "author": "Sindre Sorhus",
       "description": "Run multiple promise-returning & async functions with limited concurrency",
       "licenses": [
@@ -35432,7 +35432,7 @@
       "type": "library",
       "name": "tmp",
       "version": "0.2.7",
-      "bom-ref": "cogseed@0.9.0|tmp@0.2.7",
+      "bom-ref": "cogseed@1.0.2|tmp@0.2.7",
       "author": "KARASZI István",
       "description": "Temporary file and directory creator",
       "licenses": [
@@ -35491,7 +35491,7 @@
       "type": "library",
       "name": "async",
       "version": "3.2.6",
-      "bom-ref": "cogseed@0.9.0|async@3.2.6",
+      "bom-ref": "cogseed@1.0.2|async@3.2.6",
       "author": "Caolan McMahon",
       "description": "Higher-order functions and common patterns for asynchronous code",
       "licenses": [
@@ -35546,7 +35546,7 @@
       "type": "library",
       "name": "filelist",
       "version": "1.0.6",
-      "bom-ref": "cogseed@0.9.0|filelist@1.0.6",
+      "bom-ref": "cogseed@1.0.2|filelist@1.0.6",
       "author": "Matthew Eernisse",
       "description": "Lazy-evaluating list of files, based on globs or regex patterns",
       "licenses": [
@@ -35601,7 +35601,7 @@
           "type": "library",
           "name": "minimatch",
           "version": "5.1.9",
-          "bom-ref": "cogseed@0.9.0|filelist@1.0.6|minimatch@5.1.9",
+          "bom-ref": "cogseed@1.0.2|filelist@1.0.6|minimatch@5.1.9",
           "author": "Isaac Z. Schlueter",
           "description": "a glob matcher in javascript",
           "licenses": [
@@ -35660,7 +35660,7 @@
           "type": "library",
           "name": "brace-expansion",
           "version": "2.1.4",
-          "bom-ref": "cogseed@0.9.0|filelist@1.0.6|brace-expansion@2.1.4",
+          "bom-ref": "cogseed@1.0.2|filelist@1.0.6|brace-expansion@2.1.4",
           "author": "Julian Gruber",
           "description": "Brace expansion as known from sh/bash",
           "licenses": [
@@ -35715,7 +35715,7 @@
           "type": "library",
           "name": "balanced-match",
           "version": "1.0.2",
-          "bom-ref": "cogseed@0.9.0|filelist@1.0.6|balanced-match@1.0.2",
+          "bom-ref": "cogseed@1.0.2|filelist@1.0.6|balanced-match@1.0.2",
           "author": "Julian Gruber",
           "description": "Match balanced character pairs, like \"{\" and \"}\"",
           "licenses": [
@@ -35773,7 +35773,7 @@
       "name": "windows-sign",
       "group": "@electron",
       "version": "1.2.2",
-      "bom-ref": "cogseed@0.9.0|@electron/windows-sign@1.2.2",
+      "bom-ref": "cogseed@1.0.2|@electron/windows-sign@1.2.2",
       "author": "Felix Rieseberg",
       "description": "Codesign Electron Windows apps",
       "licenses": [
@@ -35832,7 +35832,7 @@
           "type": "library",
           "name": "fs-extra",
           "version": "11.4.0",
-          "bom-ref": "cogseed@0.9.0|@electron/windows-sign@1.2.2|fs-extra@11.4.0",
+          "bom-ref": "cogseed@1.0.2|@electron/windows-sign@1.2.2|fs-extra@11.4.0",
           "author": "JP Richardson",
           "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.",
           "licenses": [
@@ -35893,7 +35893,7 @@
       "type": "library",
       "name": "temp",
       "version": "0.9.4",
-      "bom-ref": "cogseed@0.9.0|temp@0.9.4",
+      "bom-ref": "cogseed@1.0.2|temp@0.9.4",
       "author": "Bruce Williams",
       "description": "Temporary files and directories",
       "licenses": [
@@ -35952,7 +35952,7 @@
       "type": "library",
       "name": "utf8-byte-length",
       "version": "1.0.5",
-      "bom-ref": "cogseed@0.9.0|utf8-byte-length@1.0.5",
+      "bom-ref": "cogseed@1.0.2|utf8-byte-length@1.0.5",
       "author": "Carl Xiong",
       "description": "Get utf8 byte length of string",
       "licenses": [
@@ -36005,7 +36005,7 @@
       "type": "library",
       "name": "color-name",
       "version": "1.1.4",
-      "bom-ref": "cogseed@0.9.0|color-name@1.1.4",
+      "bom-ref": "cogseed@1.0.2|color-name@1.1.4",
       "author": "DY",
       "description": "A list of color names and its values",
       "licenses": [
@@ -36060,7 +36060,7 @@
       "type": "library",
       "name": "ansi-regex",
       "version": "5.0.1",
-      "bom-ref": "cogseed@0.9.0|ansi-regex@5.0.1",
+      "bom-ref": "cogseed@1.0.2|ansi-regex@5.0.1",
       "author": "Sindre Sorhus",
       "description": "Regular expression for matching ANSI escape codes",
       "licenses": [
@@ -36115,7 +36115,7 @@
       "type": "library",
       "name": "json-buffer",
       "version": "3.0.1",
-      "bom-ref": "cogseed@0.9.0|json-buffer@3.0.1",
+      "bom-ref": "cogseed@1.0.2|json-buffer@3.0.1",
       "author": "Dominic Tarr",
       "description": "JSON parse & stringify that supports binary via bops & base64",
       "licenses": [
@@ -36170,7 +36170,7 @@
       "type": "library",
       "name": "detect-node",
       "version": "2.1.0",
-      "bom-ref": "cogseed@0.9.0|detect-node@2.1.0",
+      "bom-ref": "cogseed@1.0.2|detect-node@2.1.0",
       "author": "Ilya Kantor",
       "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
       "licenses": [
@@ -36210,7 +36210,7 @@
       "type": "library",
       "name": "globalthis",
       "version": "1.0.4",
-      "bom-ref": "cogseed@0.9.0|globalthis@1.0.4",
+      "bom-ref": "cogseed@1.0.2|globalthis@1.0.4",
       "author": "Jordan Harband",
       "description": "ECMAScript spec-compliant polyfill/shim for `globalThis`",
       "licenses": [
@@ -36254,7 +36254,7 @@
       "type": "library",
       "name": "json-stringify-safe",
       "version": "5.0.1",
-      "bom-ref": "cogseed@0.9.0|json-stringify-safe@5.0.1",
+      "bom-ref": "cogseed@1.0.2|json-stringify-safe@5.0.1",
       "author": "Isaac Z. Schlueter",
       "description": "Like JSON.stringify, but doesn't blow up on circular refs.",
       "licenses": [
@@ -36294,7 +36294,7 @@
       "type": "library",
       "name": "semver-compare",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|semver-compare@1.0.0",
+      "bom-ref": "cogseed@1.0.2|semver-compare@1.0.0",
       "author": "James Halliday",
       "description": "compare two semver version strings, returning -1, 0, or 1",
       "licenses": [
@@ -36334,7 +36334,7 @@
       "type": "library",
       "name": "sprintf-js",
       "version": "1.1.3",
-      "bom-ref": "cogseed@0.9.0|sprintf-js@1.1.3",
+      "bom-ref": "cogseed@1.0.2|sprintf-js@1.1.3",
       "author": "Alexandru Mărășteanu",
       "description": "JavaScript sprintf implementation",
       "licenses": [
@@ -36374,7 +36374,7 @@
       "type": "library",
       "name": "type-fest",
       "version": "0.13.1",
-      "bom-ref": "cogseed@0.9.0|type-fest@0.13.1",
+      "bom-ref": "cogseed@1.0.2|type-fest@0.13.1",
       "author": "Sindre Sorhus",
       "description": "A collection of essential TypeScript types",
       "licenses": [
@@ -36417,7 +36417,7 @@
       "name": "token",
       "group": "@tokenizer",
       "version": "0.3.0",
-      "bom-ref": "cogseed@0.9.0|@tokenizer/token@0.3.0",
+      "bom-ref": "cogseed@1.0.2|@tokenizer/token@0.3.0",
       "author": "Borewit",
       "description": "TypeScript definition for strtok3 token",
       "licenses": [
@@ -36469,7 +36469,7 @@
       "name": "text-codec",
       "group": "@borewit",
       "version": "0.2.2",
-      "bom-ref": "cogseed@0.9.0|@borewit/text-codec@0.2.2",
+      "bom-ref": "cogseed@1.0.2|@borewit/text-codec@0.2.2",
       "author": "Borewit",
       "description": "Text Decoder",
       "licenses": [
@@ -36520,7 +36520,7 @@
       "type": "library",
       "name": "ieee754",
       "version": "1.2.1",
-      "bom-ref": "cogseed@0.9.0|ieee754@1.2.1",
+      "bom-ref": "cogseed@1.0.2|ieee754@1.2.1",
       "author": "Feross Aboukhadijeh",
       "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
       "licenses": [
@@ -36561,7 +36561,7 @@
       "name": "is-array-buffer",
       "group": "@smithy",
       "version": "2.2.0",
-      "bom-ref": "cogseed@0.9.0|@smithy/is-array-buffer@2.2.0",
+      "bom-ref": "cogseed@1.0.2|@smithy/is-array-buffer@2.2.0",
       "author": "AWS SDK for JavaScript Team",
       "description": "Provides a function for detecting if an argument is an ArrayBuffer",
       "licenses": [
@@ -36617,7 +36617,7 @@
       "name": "entities",
       "group": "@nodable",
       "version": "2.1.1",
-      "bom-ref": "cogseed@0.9.0|@nodable/entities@2.1.1",
+      "bom-ref": "cogseed@1.0.2|@nodable/entities@2.1.1",
       "author": "Amit Gupta",
       "description": "Entity parser for XML, HTML, External entites with security and NCR control",
       "licenses": [
@@ -36668,7 +36668,7 @@
       "type": "library",
       "name": "fast-xml-builder",
       "version": "1.2.0",
-      "bom-ref": "cogseed@0.9.0|fast-xml-builder@1.2.0",
+      "bom-ref": "cogseed@1.0.2|fast-xml-builder@1.2.0",
       "author": "Amit Gupta",
       "description": "Build XML from JSON without C/C++ based libraries",
       "licenses": [
@@ -36719,7 +36719,7 @@
       "type": "library",
       "name": "path-expression-matcher",
       "version": "1.5.0",
-      "bom-ref": "cogseed@0.9.0|path-expression-matcher@1.5.0",
+      "bom-ref": "cogseed@1.0.2|path-expression-matcher@1.5.0",
       "author": "Amit Gupta",
       "description": "Efficient path tracking and pattern matching for XML/JSON parsers",
       "licenses": [
@@ -36774,7 +36774,7 @@
       "type": "library",
       "name": "strnum",
       "version": "2.3.0",
-      "bom-ref": "cogseed@0.9.0|strnum@2.3.0",
+      "bom-ref": "cogseed@1.0.2|strnum@2.3.0",
       "author": "Amit Gupta",
       "description": "Parse String to Number based on configuration",
       "licenses": [
@@ -36825,7 +36825,7 @@
       "type": "library",
       "name": "data-uri-to-buffer",
       "version": "4.0.1",
-      "bom-ref": "cogseed@0.9.0|data-uri-to-buffer@4.0.1",
+      "bom-ref": "cogseed@1.0.2|data-uri-to-buffer@4.0.1",
       "author": "Nathan Rajlich",
       "description": "Generate a Buffer instance from a Data URI string",
       "licenses": [
@@ -36880,7 +36880,7 @@
       "type": "library",
       "name": "fetch-blob",
       "version": "3.2.0",
-      "bom-ref": "cogseed@0.9.0|fetch-blob@3.2.0",
+      "bom-ref": "cogseed@1.0.2|fetch-blob@3.2.0",
       "author": "Jimmy Wärting",
       "description": "Blob & File implementation in Node.js, originally from node-fetch.",
       "licenses": [
@@ -36935,7 +36935,7 @@
       "type": "library",
       "name": "formdata-polyfill",
       "version": "4.0.10",
-      "bom-ref": "cogseed@0.9.0|formdata-polyfill@4.0.10",
+      "bom-ref": "cogseed@1.0.2|formdata-polyfill@4.0.10",
       "author": "Jimmy Wärting",
       "description": "HTML5 `FormData` for Browsers and Node.",
       "licenses": [
@@ -36990,7 +36990,7 @@
       "type": "library",
       "name": "bignumber.js",
       "version": "9.3.1",
-      "bom-ref": "cogseed@0.9.0|bignumber.js@9.3.1",
+      "bom-ref": "cogseed@1.0.2|bignumber.js@9.3.1",
       "author": "Michael Mclaughlin",
       "description": "A library for arbitrary-precision decimal and non-decimal arithmetic",
       "licenses": [
@@ -37045,7 +37045,7 @@
       "type": "library",
       "name": "buffer-equal-constant-time",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|buffer-equal-constant-time@1.0.1",
+      "bom-ref": "cogseed@1.0.2|buffer-equal-constant-time@1.0.1",
       "author": "GoInstant Inc., a salesforce.com company",
       "description": "Constant-time comparison of Buffers",
       "licenses": [
@@ -37096,7 +37096,7 @@
       "type": "library",
       "name": "call-bind-apply-helpers",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|call-bind-apply-helpers@1.0.2",
+      "bom-ref": "cogseed@1.0.2|call-bind-apply-helpers@1.0.2",
       "author": "Jordan Harband",
       "description": "Helper functions around Function call/apply/bind, for use in `call-bind`",
       "licenses": [
@@ -37151,7 +37151,7 @@
       "type": "library",
       "name": "es-object-atoms",
       "version": "1.1.1",
-      "bom-ref": "cogseed@0.9.0|es-object-atoms@1.1.1",
+      "bom-ref": "cogseed@1.0.2|es-object-atoms@1.1.1",
       "author": "Jordan Harband",
       "description": "ES Object-related atoms: Object, ToObject, RequireObjectCoercible",
       "licenses": [
@@ -37206,7 +37206,7 @@
       "type": "library",
       "name": "get-proto",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|get-proto@1.0.1",
+      "bom-ref": "cogseed@1.0.2|get-proto@1.0.1",
       "author": "Jordan Harband",
       "description": "Robustly get the [[Prototype]] of an object",
       "licenses": [
@@ -37261,7 +37261,7 @@
       "type": "library",
       "name": "gopd",
       "version": "1.2.0",
-      "bom-ref": "cogseed@0.9.0|gopd@1.2.0",
+      "bom-ref": "cogseed@1.0.2|gopd@1.2.0",
       "author": "Jordan Harband",
       "description": "`Object.getOwnPropertyDescriptor`, but accounts for IE's broken implementation.",
       "licenses": [
@@ -37305,7 +37305,7 @@
       "type": "library",
       "name": "has-symbols",
       "version": "1.1.0",
-      "bom-ref": "cogseed@0.9.0|has-symbols@1.1.0",
+      "bom-ref": "cogseed@1.0.2|has-symbols@1.1.0",
       "author": "Jordan Harband",
       "description": "Determine if the JS environment has Symbol support. Supports spec, or shams.",
       "licenses": [
@@ -37360,7 +37360,7 @@
       "type": "library",
       "name": "math-intrinsics",
       "version": "1.1.0",
-      "bom-ref": "cogseed@0.9.0|math-intrinsics@1.1.0",
+      "bom-ref": "cogseed@1.0.2|math-intrinsics@1.1.0",
       "author": "Jordan Harband",
       "description": "ES Math-related intrinsics and helpers, robustly cached.",
       "licenses": [
@@ -37415,7 +37415,7 @@
       "type": "library",
       "name": "buffer",
       "version": "5.7.1",
-      "bom-ref": "cogseed@0.9.0|buffer@5.7.1",
+      "bom-ref": "cogseed@1.0.2|buffer@5.7.1",
       "author": "Feross Aboukhadijeh",
       "description": "Node.js Buffer API, for the browser",
       "licenses": [
@@ -37455,7 +37455,7 @@
       "type": "library",
       "name": "string_decoder",
       "version": "1.3.0",
-      "bom-ref": "cogseed@0.9.0|string_decoder@1.3.0",
+      "bom-ref": "cogseed@1.0.2|string_decoder@1.3.0",
       "description": "The string_decoder module from Node core",
       "licenses": [
         {
@@ -37494,7 +37494,7 @@
       "type": "library",
       "name": "concat-map",
       "version": "0.0.1",
-      "bom-ref": "cogseed@0.9.0|concat-map@0.0.1",
+      "bom-ref": "cogseed@1.0.2|concat-map@0.0.1",
       "author": "James Halliday",
       "description": "concatenative mapdashery",
       "licenses": [
@@ -37549,7 +37549,7 @@
       "type": "library",
       "name": "defer-to-connect",
       "version": "2.0.1",
-      "bom-ref": "cogseed@0.9.0|defer-to-connect@2.0.1",
+      "bom-ref": "cogseed@1.0.2|defer-to-connect@2.0.1",
       "author": "Szymon Marczak",
       "description": "The safe way to handle the `connect` socket event",
       "licenses": [
@@ -37609,7 +37609,7 @@
       "name": "http-cache-semantics",
       "group": "@types",
       "version": "4.2.0",
-      "bom-ref": "cogseed@0.9.0|@types/http-cache-semantics@4.2.0",
+      "bom-ref": "cogseed@1.0.2|@types/http-cache-semantics@4.2.0",
       "description": "TypeScript definitions for http-cache-semantics",
       "licenses": [
         {
@@ -37664,7 +37664,7 @@
       "name": "keyv",
       "group": "@types",
       "version": "3.1.4",
-      "bom-ref": "cogseed@0.9.0|@types/keyv@3.1.4",
+      "bom-ref": "cogseed@1.0.2|@types/keyv@3.1.4",
       "description": "TypeScript definitions for keyv",
       "licenses": [
         {
@@ -37718,7 +37718,7 @@
       "type": "library",
       "name": "clone-response",
       "version": "1.0.3",
-      "bom-ref": "cogseed@0.9.0|clone-response@1.0.3",
+      "bom-ref": "cogseed@1.0.2|clone-response@1.0.3",
       "author": "Luke Childs",
       "description": "Clone a Node.js HTTP response stream",
       "licenses": [
@@ -37773,7 +37773,7 @@
       "type": "library",
       "name": "get-stream",
       "version": "5.2.0",
-      "bom-ref": "cogseed@0.9.0|get-stream@5.2.0",
+      "bom-ref": "cogseed@1.0.2|get-stream@5.2.0",
       "author": "Sindre Sorhus",
       "description": "Get a stream as a string, buffer, or array",
       "licenses": [
@@ -37832,7 +37832,7 @@
       "type": "library",
       "name": "http-cache-semantics",
       "version": "4.2.0",
-      "bom-ref": "cogseed@0.9.0|http-cache-semantics@4.2.0",
+      "bom-ref": "cogseed@1.0.2|http-cache-semantics@4.2.0",
       "author": "Kornel Lesiński",
       "description": "Parses Cache-Control and other headers. Helps building correct HTTP caches and proxies",
       "licenses": [
@@ -37887,7 +37887,7 @@
       "type": "library",
       "name": "normalize-url",
       "version": "6.1.0",
-      "bom-ref": "cogseed@0.9.0|normalize-url@6.1.0",
+      "bom-ref": "cogseed@1.0.2|normalize-url@6.1.0",
       "author": "Sindre Sorhus",
       "description": "Normalize a URL",
       "licenses": [
@@ -37946,7 +37946,7 @@
       "type": "library",
       "name": "quick-lru",
       "version": "5.1.1",
-      "bom-ref": "cogseed@0.9.0|quick-lru@5.1.1",
+      "bom-ref": "cogseed@1.0.2|quick-lru@5.1.1",
       "author": "Sindre Sorhus",
       "description": "Simple “Least Recently Used” (LRU) cache",
       "licenses": [
@@ -38005,7 +38005,7 @@
       "type": "library",
       "name": "resolve-alpn",
       "version": "1.2.1",
-      "bom-ref": "cogseed@0.9.0|resolve-alpn@1.2.1",
+      "bom-ref": "cogseed@1.0.2|resolve-alpn@1.2.1",
       "author": "Szymon Marczak",
       "description": "Detects the ALPN protocol",
       "licenses": [
@@ -38060,7 +38060,7 @@
       "type": "library",
       "name": "yocto-queue",
       "version": "0.1.0",
-      "bom-ref": "cogseed@0.9.0|yocto-queue@0.1.0",
+      "bom-ref": "cogseed@1.0.2|yocto-queue@0.1.0",
       "author": "Sindre Sorhus",
       "description": "Tiny queue data structure",
       "licenses": [
@@ -38119,7 +38119,7 @@
       "type": "library",
       "name": "cross-dirname",
       "version": "0.1.0",
-      "bom-ref": "cogseed@0.9.0|cross-dirname@0.1.0",
+      "bom-ref": "cogseed@1.0.2|cross-dirname@0.1.0",
       "licenses": [
         {
           "license": {
@@ -38172,7 +38172,7 @@
       "type": "library",
       "name": "postject",
       "version": "1.0.0-alpha.6",
-      "bom-ref": "cogseed@0.9.0|postject@1.0.0-alpha.6",
+      "bom-ref": "cogseed@1.0.2|postject@1.0.0-alpha.6",
       "description": "Easily inject arbitrary read-only resources into executable formats (Mach-O, PE, ELF) and use it at runtime.",
       "licenses": [
         {
@@ -38230,7 +38230,7 @@
           "type": "library",
           "name": "commander",
           "version": "9.5.0",
-          "bom-ref": "cogseed@0.9.0|postject@1.0.0-alpha.6|commander@9.5.0",
+          "bom-ref": "cogseed@1.0.2|postject@1.0.0-alpha.6|commander@9.5.0",
           "author": "TJ Holowaychuk",
           "description": "the complete solution for node.js command-line programs",
           "licenses": [
@@ -38291,7 +38291,7 @@
       "type": "library",
       "name": "mkdirp",
       "version": "0.5.6",
-      "bom-ref": "cogseed@0.9.0|mkdirp@0.5.6",
+      "bom-ref": "cogseed@1.0.2|mkdirp@0.5.6",
       "author": "James Halliday",
       "description": "Recursively mkdir, like `mkdir -p`",
       "licenses": [
@@ -38346,7 +38346,7 @@
       "type": "library",
       "name": "rimraf",
       "version": "2.6.3",
-      "bom-ref": "cogseed@0.9.0|rimraf@2.6.3",
+      "bom-ref": "cogseed@1.0.2|rimraf@2.6.3",
       "author": "Isaac Z. Schlueter",
       "description": "A deep deletion module for node (like `rm -rf`)",
       "licenses": [
@@ -38401,7 +38401,7 @@
       "type": "library",
       "name": "define-properties",
       "version": "1.2.1",
-      "bom-ref": "cogseed@0.9.0|define-properties@1.2.1",
+      "bom-ref": "cogseed@1.0.2|define-properties@1.2.1",
       "author": "Jordan Harband",
       "description": "Define multiple non-enumerable properties at once. Uses `Object.defineProperty` when available; falls back to standard assignment in older engines.",
       "licenses": [
@@ -38445,7 +38445,7 @@
       "type": "library",
       "name": "xml-naming",
       "version": "0.1.0",
-      "bom-ref": "cogseed@0.9.0|xml-naming@0.1.0",
+      "bom-ref": "cogseed@1.0.2|xml-naming@0.1.0",
       "author": "Amit Gupta",
       "description": "Validates XML name productions — Name, NCName, QName, NMToken, NMTokens — for XML 1.0 and 1.1",
       "licenses": [
@@ -38500,7 +38500,7 @@
       "type": "library",
       "name": "node-domexception",
       "version": "1.0.0",
-      "bom-ref": "cogseed@0.9.0|node-domexception@1.0.0",
+      "bom-ref": "cogseed@1.0.2|node-domexception@1.0.0",
       "author": "Jimmy Wärting",
       "description": "An implementation of the DOMException class from NodeJS",
       "licenses": [
@@ -38555,7 +38555,7 @@
       "type": "library",
       "name": "web-streams-polyfill",
       "version": "3.3.3",
-      "bom-ref": "cogseed@0.9.0|web-streams-polyfill@3.3.3",
+      "bom-ref": "cogseed@1.0.2|web-streams-polyfill@3.3.3",
       "author": "Mattias Buelens",
       "description": "Web Streams, based on the WHATWG spec reference implementation",
       "licenses": [
@@ -38610,7 +38610,7 @@
       "type": "library",
       "name": "dunder-proto",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|dunder-proto@1.0.1",
+      "bom-ref": "cogseed@1.0.2|dunder-proto@1.0.1",
       "author": "Jordan Harband",
       "description": "If available, the `Object.prototype.__proto__` accessor and mutator, call-bound",
       "licenses": [
@@ -38665,7 +38665,7 @@
       "type": "library",
       "name": "mimic-response",
       "version": "1.0.1",
-      "bom-ref": "cogseed@0.9.0|mimic-response@1.0.1",
+      "bom-ref": "cogseed@1.0.2|mimic-response@1.0.1",
       "author": "Sindre Sorhus",
       "description": "Mimic a Node.js HTTP response stream",
       "licenses": [
@@ -38724,7 +38724,7 @@
       "type": "library",
       "name": "define-data-property",
       "version": "1.1.4",
-      "bom-ref": "cogseed@0.9.0|define-data-property@1.1.4",
+      "bom-ref": "cogseed@1.0.2|define-data-property@1.1.4",
       "author": "Jordan Harband",
       "description": "Define a data property on an object. Will fall back to assignment in an engine without descriptors.",
       "licenses": [
@@ -38768,7 +38768,7 @@
       "type": "library",
       "name": "has-property-descriptors",
       "version": "1.0.2",
-      "bom-ref": "cogseed@0.9.0|has-property-descriptors@1.0.2",
+      "bom-ref": "cogseed@1.0.2|has-property-descriptors@1.0.2",
       "author": "Jordan Harband",
       "description": "Does the environment have full property descriptor support? Handles IE 8's broken defineProperty/gOPD.",
       "licenses": [
@@ -38808,7 +38808,7 @@
       "type": "library",
       "name": "object-keys",
       "version": "1.1.1",
-      "bom-ref": "cogseed@0.9.0|object-keys@1.1.1",
+      "bom-ref": "cogseed@1.0.2|object-keys@1.1.1",
       "author": "Jordan Harband",
       "description": "An Object.keys replacement, in case Object.keys is not available. From https://github.com/es-shims/es5-shim",
       "licenses": [
@@ -38851,4256 +38851,4256 @@
   ],
   "dependencies": [
     {
-      "ref": "cogseed@0.9.0",
+      "ref": "cogseed@1.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|@earendil-works/pi-ai@0.79.10",
-        "cogseed@0.9.0|@electron/rebuild@4.2.0",
-        "cogseed@0.9.0|@eslint/js@10.0.1",
-        "cogseed@0.9.0|@jsquash/webp@1.5.0",
-        "cogseed@0.9.0|@larksuiteoapi/node-sdk@1.73.0",
-        "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0",
-        "cogseed@0.9.0|@types/adm-zip@0.5.8",
-        "cogseed@0.9.0|@types/node@25.6.0",
-        "cogseed@0.9.0|@vitest/coverage-v8@4.1.11",
-        "cogseed@0.9.0|@wecom/aibot-node-sdk@1.0.7",
-        "cogseed@0.9.0|7zip-bin@5.2.0",
-        "cogseed@0.9.0|adm-zip@0.6.0",
-        "cogseed@0.9.0|async-mutex@0.5.0",
-        "cogseed@0.9.0|better-sqlite3@12.10.0",
-        "cogseed@0.9.0|electron-builder@26.15.7",
-        "cogseed@0.9.0|electron-log@5.4.4",
-        "cogseed@0.9.0|electron@41.10.6",
-        "cogseed@0.9.0|esbuild@0.28.2",
-        "cogseed@0.9.0|eslint@10.9.0",
-        "cogseed@0.9.0|fastembed@2.1.0",
-        "cogseed@0.9.0|get-tsconfig@4.14.0",
-        "cogseed@0.9.0|jimp@1.6.1",
-        "cogseed@0.9.0|mammoth@1.12.1",
-        "cogseed@0.9.0|node-pty@1.1.0",
-        "cogseed@0.9.0|pdfjs-dist@6.2.108",
-        "cogseed@0.9.0|resolve-pkg-maps@1.0.0",
-        "cogseed@0.9.0|sherpa-onnx-node@1.13.6",
-        "cogseed@0.9.0|socks-proxy-agent@8.0.5",
-        "cogseed@0.9.0|sqlite-vec@0.1.9",
-        "cogseed@0.9.0|tar@7.5.22",
-        "cogseed@0.9.0|tsx@4.23.13",
-        "cogseed@0.9.0|typescript-eslint@8.67.0",
-        "cogseed@0.9.0|typescript@6.0.3",
-        "cogseed@0.9.0|undici@7.29.0",
-        "cogseed@0.9.0|vitest@4.1.11",
-        "cogseed@0.9.0|ws@8.21.3",
-        "cogseed@0.9.0|yaml@2.9.0",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@earendil-works/pi-ai@0.79.10",
+        "cogseed@1.0.2|@electron/rebuild@4.2.0",
+        "cogseed@1.0.2|@eslint/js@10.0.1",
+        "cogseed@1.0.2|@jsquash/webp@1.5.0",
+        "cogseed@1.0.2|@larksuiteoapi/node-sdk@1.73.0",
+        "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0",
+        "cogseed@1.0.2|@types/adm-zip@0.5.8",
+        "cogseed@1.0.2|@types/node@25.6.0",
+        "cogseed@1.0.2|@vitest/coverage-v8@4.1.11",
+        "cogseed@1.0.2|@wecom/aibot-node-sdk@1.0.7",
+        "cogseed@1.0.2|7zip-bin@5.2.0",
+        "cogseed@1.0.2|adm-zip@0.6.0",
+        "cogseed@1.0.2|async-mutex@0.5.0",
+        "cogseed@1.0.2|better-sqlite3@12.10.0",
+        "cogseed@1.0.2|electron-builder@26.15.7",
+        "cogseed@1.0.2|electron-log@5.4.4",
+        "cogseed@1.0.2|electron@41.10.6",
+        "cogseed@1.0.2|esbuild@0.28.2",
+        "cogseed@1.0.2|eslint@10.9.0",
+        "cogseed@1.0.2|fastembed@2.1.0",
+        "cogseed@1.0.2|get-tsconfig@4.14.0",
+        "cogseed@1.0.2|jimp@1.6.1",
+        "cogseed@1.0.2|mammoth@1.12.1",
+        "cogseed@1.0.2|node-pty@1.1.0",
+        "cogseed@1.0.2|pdfjs-dist@6.2.108",
+        "cogseed@1.0.2|resolve-pkg-maps@1.0.0",
+        "cogseed@1.0.2|sherpa-onnx-node@1.13.6",
+        "cogseed@1.0.2|socks-proxy-agent@8.0.5",
+        "cogseed@1.0.2|sqlite-vec@0.1.9",
+        "cogseed@1.0.2|tar@7.5.22",
+        "cogseed@1.0.2|tsx@4.23.13",
+        "cogseed@1.0.2|typescript-eslint@8.67.0",
+        "cogseed@1.0.2|typescript@6.0.3",
+        "cogseed@1.0.2|undici@7.29.0",
+        "cogseed@1.0.2|vitest@4.1.11",
+        "cogseed@1.0.2|ws@8.21.3",
+        "cogseed@1.0.2|yaml@2.9.0",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@earendil-works/pi-ai@0.79.10",
+      "ref": "cogseed@1.0.2|@earendil-works/pi-ai@0.79.10",
       "dependsOn": [
-        "cogseed@0.9.0|@anthropic-ai/sdk@0.91.1",
-        "cogseed@0.9.0|@aws-sdk/client-bedrock-runtime@3.1048.0",
-        "cogseed@0.9.0|@google/genai@1.52.0",
-        "cogseed@0.9.0|@mistralai/mistralai@2.2.6",
-        "cogseed@0.9.0|@opentelemetry/api@1.9.0",
-        "cogseed@0.9.0|@smithy/node-http-handler@4.7.3",
-        "cogseed@0.9.0|http-proxy-agent@7.0.2",
-        "cogseed@0.9.0|https-proxy-agent@7.0.6",
-        "cogseed@0.9.0|openai@6.26.0",
-        "cogseed@0.9.0|partial-json@0.1.7",
-        "cogseed@0.9.0|typebox@1.1.38"
+        "cogseed@1.0.2|@anthropic-ai/sdk@0.91.1",
+        "cogseed@1.0.2|@aws-sdk/client-bedrock-runtime@3.1048.0",
+        "cogseed@1.0.2|@google/genai@1.52.0",
+        "cogseed@1.0.2|@mistralai/mistralai@2.2.6",
+        "cogseed@1.0.2|@opentelemetry/api@1.9.0",
+        "cogseed@1.0.2|@smithy/node-http-handler@4.7.3",
+        "cogseed@1.0.2|http-proxy-agent@7.0.2",
+        "cogseed@1.0.2|https-proxy-agent@7.0.6",
+        "cogseed@1.0.2|openai@6.26.0",
+        "cogseed@1.0.2|partial-json@0.1.7",
+        "cogseed@1.0.2|typebox@1.1.38"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/rebuild@4.2.0",
+      "ref": "cogseed@1.0.2|@electron/rebuild@4.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|@malept/cross-spawn-promise@2.0.0",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|@electron/rebuild@4.2.0|node-abi@4.33.0",
-        "cogseed@0.9.0|node-api-version@0.2.1",
-        "cogseed@0.9.0|node-gyp@12.4.0",
-        "cogseed@0.9.0|read-binary-file-arch@1.0.6"
+        "cogseed@1.0.2|@malept/cross-spawn-promise@2.0.0",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|@electron/rebuild@4.2.0|node-abi@4.33.0",
+        "cogseed@1.0.2|node-api-version@0.2.1",
+        "cogseed@1.0.2|node-gyp@12.4.0",
+        "cogseed@1.0.2|read-binary-file-arch@1.0.6"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/rebuild@4.2.0|node-abi@4.33.0",
+      "ref": "cogseed@1.0.2|@electron/rebuild@4.2.0|node-abi@4.33.0",
       "dependsOn": [
-        "cogseed@0.9.0|semver@7.8.5"
+        "cogseed@1.0.2|semver@7.8.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@eslint/js@10.0.1",
+      "ref": "cogseed@1.0.2|@eslint/js@10.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|eslint@10.9.0"
+        "cogseed@1.0.2|eslint@10.9.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jsquash/webp@1.5.0",
+      "ref": "cogseed@1.0.2|@jsquash/webp@1.5.0",
       "dependsOn": [
-        "cogseed@0.9.0|wasm-feature-detect@1.9.0"
+        "cogseed@1.0.2|wasm-feature-detect@1.9.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@larksuiteoapi/node-sdk@1.73.0",
+      "ref": "cogseed@1.0.2|@larksuiteoapi/node-sdk@1.73.0",
       "dependsOn": [
-        "cogseed@0.9.0|axios@1.19.0",
-        "cogseed@0.9.0|lodash.identity@3.0.0",
-        "cogseed@0.9.0|lodash.merge@4.6.2",
-        "cogseed@0.9.0|lodash.pickby@4.6.0",
-        "cogseed@0.9.0|protobufjs@7.6.5",
-        "cogseed@0.9.0|qs@6.16.0",
-        "cogseed@0.9.0|ws@8.21.3"
+        "cogseed@1.0.2|axios@1.19.0",
+        "cogseed@1.0.2|lodash.identity@3.0.0",
+        "cogseed@1.0.2|lodash.merge@4.6.2",
+        "cogseed@1.0.2|lodash.pickby@4.6.0",
+        "cogseed@1.0.2|protobufjs@7.6.5",
+        "cogseed@1.0.2|qs@6.16.0",
+        "cogseed@1.0.2|ws@8.21.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0",
+      "ref": "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0",
       "dependsOn": [
-        "cogseed@0.9.0|@hono/node-server@1.19.17",
-        "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0|ajv-formats@3.0.1",
-        "cogseed@0.9.0|ajv@8.20.0",
-        "cogseed@0.9.0|content-type@1.0.5",
-        "cogseed@0.9.0|cors@2.8.6",
-        "cogseed@0.9.0|cross-spawn@7.0.6",
-        "cogseed@0.9.0|eventsource-parser@3.0.8",
-        "cogseed@0.9.0|eventsource@3.0.7",
-        "cogseed@0.9.0|express-rate-limit@8.5.1",
-        "cogseed@0.9.0|express@5.2.1",
-        "cogseed@0.9.0|hono@4.13.7",
-        "cogseed@0.9.0|jose@6.2.3",
-        "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0|json-schema-typed@8.0.2",
-        "cogseed@0.9.0|pkce-challenge@5.0.1",
-        "cogseed@0.9.0|raw-body@3.0.2",
-        "cogseed@0.9.0|zod-to-json-schema@3.25.2",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@hono/node-server@1.19.17",
+        "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0|ajv-formats@3.0.1",
+        "cogseed@1.0.2|ajv@8.20.0",
+        "cogseed@1.0.2|content-type@1.0.5",
+        "cogseed@1.0.2|cors@2.8.6",
+        "cogseed@1.0.2|cross-spawn@7.0.6",
+        "cogseed@1.0.2|eventsource-parser@3.0.8",
+        "cogseed@1.0.2|eventsource@3.0.7",
+        "cogseed@1.0.2|express-rate-limit@8.5.1",
+        "cogseed@1.0.2|express@5.2.1",
+        "cogseed@1.0.2|hono@4.13.7",
+        "cogseed@1.0.2|jose@6.2.3",
+        "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0|json-schema-typed@8.0.2",
+        "cogseed@1.0.2|pkce-challenge@5.0.1",
+        "cogseed@1.0.2|raw-body@3.0.2",
+        "cogseed@1.0.2|zod-to-json-schema@3.25.2",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0|ajv-formats@3.0.1",
+      "ref": "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0|ajv-formats@3.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|ajv@8.20.0"
+        "cogseed@1.0.2|ajv@8.20.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0|json-schema-typed@8.0.2"
+      "ref": "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0|json-schema-typed@8.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@types/adm-zip@0.5.8",
+      "ref": "cogseed@1.0.2|@types/adm-zip@0.5.8",
       "dependsOn": [
-        "cogseed@0.9.0|@types/node@25.6.0"
+        "cogseed@1.0.2|@types/node@25.6.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@types/node@25.6.0",
+      "ref": "cogseed@1.0.2|@types/node@25.6.0",
       "dependsOn": [
-        "cogseed@0.9.0|@types/node@25.6.0|undici-types@7.19.2"
+        "cogseed@1.0.2|@types/node@25.6.0|undici-types@7.19.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@types/node@25.6.0|undici-types@7.19.2"
+      "ref": "cogseed@1.0.2|@types/node@25.6.0|undici-types@7.19.2"
     },
     {
-      "ref": "cogseed@0.9.0|@vitest/coverage-v8@4.1.11",
+      "ref": "cogseed@1.0.2|@vitest/coverage-v8@4.1.11",
       "dependsOn": [
-        "cogseed@0.9.0|@bcoe/v8-coverage@1.0.2",
-        "cogseed@0.9.0|@vitest/utils@4.1.11",
-        "cogseed@0.9.0|ast-v8-to-istanbul@1.0.5",
-        "cogseed@0.9.0|istanbul-lib-coverage@3.2.2",
-        "cogseed@0.9.0|istanbul-lib-report@3.0.1",
-        "cogseed@0.9.0|istanbul-reports@3.2.0",
-        "cogseed@0.9.0|magicast@0.5.3",
-        "cogseed@0.9.0|obug@2.1.1",
-        "cogseed@0.9.0|std-env@4.2.0",
-        "cogseed@0.9.0|tinyrainbow@3.1.0",
-        "cogseed@0.9.0|vitest@4.1.11"
+        "cogseed@1.0.2|@bcoe/v8-coverage@1.0.2",
+        "cogseed@1.0.2|@vitest/utils@4.1.11",
+        "cogseed@1.0.2|ast-v8-to-istanbul@1.0.5",
+        "cogseed@1.0.2|istanbul-lib-coverage@3.2.2",
+        "cogseed@1.0.2|istanbul-lib-report@3.0.1",
+        "cogseed@1.0.2|istanbul-reports@3.2.0",
+        "cogseed@1.0.2|magicast@0.5.3",
+        "cogseed@1.0.2|obug@2.1.1",
+        "cogseed@1.0.2|std-env@4.2.0",
+        "cogseed@1.0.2|tinyrainbow@3.1.0",
+        "cogseed@1.0.2|vitest@4.1.11"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@wecom/aibot-node-sdk@1.0.7",
+      "ref": "cogseed@1.0.2|@wecom/aibot-node-sdk@1.0.7",
       "dependsOn": [
-        "cogseed@0.9.0|axios@1.19.0",
-        "cogseed@0.9.0|eventemitter3@5.0.4",
-        "cogseed@0.9.0|ws@8.21.3"
+        "cogseed@1.0.2|axios@1.19.0",
+        "cogseed@1.0.2|eventemitter3@5.0.4",
+        "cogseed@1.0.2|ws@8.21.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|7zip-bin@5.2.0"
+      "ref": "cogseed@1.0.2|7zip-bin@5.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|adm-zip@0.6.0"
+      "ref": "cogseed@1.0.2|adm-zip@0.6.0"
     },
     {
-      "ref": "cogseed@0.9.0|async-mutex@0.5.0",
+      "ref": "cogseed@1.0.2|async-mutex@0.5.0",
       "dependsOn": [
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|better-sqlite3@12.10.0",
+      "ref": "cogseed@1.0.2|better-sqlite3@12.10.0",
       "dependsOn": [
-        "cogseed@0.9.0|bindings@1.5.0",
-        "cogseed@0.9.0|prebuild-install@7.1.3"
+        "cogseed@1.0.2|bindings@1.5.0",
+        "cogseed@1.0.2|prebuild-install@7.1.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-builder@26.15.7",
+      "ref": "cogseed@1.0.2|electron-builder@26.15.7",
       "dependsOn": [
-        "cogseed@0.9.0|app-builder-lib@26.15.7",
-        "cogseed@0.9.0|builder-util-runtime@9.7.0",
-        "cogseed@0.9.0|builder-util@26.15.3",
-        "cogseed@0.9.0|chalk@4.1.2",
-        "cogseed@0.9.0|ci-info@4.4.0",
-        "cogseed@0.9.0|dmg-builder@26.15.7",
-        "cogseed@0.9.0|fs-extra@10.1.0",
-        "cogseed@0.9.0|lazy-val@1.0.5",
-        "cogseed@0.9.0|simple-update-notifier@2.0.0",
-        "cogseed@0.9.0|yargs@17.7.3"
+        "cogseed@1.0.2|app-builder-lib@26.15.7",
+        "cogseed@1.0.2|builder-util-runtime@9.7.0",
+        "cogseed@1.0.2|builder-util@26.15.3",
+        "cogseed@1.0.2|chalk@4.1.2",
+        "cogseed@1.0.2|ci-info@4.4.0",
+        "cogseed@1.0.2|dmg-builder@26.15.7",
+        "cogseed@1.0.2|fs-extra@10.1.0",
+        "cogseed@1.0.2|lazy-val@1.0.5",
+        "cogseed@1.0.2|simple-update-notifier@2.0.0",
+        "cogseed@1.0.2|yargs@17.7.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-log@5.4.4"
+      "ref": "cogseed@1.0.2|electron-log@5.4.4"
     },
     {
-      "ref": "cogseed@0.9.0|electron@41.10.6",
+      "ref": "cogseed@1.0.2|electron@41.10.6",
       "dependsOn": [
-        "cogseed@0.9.0|@electron-internal/extract-zip@1.0.5",
-        "cogseed@0.9.0|@electron/get@5.1.0",
-        "cogseed@0.9.0|electron@41.10.6|@types/node@24.12.4"
+        "cogseed@1.0.2|@electron-internal/extract-zip@1.0.5",
+        "cogseed@1.0.2|@electron/get@5.1.0",
+        "cogseed@1.0.2|electron@41.10.6|@types/node@24.12.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron@41.10.6|@types/node@24.12.4",
+      "ref": "cogseed@1.0.2|electron@41.10.6|@types/node@24.12.4",
       "dependsOn": [
-        "cogseed@0.9.0|undici-types@7.16.0"
+        "cogseed@1.0.2|undici-types@7.16.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|esbuild@0.28.2",
+      "ref": "cogseed@1.0.2|esbuild@0.28.2",
       "dependsOn": [
-        "cogseed@0.9.0|@esbuild/darwin-arm64@0.28.2"
+        "cogseed@1.0.2|@esbuild/darwin-arm64@0.28.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|eslint@10.9.0",
+      "ref": "cogseed@1.0.2|eslint@10.9.0",
       "dependsOn": [
-        "cogseed@0.9.0|@eslint-community/eslint-utils@4.10.1",
-        "cogseed@0.9.0|@eslint-community/regexpp@4.12.2",
-        "cogseed@0.9.0|@eslint/config-array@0.23.5",
-        "cogseed@0.9.0|@eslint/config-helpers@0.7.0",
-        "cogseed@0.9.0|@eslint/core@1.2.1",
-        "cogseed@0.9.0|@eslint/plugin-kit@0.7.2",
-        "cogseed@0.9.0|@humanfs/node@0.16.8",
-        "cogseed@0.9.0|@humanwhocodes/module-importer@1.0.1",
-        "cogseed@0.9.0|@humanwhocodes/retry@0.4.3",
-        "cogseed@0.9.0|@types/estree@1.0.9",
-        "cogseed@0.9.0|eslint@10.9.0|ajv@6.15.0",
-        "cogseed@0.9.0|cross-spawn@7.0.6",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|escape-string-regexp@4.0.0",
-        "cogseed@0.9.0|eslint-scope@9.1.2",
-        "cogseed@0.9.0|eslint-visitor-keys@5.0.1",
-        "cogseed@0.9.0|espree@11.2.0",
-        "cogseed@0.9.0|esquery@1.7.0",
-        "cogseed@0.9.0|esutils@2.0.3",
-        "cogseed@0.9.0|fast-deep-equal@3.1.3",
-        "cogseed@0.9.0|file-entry-cache@8.0.0",
-        "cogseed@0.9.0|find-up@5.0.0",
-        "cogseed@0.9.0|glob-parent@6.0.2",
-        "cogseed@0.9.0|ignore@5.3.2",
-        "cogseed@0.9.0|imurmurhash@0.1.4",
-        "cogseed@0.9.0|is-glob@4.0.3",
-        "cogseed@0.9.0|jiti@2.7.0",
-        "cogseed@0.9.0|json-stable-stringify-without-jsonify@1.0.1",
-        "cogseed@0.9.0|minimatch@10.2.6",
-        "cogseed@0.9.0|natural-compare@1.4.0",
-        "cogseed@0.9.0|optionator@0.9.4"
+        "cogseed@1.0.2|@eslint-community/eslint-utils@4.10.1",
+        "cogseed@1.0.2|@eslint-community/regexpp@4.12.2",
+        "cogseed@1.0.2|@eslint/config-array@0.23.5",
+        "cogseed@1.0.2|@eslint/config-helpers@0.7.0",
+        "cogseed@1.0.2|@eslint/core@1.2.1",
+        "cogseed@1.0.2|@eslint/plugin-kit@0.7.2",
+        "cogseed@1.0.2|@humanfs/node@0.16.8",
+        "cogseed@1.0.2|@humanwhocodes/module-importer@1.0.1",
+        "cogseed@1.0.2|@humanwhocodes/retry@0.4.3",
+        "cogseed@1.0.2|@types/estree@1.0.9",
+        "cogseed@1.0.2|eslint@10.9.0|ajv@6.15.0",
+        "cogseed@1.0.2|cross-spawn@7.0.6",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|escape-string-regexp@4.0.0",
+        "cogseed@1.0.2|eslint-scope@9.1.2",
+        "cogseed@1.0.2|eslint-visitor-keys@5.0.1",
+        "cogseed@1.0.2|espree@11.2.0",
+        "cogseed@1.0.2|esquery@1.7.0",
+        "cogseed@1.0.2|esutils@2.0.3",
+        "cogseed@1.0.2|fast-deep-equal@3.1.3",
+        "cogseed@1.0.2|file-entry-cache@8.0.0",
+        "cogseed@1.0.2|find-up@5.0.0",
+        "cogseed@1.0.2|glob-parent@6.0.2",
+        "cogseed@1.0.2|ignore@5.3.2",
+        "cogseed@1.0.2|imurmurhash@0.1.4",
+        "cogseed@1.0.2|is-glob@4.0.3",
+        "cogseed@1.0.2|jiti@2.7.0",
+        "cogseed@1.0.2|json-stable-stringify-without-jsonify@1.0.1",
+        "cogseed@1.0.2|minimatch@10.2.6",
+        "cogseed@1.0.2|natural-compare@1.4.0",
+        "cogseed@1.0.2|optionator@0.9.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|eslint@10.9.0|ajv@6.15.0",
+      "ref": "cogseed@1.0.2|eslint@10.9.0|ajv@6.15.0",
       "dependsOn": [
-        "cogseed@0.9.0|fast-deep-equal@3.1.3",
-        "cogseed@0.9.0|fast-json-stable-stringify@2.1.0",
-        "cogseed@0.9.0|eslint@10.9.0|json-schema-traverse@0.4.1",
-        "cogseed@0.9.0|uri-js@4.4.1"
+        "cogseed@1.0.2|fast-deep-equal@3.1.3",
+        "cogseed@1.0.2|fast-json-stable-stringify@2.1.0",
+        "cogseed@1.0.2|eslint@10.9.0|json-schema-traverse@0.4.1",
+        "cogseed@1.0.2|uri-js@4.4.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|eslint@10.9.0|json-schema-traverse@0.4.1"
+      "ref": "cogseed@1.0.2|eslint@10.9.0|json-schema-traverse@0.4.1"
     },
     {
-      "ref": "cogseed@0.9.0|fastembed@2.1.0",
+      "ref": "cogseed@1.0.2|fastembed@2.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|@anush008/tokenizers@0.0.0",
-        "cogseed@0.9.0|@huggingface/hub@2.11.0",
-        "cogseed@0.9.0|onnxruntime-node@1.21.0",
-        "cogseed@0.9.0|progress@2.0.3",
-        "cogseed@0.9.0|tar@7.5.22"
+        "cogseed@1.0.2|@anush008/tokenizers@0.0.0",
+        "cogseed@1.0.2|@huggingface/hub@2.11.0",
+        "cogseed@1.0.2|onnxruntime-node@1.21.0",
+        "cogseed@1.0.2|progress@2.0.3",
+        "cogseed@1.0.2|tar@7.5.22"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|get-tsconfig@4.14.0",
+      "ref": "cogseed@1.0.2|get-tsconfig@4.14.0",
       "dependsOn": [
-        "cogseed@0.9.0|resolve-pkg-maps@1.0.0"
+        "cogseed@1.0.2|resolve-pkg-maps@1.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|jimp@1.6.1",
+      "ref": "cogseed@1.0.2|jimp@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/diff@1.6.1",
-        "cogseed@0.9.0|@jimp/js-bmp@1.6.1",
-        "cogseed@0.9.0|@jimp/js-gif@1.6.1",
-        "cogseed@0.9.0|@jimp/js-jpeg@1.6.1",
-        "cogseed@0.9.0|@jimp/js-png@1.6.1",
-        "cogseed@0.9.0|@jimp/js-tiff@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-blit@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-blur@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-circle@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-color@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-contain@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-cover@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-crop@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-displace@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-dither@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-fisheye@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-flip@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-hash@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-mask@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-print@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-quantize@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-resize@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-rotate@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-threshold@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/diff@1.6.1",
+        "cogseed@1.0.2|@jimp/js-bmp@1.6.1",
+        "cogseed@1.0.2|@jimp/js-gif@1.6.1",
+        "cogseed@1.0.2|@jimp/js-jpeg@1.6.1",
+        "cogseed@1.0.2|@jimp/js-png@1.6.1",
+        "cogseed@1.0.2|@jimp/js-tiff@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-blit@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-blur@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-circle@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-color@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-contain@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-cover@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-crop@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-displace@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-dither@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-fisheye@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-flip@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-hash@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-mask@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-print@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-quantize@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-resize@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-rotate@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-threshold@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|mammoth@1.12.1",
+      "ref": "cogseed@1.0.2|mammoth@1.12.1",
       "dependsOn": [
-        "cogseed@0.9.0|@xmldom/xmldom@0.8.15",
-        "cogseed@0.9.0|argparse@1.0.10",
-        "cogseed@0.9.0|base64-js@1.5.1",
-        "cogseed@0.9.0|bluebird@3.4.7",
-        "cogseed@0.9.0|dingbat-to-unicode@1.0.1",
-        "cogseed@0.9.0|jszip@3.10.1",
-        "cogseed@0.9.0|lop@0.4.2",
-        "cogseed@0.9.0|path-is-absolute@1.0.1",
-        "cogseed@0.9.0|underscore@1.13.8",
-        "cogseed@0.9.0|xmlbuilder@10.1.1"
+        "cogseed@1.0.2|@xmldom/xmldom@0.8.15",
+        "cogseed@1.0.2|argparse@1.0.10",
+        "cogseed@1.0.2|base64-js@1.5.1",
+        "cogseed@1.0.2|bluebird@3.4.7",
+        "cogseed@1.0.2|dingbat-to-unicode@1.0.1",
+        "cogseed@1.0.2|jszip@3.10.1",
+        "cogseed@1.0.2|lop@0.4.2",
+        "cogseed@1.0.2|path-is-absolute@1.0.1",
+        "cogseed@1.0.2|underscore@1.13.8",
+        "cogseed@1.0.2|xmlbuilder@10.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|node-pty@1.1.0",
+      "ref": "cogseed@1.0.2|node-pty@1.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|node-addon-api@7.1.1"
+        "cogseed@1.0.2|node-addon-api@7.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|pdfjs-dist@6.2.108",
+      "ref": "cogseed@1.0.2|pdfjs-dist@6.2.108",
       "dependsOn": [
-        "cogseed@0.9.0|@napi-rs/canvas@1.0.7"
+        "cogseed@1.0.2|@napi-rs/canvas@1.0.7"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|resolve-pkg-maps@1.0.0"
+      "ref": "cogseed@1.0.2|resolve-pkg-maps@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|sherpa-onnx-node@1.13.6",
+      "ref": "cogseed@1.0.2|sherpa-onnx-node@1.13.6",
       "dependsOn": [
-        "cogseed@0.9.0|sherpa-onnx-darwin-arm64@1.13.6"
+        "cogseed@1.0.2|sherpa-onnx-darwin-arm64@1.13.6"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|socks-proxy-agent@8.0.5",
+      "ref": "cogseed@1.0.2|socks-proxy-agent@8.0.5",
       "dependsOn": [
-        "cogseed@0.9.0|agent-base@7.1.4",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|socks@2.8.9"
+        "cogseed@1.0.2|agent-base@7.1.4",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|socks@2.8.9"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|sqlite-vec@0.1.9",
+      "ref": "cogseed@1.0.2|sqlite-vec@0.1.9",
       "dependsOn": [
-        "cogseed@0.9.0|sqlite-vec-darwin-arm64@0.1.9"
+        "cogseed@1.0.2|sqlite-vec-darwin-arm64@0.1.9"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|tar@7.5.22",
+      "ref": "cogseed@1.0.2|tar@7.5.22",
       "dependsOn": [
-        "cogseed@0.9.0|@isaacs/fs-minipass@4.0.1",
-        "cogseed@0.9.0|tar@7.5.22|chownr@3.0.0",
-        "cogseed@0.9.0|minipass@7.1.3",
-        "cogseed@0.9.0|minizlib@3.1.0",
-        "cogseed@0.9.0|yallist@5.0.0"
+        "cogseed@1.0.2|@isaacs/fs-minipass@4.0.1",
+        "cogseed@1.0.2|tar@7.5.22|chownr@3.0.0",
+        "cogseed@1.0.2|minipass@7.1.3",
+        "cogseed@1.0.2|minizlib@3.1.0",
+        "cogseed@1.0.2|yallist@5.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|tar@7.5.22|chownr@3.0.0"
+      "ref": "cogseed@1.0.2|tar@7.5.22|chownr@3.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|tsx@4.23.13",
+      "ref": "cogseed@1.0.2|tsx@4.23.13",
       "dependsOn": [
-        "cogseed@0.9.0|esbuild@0.28.2",
-        "cogseed@0.9.0|fsevents@2.3.3"
+        "cogseed@1.0.2|esbuild@0.28.2",
+        "cogseed@1.0.2|fsevents@2.3.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|typescript-eslint@8.67.0",
+      "ref": "cogseed@1.0.2|typescript-eslint@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@typescript-eslint/eslint-plugin@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/parser@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/typescript-estree@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/utils@8.67.0",
-        "cogseed@0.9.0|eslint@10.9.0",
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|@typescript-eslint/eslint-plugin@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/parser@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/typescript-estree@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/utils@8.67.0",
+        "cogseed@1.0.2|eslint@10.9.0",
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|typescript@6.0.3"
+      "ref": "cogseed@1.0.2|typescript@6.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|undici@7.29.0"
+      "ref": "cogseed@1.0.2|undici@7.29.0"
     },
     {
-      "ref": "cogseed@0.9.0|vitest@4.1.11",
+      "ref": "cogseed@1.0.2|vitest@4.1.11",
       "dependsOn": [
-        "cogseed@0.9.0|@opentelemetry/api@1.9.0",
-        "cogseed@0.9.0|@types/node@25.6.0",
-        "cogseed@0.9.0|@vitest/coverage-v8@4.1.11",
-        "cogseed@0.9.0|@vitest/expect@4.1.11",
-        "cogseed@0.9.0|@vitest/mocker@4.1.11",
-        "cogseed@0.9.0|@vitest/pretty-format@4.1.11",
-        "cogseed@0.9.0|@vitest/runner@4.1.11",
-        "cogseed@0.9.0|@vitest/snapshot@4.1.11",
-        "cogseed@0.9.0|@vitest/spy@4.1.11",
-        "cogseed@0.9.0|@vitest/utils@4.1.11",
-        "cogseed@0.9.0|vitest@4.1.11|es-module-lexer@2.0.0",
-        "cogseed@0.9.0|expect-type@1.3.0",
-        "cogseed@0.9.0|magic-string@0.30.21",
-        "cogseed@0.9.0|obug@2.1.1",
-        "cogseed@0.9.0|pathe@2.0.3",
-        "cogseed@0.9.0|picomatch@4.0.5",
-        "cogseed@0.9.0|std-env@4.2.0",
-        "cogseed@0.9.0|tinybench@2.9.0",
-        "cogseed@0.9.0|vitest@4.1.11|tinyexec@1.1.1",
-        "cogseed@0.9.0|tinyglobby@0.2.17",
-        "cogseed@0.9.0|tinyrainbow@3.1.0",
-        "cogseed@0.9.0|vite@8.2.2",
-        "cogseed@0.9.0|why-is-node-running@2.3.0"
+        "cogseed@1.0.2|@opentelemetry/api@1.9.0",
+        "cogseed@1.0.2|@types/node@25.6.0",
+        "cogseed@1.0.2|@vitest/coverage-v8@4.1.11",
+        "cogseed@1.0.2|@vitest/expect@4.1.11",
+        "cogseed@1.0.2|@vitest/mocker@4.1.11",
+        "cogseed@1.0.2|@vitest/pretty-format@4.1.11",
+        "cogseed@1.0.2|@vitest/runner@4.1.11",
+        "cogseed@1.0.2|@vitest/snapshot@4.1.11",
+        "cogseed@1.0.2|@vitest/spy@4.1.11",
+        "cogseed@1.0.2|@vitest/utils@4.1.11",
+        "cogseed@1.0.2|vitest@4.1.11|es-module-lexer@2.0.0",
+        "cogseed@1.0.2|expect-type@1.3.0",
+        "cogseed@1.0.2|magic-string@0.30.21",
+        "cogseed@1.0.2|obug@2.1.1",
+        "cogseed@1.0.2|pathe@2.0.3",
+        "cogseed@1.0.2|picomatch@4.0.5",
+        "cogseed@1.0.2|std-env@4.2.0",
+        "cogseed@1.0.2|tinybench@2.9.0",
+        "cogseed@1.0.2|vitest@4.1.11|tinyexec@1.1.1",
+        "cogseed@1.0.2|tinyglobby@0.2.17",
+        "cogseed@1.0.2|tinyrainbow@3.1.0",
+        "cogseed@1.0.2|vite@8.2.2",
+        "cogseed@1.0.2|why-is-node-running@2.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|vitest@4.1.11|es-module-lexer@2.0.0"
+      "ref": "cogseed@1.0.2|vitest@4.1.11|es-module-lexer@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|vitest@4.1.11|tinyexec@1.1.1"
+      "ref": "cogseed@1.0.2|vitest@4.1.11|tinyexec@1.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|ws@8.21.3"
+      "ref": "cogseed@1.0.2|ws@8.21.3"
     },
     {
-      "ref": "cogseed@0.9.0|yaml@2.9.0"
+      "ref": "cogseed@1.0.2|yaml@2.9.0"
     },
     {
-      "ref": "cogseed@0.9.0|zod@3.25.76"
+      "ref": "cogseed@1.0.2|zod@3.25.76"
     },
     {
-      "ref": "cogseed@0.9.0|@anthropic-ai/sdk@0.91.1",
+      "ref": "cogseed@1.0.2|@anthropic-ai/sdk@0.91.1",
       "dependsOn": [
-        "cogseed@0.9.0|json-schema-to-ts@3.1.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|json-schema-to-ts@3.1.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/client-bedrock-runtime@3.1048.0",
+      "ref": "cogseed@1.0.2|@aws-sdk/client-bedrock-runtime@3.1048.0",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-crypto/sha256-browser@5.2.0",
-        "cogseed@0.9.0|@aws-crypto/sha256-js@5.2.0",
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-node@3.972.47",
-        "cogseed@0.9.0|@aws-sdk/eventstream-handler-node@3.972.18",
-        "cogseed@0.9.0|@aws-sdk/middleware-eventstream@3.972.14",
-        "cogseed@0.9.0|@aws-sdk/middleware-websocket@3.972.23",
-        "cogseed@0.9.0|@aws-sdk/token-providers@3.1048.0",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/fetch-http-handler@5.4.5",
-        "cogseed@0.9.0|@smithy/node-http-handler@4.7.3",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-crypto/sha256-browser@5.2.0",
+        "cogseed@1.0.2|@aws-crypto/sha256-js@5.2.0",
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-node@3.972.47",
+        "cogseed@1.0.2|@aws-sdk/eventstream-handler-node@3.972.18",
+        "cogseed@1.0.2|@aws-sdk/middleware-eventstream@3.972.14",
+        "cogseed@1.0.2|@aws-sdk/middleware-websocket@3.972.23",
+        "cogseed@1.0.2|@aws-sdk/token-providers@3.1048.0",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/fetch-http-handler@5.4.5",
+        "cogseed@1.0.2|@smithy/node-http-handler@4.7.3",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@google/genai@1.52.0",
+      "ref": "cogseed@1.0.2|@google/genai@1.52.0",
       "dependsOn": [
-        "cogseed@0.9.0|@modelcontextprotocol/sdk@1.29.0",
-        "cogseed@0.9.0|google-auth-library@10.6.2",
-        "cogseed@0.9.0|p-retry@4.6.2",
-        "cogseed@0.9.0|protobufjs@7.6.5",
-        "cogseed@0.9.0|ws@8.21.3"
+        "cogseed@1.0.2|@modelcontextprotocol/sdk@1.29.0",
+        "cogseed@1.0.2|google-auth-library@10.6.2",
+        "cogseed@1.0.2|p-retry@4.6.2",
+        "cogseed@1.0.2|protobufjs@7.6.5",
+        "cogseed@1.0.2|ws@8.21.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@mistralai/mistralai@2.2.6",
+      "ref": "cogseed@1.0.2|@mistralai/mistralai@2.2.6",
       "dependsOn": [
-        "cogseed@0.9.0|@opentelemetry/api@1.9.0",
-        "cogseed@0.9.0|@opentelemetry/semantic-conventions@1.41.1",
-        "cogseed@0.9.0|ws@8.21.3",
-        "cogseed@0.9.0|zod-to-json-schema@3.25.2",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@opentelemetry/api@1.9.0",
+        "cogseed@1.0.2|@opentelemetry/semantic-conventions@1.41.1",
+        "cogseed@1.0.2|ws@8.21.3",
+        "cogseed@1.0.2|zod-to-json-schema@3.25.2",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@opentelemetry/api@1.9.0"
+      "ref": "cogseed@1.0.2|@opentelemetry/api@1.9.0"
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/node-http-handler@4.7.3",
+      "ref": "cogseed@1.0.2|@smithy/node-http-handler@4.7.3",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|http-proxy-agent@7.0.2",
+      "ref": "cogseed@1.0.2|http-proxy-agent@7.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|agent-base@7.1.4",
-        "cogseed@0.9.0|debug@4.4.3"
+        "cogseed@1.0.2|agent-base@7.1.4",
+        "cogseed@1.0.2|debug@4.4.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|https-proxy-agent@7.0.6",
+      "ref": "cogseed@1.0.2|https-proxy-agent@7.0.6",
       "dependsOn": [
-        "cogseed@0.9.0|agent-base@7.1.4",
-        "cogseed@0.9.0|debug@4.4.3"
+        "cogseed@1.0.2|agent-base@7.1.4",
+        "cogseed@1.0.2|debug@4.4.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|openai@6.26.0",
+      "ref": "cogseed@1.0.2|openai@6.26.0",
       "dependsOn": [
-        "cogseed@0.9.0|ws@8.21.3",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|ws@8.21.3",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|partial-json@0.1.7"
+      "ref": "cogseed@1.0.2|partial-json@0.1.7"
     },
     {
-      "ref": "cogseed@0.9.0|typebox@1.1.38"
+      "ref": "cogseed@1.0.2|typebox@1.1.38"
     },
     {
-      "ref": "cogseed@0.9.0|@malept/cross-spawn-promise@2.0.0",
+      "ref": "cogseed@1.0.2|@malept/cross-spawn-promise@2.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|cross-spawn@7.0.6"
+        "cogseed@1.0.2|cross-spawn@7.0.6"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|debug@4.4.3",
+      "ref": "cogseed@1.0.2|debug@4.4.3",
       "dependsOn": [
-        "cogseed@0.9.0|ms@2.1.3"
+        "cogseed@1.0.2|ms@2.1.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|node-api-version@0.2.1",
+      "ref": "cogseed@1.0.2|node-api-version@0.2.1",
       "dependsOn": [
-        "cogseed@0.9.0|semver@7.8.5"
+        "cogseed@1.0.2|semver@7.8.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|node-gyp@12.4.0",
+      "ref": "cogseed@1.0.2|node-gyp@12.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|env-paths@2.2.1",
-        "cogseed@0.9.0|exponential-backoff@3.1.3",
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|nopt@9.0.0",
-        "cogseed@0.9.0|proc-log@6.1.0",
-        "cogseed@0.9.0|semver@7.8.5",
-        "cogseed@0.9.0|tar@7.5.22",
-        "cogseed@0.9.0|tinyglobby@0.2.17",
-        "cogseed@0.9.0|node-gyp@12.4.0|undici@6.28.0",
-        "cogseed@0.9.0|node-gyp@12.4.0|which@6.0.1"
+        "cogseed@1.0.2|env-paths@2.2.1",
+        "cogseed@1.0.2|exponential-backoff@3.1.3",
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|nopt@9.0.0",
+        "cogseed@1.0.2|proc-log@6.1.0",
+        "cogseed@1.0.2|semver@7.8.5",
+        "cogseed@1.0.2|tar@7.5.22",
+        "cogseed@1.0.2|tinyglobby@0.2.17",
+        "cogseed@1.0.2|node-gyp@12.4.0|undici@6.28.0",
+        "cogseed@1.0.2|node-gyp@12.4.0|which@6.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|node-gyp@12.4.0|undici@6.28.0"
+      "ref": "cogseed@1.0.2|node-gyp@12.4.0|undici@6.28.0"
     },
     {
-      "ref": "cogseed@0.9.0|node-gyp@12.4.0|which@6.0.1",
+      "ref": "cogseed@1.0.2|node-gyp@12.4.0|which@6.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|node-gyp@12.4.0|isexe@4.0.0"
+        "cogseed@1.0.2|node-gyp@12.4.0|isexe@4.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|node-gyp@12.4.0|isexe@4.0.0"
+      "ref": "cogseed@1.0.2|node-gyp@12.4.0|isexe@4.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|read-binary-file-arch@1.0.6",
+      "ref": "cogseed@1.0.2|read-binary-file-arch@1.0.6",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3"
+        "cogseed@1.0.2|debug@4.4.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|wasm-feature-detect@1.9.0"
+      "ref": "cogseed@1.0.2|wasm-feature-detect@1.9.0"
     },
     {
-      "ref": "cogseed@0.9.0|axios@1.19.0",
+      "ref": "cogseed@1.0.2|axios@1.19.0",
       "dependsOn": [
-        "cogseed@0.9.0|follow-redirects@1.16.0",
-        "cogseed@0.9.0|form-data@4.0.6",
-        "cogseed@0.9.0|axios@1.19.0|https-proxy-agent@5.0.1",
-        "cogseed@0.9.0|proxy-from-env@2.1.0"
+        "cogseed@1.0.2|follow-redirects@1.16.0",
+        "cogseed@1.0.2|form-data@4.0.6",
+        "cogseed@1.0.2|axios@1.19.0|https-proxy-agent@5.0.1",
+        "cogseed@1.0.2|proxy-from-env@2.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|axios@1.19.0|https-proxy-agent@5.0.1",
+      "ref": "cogseed@1.0.2|axios@1.19.0|https-proxy-agent@5.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|axios@1.19.0|agent-base@6.0.2",
-        "cogseed@0.9.0|debug@4.4.3"
+        "cogseed@1.0.2|axios@1.19.0|agent-base@6.0.2",
+        "cogseed@1.0.2|debug@4.4.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|axios@1.19.0|agent-base@6.0.2",
+      "ref": "cogseed@1.0.2|axios@1.19.0|agent-base@6.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3"
+        "cogseed@1.0.2|debug@4.4.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|lodash.identity@3.0.0"
+      "ref": "cogseed@1.0.2|lodash.identity@3.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|lodash.merge@4.6.2"
+      "ref": "cogseed@1.0.2|lodash.merge@4.6.2"
     },
     {
-      "ref": "cogseed@0.9.0|lodash.pickby@4.6.0"
+      "ref": "cogseed@1.0.2|lodash.pickby@4.6.0"
     },
     {
-      "ref": "cogseed@0.9.0|protobufjs@7.6.5",
+      "ref": "cogseed@1.0.2|protobufjs@7.6.5",
       "dependsOn": [
-        "cogseed@0.9.0|@protobufjs/aspromise@1.1.2",
-        "cogseed@0.9.0|@protobufjs/base64@1.1.2",
-        "cogseed@0.9.0|@protobufjs/codegen@2.0.5",
-        "cogseed@0.9.0|@protobufjs/eventemitter@1.1.1",
-        "cogseed@0.9.0|@protobufjs/fetch@1.1.1",
-        "cogseed@0.9.0|@protobufjs/float@1.0.2",
-        "cogseed@0.9.0|@protobufjs/path@1.1.2",
-        "cogseed@0.9.0|@protobufjs/pool@1.1.0",
-        "cogseed@0.9.0|@protobufjs/utf8@1.1.1",
-        "cogseed@0.9.0|@types/node@25.6.0",
-        "cogseed@0.9.0|long@5.3.2"
+        "cogseed@1.0.2|@protobufjs/aspromise@1.1.2",
+        "cogseed@1.0.2|@protobufjs/base64@1.1.2",
+        "cogseed@1.0.2|@protobufjs/codegen@2.0.5",
+        "cogseed@1.0.2|@protobufjs/eventemitter@1.1.1",
+        "cogseed@1.0.2|@protobufjs/fetch@1.1.1",
+        "cogseed@1.0.2|@protobufjs/float@1.0.2",
+        "cogseed@1.0.2|@protobufjs/path@1.1.2",
+        "cogseed@1.0.2|@protobufjs/pool@1.1.0",
+        "cogseed@1.0.2|@protobufjs/utf8@1.1.1",
+        "cogseed@1.0.2|@types/node@25.6.0",
+        "cogseed@1.0.2|long@5.3.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|qs@6.16.0",
+      "ref": "cogseed@1.0.2|qs@6.16.0",
       "dependsOn": [
-        "cogseed@0.9.0|es-define-property@1.0.1",
-        "cogseed@0.9.0|side-channel@1.1.1"
+        "cogseed@1.0.2|es-define-property@1.0.1",
+        "cogseed@1.0.2|side-channel@1.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@hono/node-server@1.19.17",
+      "ref": "cogseed@1.0.2|@hono/node-server@1.19.17",
       "dependsOn": [
-        "cogseed@0.9.0|hono@4.13.7"
+        "cogseed@1.0.2|hono@4.13.7"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|ajv@8.20.0",
+      "ref": "cogseed@1.0.2|ajv@8.20.0",
       "dependsOn": [
-        "cogseed@0.9.0|fast-deep-equal@3.1.3",
-        "cogseed@0.9.0|fast-uri@3.1.7",
-        "cogseed@0.9.0|json-schema-traverse@1.0.0",
-        "cogseed@0.9.0|require-from-string@2.0.2"
+        "cogseed@1.0.2|fast-deep-equal@3.1.3",
+        "cogseed@1.0.2|fast-uri@3.1.7",
+        "cogseed@1.0.2|json-schema-traverse@1.0.0",
+        "cogseed@1.0.2|require-from-string@2.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|content-type@1.0.5"
+      "ref": "cogseed@1.0.2|content-type@1.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|cors@2.8.6",
+      "ref": "cogseed@1.0.2|cors@2.8.6",
       "dependsOn": [
-        "cogseed@0.9.0|object-assign@4.1.1",
-        "cogseed@0.9.0|vary@1.1.2"
+        "cogseed@1.0.2|object-assign@4.1.1",
+        "cogseed@1.0.2|vary@1.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|cross-spawn@7.0.6",
+      "ref": "cogseed@1.0.2|cross-spawn@7.0.6",
       "dependsOn": [
-        "cogseed@0.9.0|path-key@3.1.1",
-        "cogseed@0.9.0|shebang-command@2.0.0",
-        "cogseed@0.9.0|which@2.0.2"
+        "cogseed@1.0.2|path-key@3.1.1",
+        "cogseed@1.0.2|shebang-command@2.0.0",
+        "cogseed@1.0.2|which@2.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|eventsource-parser@3.0.8"
+      "ref": "cogseed@1.0.2|eventsource-parser@3.0.8"
     },
     {
-      "ref": "cogseed@0.9.0|eventsource@3.0.7",
+      "ref": "cogseed@1.0.2|eventsource@3.0.7",
       "dependsOn": [
-        "cogseed@0.9.0|eventsource-parser@3.0.8"
+        "cogseed@1.0.2|eventsource-parser@3.0.8"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|express-rate-limit@8.5.1",
+      "ref": "cogseed@1.0.2|express-rate-limit@8.5.1",
       "dependsOn": [
-        "cogseed@0.9.0|express@5.2.1",
-        "cogseed@0.9.0|ip-address@10.5.0"
+        "cogseed@1.0.2|express@5.2.1",
+        "cogseed@1.0.2|ip-address@10.5.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|express@5.2.1",
+      "ref": "cogseed@1.0.2|express@5.2.1",
       "dependsOn": [
-        "cogseed@0.9.0|accepts@2.0.0",
-        "cogseed@0.9.0|body-parser@2.3.0",
-        "cogseed@0.9.0|content-disposition@1.1.0",
-        "cogseed@0.9.0|content-type@1.0.5",
-        "cogseed@0.9.0|cookie-signature@1.2.2",
-        "cogseed@0.9.0|cookie@0.7.2",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|depd@2.0.0",
-        "cogseed@0.9.0|encodeurl@2.0.0",
-        "cogseed@0.9.0|escape-html@1.0.3",
-        "cogseed@0.9.0|etag@1.8.1",
-        "cogseed@0.9.0|finalhandler@2.1.1",
-        "cogseed@0.9.0|fresh@2.0.0",
-        "cogseed@0.9.0|http-errors@2.0.1",
-        "cogseed@0.9.0|merge-descriptors@2.0.0",
-        "cogseed@0.9.0|express@5.2.1|mime-types@3.0.2",
-        "cogseed@0.9.0|on-finished@2.4.1",
-        "cogseed@0.9.0|once@1.4.0",
-        "cogseed@0.9.0|parseurl@1.3.3",
-        "cogseed@0.9.0|proxy-addr@2.0.7",
-        "cogseed@0.9.0|qs@6.16.0",
-        "cogseed@0.9.0|range-parser@1.2.1",
-        "cogseed@0.9.0|router@2.2.0",
-        "cogseed@0.9.0|send@1.2.1",
-        "cogseed@0.9.0|serve-static@2.2.1",
-        "cogseed@0.9.0|statuses@2.0.2",
-        "cogseed@0.9.0|type-is@2.1.0",
-        "cogseed@0.9.0|vary@1.1.2"
+        "cogseed@1.0.2|accepts@2.0.0",
+        "cogseed@1.0.2|body-parser@2.3.0",
+        "cogseed@1.0.2|content-disposition@1.1.0",
+        "cogseed@1.0.2|content-type@1.0.5",
+        "cogseed@1.0.2|cookie-signature@1.2.2",
+        "cogseed@1.0.2|cookie@0.7.2",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|depd@2.0.0",
+        "cogseed@1.0.2|encodeurl@2.0.0",
+        "cogseed@1.0.2|escape-html@1.0.3",
+        "cogseed@1.0.2|etag@1.8.1",
+        "cogseed@1.0.2|finalhandler@2.1.1",
+        "cogseed@1.0.2|fresh@2.0.0",
+        "cogseed@1.0.2|http-errors@2.0.1",
+        "cogseed@1.0.2|merge-descriptors@2.0.0",
+        "cogseed@1.0.2|express@5.2.1|mime-types@3.0.2",
+        "cogseed@1.0.2|on-finished@2.4.1",
+        "cogseed@1.0.2|once@1.4.0",
+        "cogseed@1.0.2|parseurl@1.3.3",
+        "cogseed@1.0.2|proxy-addr@2.0.7",
+        "cogseed@1.0.2|qs@6.16.0",
+        "cogseed@1.0.2|range-parser@1.2.1",
+        "cogseed@1.0.2|router@2.2.0",
+        "cogseed@1.0.2|send@1.2.1",
+        "cogseed@1.0.2|serve-static@2.2.1",
+        "cogseed@1.0.2|statuses@2.0.2",
+        "cogseed@1.0.2|type-is@2.1.0",
+        "cogseed@1.0.2|vary@1.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|express@5.2.1|mime-types@3.0.2",
+      "ref": "cogseed@1.0.2|express@5.2.1|mime-types@3.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|express@5.2.1|mime-db@1.54.0"
+        "cogseed@1.0.2|express@5.2.1|mime-db@1.54.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|express@5.2.1|mime-db@1.54.0"
+      "ref": "cogseed@1.0.2|express@5.2.1|mime-db@1.54.0"
     },
     {
-      "ref": "cogseed@0.9.0|hono@4.13.7"
+      "ref": "cogseed@1.0.2|hono@4.13.7"
     },
     {
-      "ref": "cogseed@0.9.0|jose@6.2.3"
+      "ref": "cogseed@1.0.2|jose@6.2.3"
     },
     {
-      "ref": "cogseed@0.9.0|pkce-challenge@5.0.1"
+      "ref": "cogseed@1.0.2|pkce-challenge@5.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|raw-body@3.0.2",
+      "ref": "cogseed@1.0.2|raw-body@3.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|bytes@3.1.2",
-        "cogseed@0.9.0|http-errors@2.0.1",
-        "cogseed@0.9.0|iconv-lite@0.7.2",
-        "cogseed@0.9.0|unpipe@1.0.0"
+        "cogseed@1.0.2|bytes@3.1.2",
+        "cogseed@1.0.2|http-errors@2.0.1",
+        "cogseed@1.0.2|iconv-lite@0.7.2",
+        "cogseed@1.0.2|unpipe@1.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|zod-to-json-schema@3.25.2",
+      "ref": "cogseed@1.0.2|zod-to-json-schema@3.25.2",
       "dependsOn": [
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@bcoe/v8-coverage@1.0.2"
+      "ref": "cogseed@1.0.2|@bcoe/v8-coverage@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@vitest/utils@4.1.11",
+      "ref": "cogseed@1.0.2|@vitest/utils@4.1.11",
       "dependsOn": [
-        "cogseed@0.9.0|@vitest/pretty-format@4.1.11",
-        "cogseed@0.9.0|convert-source-map@2.0.0",
-        "cogseed@0.9.0|tinyrainbow@3.1.0"
+        "cogseed@1.0.2|@vitest/pretty-format@4.1.11",
+        "cogseed@1.0.2|convert-source-map@2.0.0",
+        "cogseed@1.0.2|tinyrainbow@3.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|ast-v8-to-istanbul@1.0.5",
+      "ref": "cogseed@1.0.2|ast-v8-to-istanbul@1.0.5",
       "dependsOn": [
-        "cogseed@0.9.0|@jridgewell/trace-mapping@0.3.31",
-        "cogseed@0.9.0|estree-walker@3.0.3",
-        "cogseed@0.9.0|js-tokens@10.0.0"
+        "cogseed@1.0.2|@jridgewell/trace-mapping@0.3.31",
+        "cogseed@1.0.2|estree-walker@3.0.3",
+        "cogseed@1.0.2|js-tokens@10.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|istanbul-lib-coverage@3.2.2"
+      "ref": "cogseed@1.0.2|istanbul-lib-coverage@3.2.2"
     },
     {
-      "ref": "cogseed@0.9.0|istanbul-lib-report@3.0.1",
+      "ref": "cogseed@1.0.2|istanbul-lib-report@3.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|istanbul-lib-coverage@3.2.2",
-        "cogseed@0.9.0|make-dir@4.0.0",
-        "cogseed@0.9.0|supports-color@7.2.0"
+        "cogseed@1.0.2|istanbul-lib-coverage@3.2.2",
+        "cogseed@1.0.2|make-dir@4.0.0",
+        "cogseed@1.0.2|supports-color@7.2.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|istanbul-reports@3.2.0",
+      "ref": "cogseed@1.0.2|istanbul-reports@3.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|html-escaper@2.0.2",
-        "cogseed@0.9.0|istanbul-lib-report@3.0.1"
+        "cogseed@1.0.2|html-escaper@2.0.2",
+        "cogseed@1.0.2|istanbul-lib-report@3.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|magicast@0.5.3",
+      "ref": "cogseed@1.0.2|magicast@0.5.3",
       "dependsOn": [
-        "cogseed@0.9.0|@babel/parser@7.29.7",
-        "cogseed@0.9.0|@babel/types@7.29.7",
-        "cogseed@0.9.0|source-map-js@1.2.1"
+        "cogseed@1.0.2|@babel/parser@7.29.7",
+        "cogseed@1.0.2|@babel/types@7.29.7",
+        "cogseed@1.0.2|source-map-js@1.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|obug@2.1.1"
+      "ref": "cogseed@1.0.2|obug@2.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|std-env@4.2.0"
+      "ref": "cogseed@1.0.2|std-env@4.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|tinyrainbow@3.1.0"
+      "ref": "cogseed@1.0.2|tinyrainbow@3.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|eventemitter3@5.0.4"
+      "ref": "cogseed@1.0.2|eventemitter3@5.0.4"
     },
     {
-      "ref": "cogseed@0.9.0|tslib@2.8.1"
+      "ref": "cogseed@1.0.2|tslib@2.8.1"
     },
     {
-      "ref": "cogseed@0.9.0|bindings@1.5.0",
+      "ref": "cogseed@1.0.2|bindings@1.5.0",
       "dependsOn": [
-        "cogseed@0.9.0|file-uri-to-path@1.0.0"
+        "cogseed@1.0.2|file-uri-to-path@1.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|prebuild-install@7.1.3",
+      "ref": "cogseed@1.0.2|prebuild-install@7.1.3",
       "dependsOn": [
-        "cogseed@0.9.0|detect-libc@2.1.2",
-        "cogseed@0.9.0|expand-template@2.0.3",
-        "cogseed@0.9.0|github-from-package@0.0.0",
-        "cogseed@0.9.0|minimist@1.2.8",
-        "cogseed@0.9.0|mkdirp-classic@0.5.3",
-        "cogseed@0.9.0|napi-build-utils@2.0.0",
-        "cogseed@0.9.0|node-abi@3.89.0",
-        "cogseed@0.9.0|pump@3.0.4",
-        "cogseed@0.9.0|rc@1.2.8",
-        "cogseed@0.9.0|simple-get@4.0.1",
-        "cogseed@0.9.0|tar-fs@2.1.4",
-        "cogseed@0.9.0|tunnel-agent@0.6.0"
+        "cogseed@1.0.2|detect-libc@2.1.2",
+        "cogseed@1.0.2|expand-template@2.0.3",
+        "cogseed@1.0.2|github-from-package@0.0.0",
+        "cogseed@1.0.2|minimist@1.2.8",
+        "cogseed@1.0.2|mkdirp-classic@0.5.3",
+        "cogseed@1.0.2|napi-build-utils@2.0.0",
+        "cogseed@1.0.2|node-abi@3.89.0",
+        "cogseed@1.0.2|pump@3.0.4",
+        "cogseed@1.0.2|rc@1.2.8",
+        "cogseed@1.0.2|simple-get@4.0.1",
+        "cogseed@1.0.2|tar-fs@2.1.4",
+        "cogseed@1.0.2|tunnel-agent@0.6.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7",
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7",
       "dependsOn": [
-        "cogseed@0.9.0|@electron/asar@3.4.1",
-        "cogseed@0.9.0|@electron/fuses@1.8.0",
-        "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0",
-        "cogseed@0.9.0|@electron/notarize@2.5.0",
-        "cogseed@0.9.0|@electron/osx-sign@1.3.3",
-        "cogseed@0.9.0|@electron/rebuild@4.2.0",
-        "cogseed@0.9.0|@electron/universal@2.0.3",
-        "cogseed@0.9.0|@malept/flatpak-bundler@0.4.0",
-        "cogseed@0.9.0|@noble/hashes@2.3.0",
-        "cogseed@0.9.0|@peculiar/webcrypto@1.7.1",
-        "cogseed@0.9.0|@types/fs-extra@9.0.13",
-        "cogseed@0.9.0|ajv@8.20.0",
-        "cogseed@0.9.0|asn1js@3.0.10",
-        "cogseed@0.9.0|async-exit-hook@2.0.1",
-        "cogseed@0.9.0|builder-util-runtime@9.7.0",
-        "cogseed@0.9.0|builder-util@26.15.3",
-        "cogseed@0.9.0|chromium-pickle-js@0.2.0",
-        "cogseed@0.9.0|app-builder-lib@26.15.7|ci-info@4.3.1",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|dmg-builder@26.15.7",
-        "cogseed@0.9.0|dotenv-expand@11.0.7",
-        "cogseed@0.9.0|dotenv@16.6.1",
-        "cogseed@0.9.0|ejs@3.1.10",
-        "cogseed@0.9.0|electron-builder-squirrel-windows@26.15.7",
-        "cogseed@0.9.0|electron-publish@26.15.3",
-        "cogseed@0.9.0|fs-extra@10.1.0",
-        "cogseed@0.9.0|hosted-git-info@4.1.0",
-        "cogseed@0.9.0|isbinaryfile@5.0.7",
-        "cogseed@0.9.0|jiti@2.7.0",
-        "cogseed@0.9.0|js-yaml@4.3.2",
-        "cogseed@0.9.0|json5@2.2.3",
-        "cogseed@0.9.0|lazy-val@1.0.5",
-        "cogseed@0.9.0|minimatch@10.2.6",
-        "cogseed@0.9.0|pkijs@3.4.0",
-        "cogseed@0.9.0|plist@3.1.0",
-        "cogseed@0.9.0|proper-lockfile@4.1.2",
-        "cogseed@0.9.0|resedit@1.7.2",
-        "cogseed@0.9.0|app-builder-lib@26.15.7|semver@7.7.4",
-        "cogseed@0.9.0|tar@7.5.22",
-        "cogseed@0.9.0|temp-file@3.4.0",
-        "cogseed@0.9.0|tiny-async-pool@1.3.0",
-        "cogseed@0.9.0|unzipper@0.12.5",
-        "cogseed@0.9.0|app-builder-lib@26.15.7|which@5.0.0"
+        "cogseed@1.0.2|@electron/asar@3.4.1",
+        "cogseed@1.0.2|@electron/fuses@1.8.0",
+        "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0",
+        "cogseed@1.0.2|@electron/notarize@2.5.0",
+        "cogseed@1.0.2|@electron/osx-sign@1.3.3",
+        "cogseed@1.0.2|@electron/rebuild@4.2.0",
+        "cogseed@1.0.2|@electron/universal@2.0.3",
+        "cogseed@1.0.2|@malept/flatpak-bundler@0.4.0",
+        "cogseed@1.0.2|@noble/hashes@2.3.0",
+        "cogseed@1.0.2|@peculiar/webcrypto@1.7.1",
+        "cogseed@1.0.2|@types/fs-extra@9.0.13",
+        "cogseed@1.0.2|ajv@8.20.0",
+        "cogseed@1.0.2|asn1js@3.0.10",
+        "cogseed@1.0.2|async-exit-hook@2.0.1",
+        "cogseed@1.0.2|builder-util-runtime@9.7.0",
+        "cogseed@1.0.2|builder-util@26.15.3",
+        "cogseed@1.0.2|chromium-pickle-js@0.2.0",
+        "cogseed@1.0.2|app-builder-lib@26.15.7|ci-info@4.3.1",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|dmg-builder@26.15.7",
+        "cogseed@1.0.2|dotenv-expand@11.0.7",
+        "cogseed@1.0.2|dotenv@16.6.1",
+        "cogseed@1.0.2|ejs@3.1.10",
+        "cogseed@1.0.2|electron-builder-squirrel-windows@26.15.7",
+        "cogseed@1.0.2|electron-publish@26.15.3",
+        "cogseed@1.0.2|fs-extra@10.1.0",
+        "cogseed@1.0.2|hosted-git-info@4.1.0",
+        "cogseed@1.0.2|isbinaryfile@5.0.7",
+        "cogseed@1.0.2|jiti@2.7.0",
+        "cogseed@1.0.2|js-yaml@4.3.2",
+        "cogseed@1.0.2|json5@2.2.3",
+        "cogseed@1.0.2|lazy-val@1.0.5",
+        "cogseed@1.0.2|minimatch@10.2.6",
+        "cogseed@1.0.2|pkijs@3.4.0",
+        "cogseed@1.0.2|plist@3.1.0",
+        "cogseed@1.0.2|proper-lockfile@4.1.2",
+        "cogseed@1.0.2|resedit@1.7.2",
+        "cogseed@1.0.2|app-builder-lib@26.15.7|semver@7.7.4",
+        "cogseed@1.0.2|tar@7.5.22",
+        "cogseed@1.0.2|temp-file@3.4.0",
+        "cogseed@1.0.2|tiny-async-pool@1.3.0",
+        "cogseed@1.0.2|unzipper@0.12.5",
+        "cogseed@1.0.2|app-builder-lib@26.15.7|which@5.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0",
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|env-paths@2.2.1",
-        "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0|fs-extra@8.1.0",
-        "cogseed@0.9.0|global-agent@3.0.0",
-        "cogseed@0.9.0|got@11.8.6",
-        "cogseed@0.9.0|progress@2.0.3",
-        "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0|semver@6.3.1",
-        "cogseed@0.9.0|sumchecker@3.0.1"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|env-paths@2.2.1",
+        "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0|fs-extra@8.1.0",
+        "cogseed@1.0.2|global-agent@3.0.0",
+        "cogseed@1.0.2|got@11.8.6",
+        "cogseed@1.0.2|progress@2.0.3",
+        "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0|semver@6.3.1",
+        "cogseed@1.0.2|sumchecker@3.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0|fs-extra@8.1.0",
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0|fs-extra@8.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|app-builder-lib@26.15.7|jsonfile@4.0.0",
-        "cogseed@0.9.0|app-builder-lib@26.15.7|universalify@0.1.2"
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|app-builder-lib@26.15.7|jsonfile@4.0.0",
+        "cogseed@1.0.2|app-builder-lib@26.15.7|universalify@0.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|@electron/get@3.1.0|semver@6.3.1"
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|@electron/get@3.1.0|semver@6.3.1"
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|ci-info@4.3.1"
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|ci-info@4.3.1"
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|semver@7.7.4"
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|semver@7.7.4"
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|which@5.0.0",
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|which@5.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|app-builder-lib@26.15.7|isexe@3.1.5"
+        "cogseed@1.0.2|app-builder-lib@26.15.7|isexe@3.1.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|isexe@3.1.5"
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|isexe@3.1.5"
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|jsonfile@4.0.0",
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|jsonfile@4.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11"
+        "cogseed@1.0.2|graceful-fs@4.2.11"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|app-builder-lib@26.15.7|universalify@0.1.2"
+      "ref": "cogseed@1.0.2|app-builder-lib@26.15.7|universalify@0.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|builder-util-runtime@9.7.0",
+      "ref": "cogseed@1.0.2|builder-util-runtime@9.7.0",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|sax@1.6.0"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|sax@1.6.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|builder-util@26.15.3",
+      "ref": "cogseed@1.0.2|builder-util@26.15.3",
       "dependsOn": [
-        "cogseed@0.9.0|@types/debug@4.1.13",
-        "cogseed@0.9.0|builder-util-runtime@9.7.0",
-        "cogseed@0.9.0|chalk@4.1.2",
-        "cogseed@0.9.0|cross-spawn@7.0.6",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|fs-extra@10.1.0",
-        "cogseed@0.9.0|http-proxy-agent@7.0.2",
-        "cogseed@0.9.0|https-proxy-agent@7.0.6",
-        "cogseed@0.9.0|js-yaml@4.3.2",
-        "cogseed@0.9.0|sanitize-filename@1.6.4",
-        "cogseed@0.9.0|source-map-support@0.5.21",
-        "cogseed@0.9.0|stat-mode@1.0.0",
-        "cogseed@0.9.0|temp-file@3.4.0",
-        "cogseed@0.9.0|tiny-async-pool@1.3.0"
+        "cogseed@1.0.2|@types/debug@4.1.13",
+        "cogseed@1.0.2|builder-util-runtime@9.7.0",
+        "cogseed@1.0.2|chalk@4.1.2",
+        "cogseed@1.0.2|cross-spawn@7.0.6",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|fs-extra@10.1.0",
+        "cogseed@1.0.2|http-proxy-agent@7.0.2",
+        "cogseed@1.0.2|https-proxy-agent@7.0.6",
+        "cogseed@1.0.2|js-yaml@4.3.2",
+        "cogseed@1.0.2|sanitize-filename@1.6.4",
+        "cogseed@1.0.2|source-map-support@0.5.21",
+        "cogseed@1.0.2|stat-mode@1.0.0",
+        "cogseed@1.0.2|temp-file@3.4.0",
+        "cogseed@1.0.2|tiny-async-pool@1.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|chalk@4.1.2",
+      "ref": "cogseed@1.0.2|chalk@4.1.2",
       "dependsOn": [
-        "cogseed@0.9.0|ansi-styles@4.3.0",
-        "cogseed@0.9.0|supports-color@7.2.0"
+        "cogseed@1.0.2|ansi-styles@4.3.0",
+        "cogseed@1.0.2|supports-color@7.2.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|ci-info@4.4.0"
+      "ref": "cogseed@1.0.2|ci-info@4.4.0"
     },
     {
-      "ref": "cogseed@0.9.0|dmg-builder@26.15.7",
+      "ref": "cogseed@1.0.2|dmg-builder@26.15.7",
       "dependsOn": [
-        "cogseed@0.9.0|app-builder-lib@26.15.7",
-        "cogseed@0.9.0|builder-util@26.15.3",
-        "cogseed@0.9.0|fs-extra@10.1.0",
-        "cogseed@0.9.0|js-yaml@4.3.2"
+        "cogseed@1.0.2|app-builder-lib@26.15.7",
+        "cogseed@1.0.2|builder-util@26.15.3",
+        "cogseed@1.0.2|fs-extra@10.1.0",
+        "cogseed@1.0.2|js-yaml@4.3.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|fs-extra@10.1.0",
+      "ref": "cogseed@1.0.2|fs-extra@10.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|jsonfile@6.2.1",
-        "cogseed@0.9.0|universalify@2.0.1"
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|jsonfile@6.2.1",
+        "cogseed@1.0.2|universalify@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|lazy-val@1.0.5"
+      "ref": "cogseed@1.0.2|lazy-val@1.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|simple-update-notifier@2.0.0",
+      "ref": "cogseed@1.0.2|simple-update-notifier@2.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|semver@7.8.5"
+        "cogseed@1.0.2|semver@7.8.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|yargs@17.7.3",
+      "ref": "cogseed@1.0.2|yargs@17.7.3",
       "dependsOn": [
-        "cogseed@0.9.0|cliui@8.0.1",
-        "cogseed@0.9.0|escalade@3.2.0",
-        "cogseed@0.9.0|get-caller-file@2.0.5",
-        "cogseed@0.9.0|require-directory@2.1.1",
-        "cogseed@0.9.0|string-width@4.2.3",
-        "cogseed@0.9.0|y18n@5.0.8",
-        "cogseed@0.9.0|yargs-parser@21.1.1"
+        "cogseed@1.0.2|cliui@8.0.1",
+        "cogseed@1.0.2|escalade@3.2.0",
+        "cogseed@1.0.2|get-caller-file@2.0.5",
+        "cogseed@1.0.2|require-directory@2.1.1",
+        "cogseed@1.0.2|string-width@4.2.3",
+        "cogseed@1.0.2|y18n@5.0.8",
+        "cogseed@1.0.2|yargs-parser@21.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron-internal/extract-zip@1.0.5"
+      "ref": "cogseed@1.0.2|@electron-internal/extract-zip@1.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|@electron/get@5.1.0",
+      "ref": "cogseed@1.0.2|@electron/get@5.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|@electron/get@5.1.0|env-paths@3.0.0",
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|progress@2.0.3",
-        "cogseed@0.9.0|semver@7.8.5",
-        "cogseed@0.9.0|sumchecker@3.0.1",
-        "cogseed@0.9.0|undici@7.29.0"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|@electron/get@5.1.0|env-paths@3.0.0",
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|progress@2.0.3",
+        "cogseed@1.0.2|semver@7.8.5",
+        "cogseed@1.0.2|sumchecker@3.0.1",
+        "cogseed@1.0.2|undici@7.29.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/get@5.1.0|env-paths@3.0.0"
+      "ref": "cogseed@1.0.2|@electron/get@5.1.0|env-paths@3.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|@esbuild/darwin-arm64@0.28.2"
+      "ref": "cogseed@1.0.2|@esbuild/darwin-arm64@0.28.2"
     },
     {
-      "ref": "cogseed@0.9.0|@eslint-community/eslint-utils@4.10.1",
+      "ref": "cogseed@1.0.2|@eslint-community/eslint-utils@4.10.1",
       "dependsOn": [
-        "cogseed@0.9.0|@eslint-community/eslint-utils@4.10.1|eslint-visitor-keys@3.4.3",
-        "cogseed@0.9.0|eslint@10.9.0"
+        "cogseed@1.0.2|@eslint-community/eslint-utils@4.10.1|eslint-visitor-keys@3.4.3",
+        "cogseed@1.0.2|eslint@10.9.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@eslint-community/eslint-utils@4.10.1|eslint-visitor-keys@3.4.3"
+      "ref": "cogseed@1.0.2|@eslint-community/eslint-utils@4.10.1|eslint-visitor-keys@3.4.3"
     },
     {
-      "ref": "cogseed@0.9.0|@eslint-community/regexpp@4.12.2"
+      "ref": "cogseed@1.0.2|@eslint-community/regexpp@4.12.2"
     },
     {
-      "ref": "cogseed@0.9.0|@eslint/config-array@0.23.5",
+      "ref": "cogseed@1.0.2|@eslint/config-array@0.23.5",
       "dependsOn": [
-        "cogseed@0.9.0|@eslint/object-schema@3.0.5",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|minimatch@10.2.6"
+        "cogseed@1.0.2|@eslint/object-schema@3.0.5",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|minimatch@10.2.6"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@eslint/config-helpers@0.7.0",
+      "ref": "cogseed@1.0.2|@eslint/config-helpers@0.7.0",
       "dependsOn": [
-        "cogseed@0.9.0|@eslint/core@1.2.1"
+        "cogseed@1.0.2|@eslint/core@1.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@eslint/core@1.2.1",
+      "ref": "cogseed@1.0.2|@eslint/core@1.2.1",
       "dependsOn": [
-        "cogseed@0.9.0|@types/json-schema@7.0.15"
+        "cogseed@1.0.2|@types/json-schema@7.0.15"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@eslint/plugin-kit@0.7.2",
+      "ref": "cogseed@1.0.2|@eslint/plugin-kit@0.7.2",
       "dependsOn": [
-        "cogseed@0.9.0|@eslint/core@1.2.1",
-        "cogseed@0.9.0|levn@0.4.1"
+        "cogseed@1.0.2|@eslint/core@1.2.1",
+        "cogseed@1.0.2|levn@0.4.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@humanfs/node@0.16.8",
+      "ref": "cogseed@1.0.2|@humanfs/node@0.16.8",
       "dependsOn": [
-        "cogseed@0.9.0|@humanfs/core@0.19.2",
-        "cogseed@0.9.0|@humanfs/types@0.15.0",
-        "cogseed@0.9.0|@humanwhocodes/retry@0.4.3"
+        "cogseed@1.0.2|@humanfs/core@0.19.2",
+        "cogseed@1.0.2|@humanfs/types@0.15.0",
+        "cogseed@1.0.2|@humanwhocodes/retry@0.4.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@humanwhocodes/module-importer@1.0.1"
+      "ref": "cogseed@1.0.2|@humanwhocodes/module-importer@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|@humanwhocodes/retry@0.4.3"
+      "ref": "cogseed@1.0.2|@humanwhocodes/retry@0.4.3"
     },
     {
-      "ref": "cogseed@0.9.0|@types/estree@1.0.9"
+      "ref": "cogseed@1.0.2|@types/estree@1.0.9"
     },
     {
-      "ref": "cogseed@0.9.0|escape-string-regexp@4.0.0"
+      "ref": "cogseed@1.0.2|escape-string-regexp@4.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|eslint-scope@9.1.2",
+      "ref": "cogseed@1.0.2|eslint-scope@9.1.2",
       "dependsOn": [
-        "cogseed@0.9.0|@types/esrecurse@4.3.1",
-        "cogseed@0.9.0|@types/estree@1.0.9",
-        "cogseed@0.9.0|esrecurse@4.3.0",
-        "cogseed@0.9.0|estraverse@5.3.0"
+        "cogseed@1.0.2|@types/esrecurse@4.3.1",
+        "cogseed@1.0.2|@types/estree@1.0.9",
+        "cogseed@1.0.2|esrecurse@4.3.0",
+        "cogseed@1.0.2|estraverse@5.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|eslint-visitor-keys@5.0.1"
+      "ref": "cogseed@1.0.2|eslint-visitor-keys@5.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|espree@11.2.0",
+      "ref": "cogseed@1.0.2|espree@11.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|acorn-jsx@5.3.2",
-        "cogseed@0.9.0|acorn@8.18.0",
-        "cogseed@0.9.0|eslint-visitor-keys@5.0.1"
+        "cogseed@1.0.2|acorn-jsx@5.3.2",
+        "cogseed@1.0.2|acorn@8.18.0",
+        "cogseed@1.0.2|eslint-visitor-keys@5.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|esquery@1.7.0",
+      "ref": "cogseed@1.0.2|esquery@1.7.0",
       "dependsOn": [
-        "cogseed@0.9.0|estraverse@5.3.0"
+        "cogseed@1.0.2|estraverse@5.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|esutils@2.0.3"
+      "ref": "cogseed@1.0.2|esutils@2.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|fast-deep-equal@3.1.3"
+      "ref": "cogseed@1.0.2|fast-deep-equal@3.1.3"
     },
     {
-      "ref": "cogseed@0.9.0|file-entry-cache@8.0.0",
+      "ref": "cogseed@1.0.2|file-entry-cache@8.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|flat-cache@4.0.1"
+        "cogseed@1.0.2|flat-cache@4.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|find-up@5.0.0",
+      "ref": "cogseed@1.0.2|find-up@5.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|locate-path@6.0.0",
-        "cogseed@0.9.0|path-exists@4.0.0"
+        "cogseed@1.0.2|locate-path@6.0.0",
+        "cogseed@1.0.2|path-exists@4.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|glob-parent@6.0.2",
+      "ref": "cogseed@1.0.2|glob-parent@6.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|is-glob@4.0.3"
+        "cogseed@1.0.2|is-glob@4.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|ignore@5.3.2"
+      "ref": "cogseed@1.0.2|ignore@5.3.2"
     },
     {
-      "ref": "cogseed@0.9.0|imurmurhash@0.1.4"
+      "ref": "cogseed@1.0.2|imurmurhash@0.1.4"
     },
     {
-      "ref": "cogseed@0.9.0|is-glob@4.0.3",
+      "ref": "cogseed@1.0.2|is-glob@4.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|is-extglob@2.1.1"
+        "cogseed@1.0.2|is-extglob@2.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|jiti@2.7.0"
+      "ref": "cogseed@1.0.2|jiti@2.7.0"
     },
     {
-      "ref": "cogseed@0.9.0|json-stable-stringify-without-jsonify@1.0.1"
+      "ref": "cogseed@1.0.2|json-stable-stringify-without-jsonify@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|minimatch@10.2.6",
+      "ref": "cogseed@1.0.2|minimatch@10.2.6",
       "dependsOn": [
-        "cogseed@0.9.0|brace-expansion@5.0.9"
+        "cogseed@1.0.2|brace-expansion@5.0.9"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|natural-compare@1.4.0"
+      "ref": "cogseed@1.0.2|natural-compare@1.4.0"
     },
     {
-      "ref": "cogseed@0.9.0|optionator@0.9.4",
+      "ref": "cogseed@1.0.2|optionator@0.9.4",
       "dependsOn": [
-        "cogseed@0.9.0|deep-is@0.1.4",
-        "cogseed@0.9.0|fast-levenshtein@2.0.6",
-        "cogseed@0.9.0|levn@0.4.1",
-        "cogseed@0.9.0|prelude-ls@1.2.1",
-        "cogseed@0.9.0|type-check@0.4.0",
-        "cogseed@0.9.0|word-wrap@1.2.5"
+        "cogseed@1.0.2|deep-is@0.1.4",
+        "cogseed@1.0.2|fast-levenshtein@2.0.6",
+        "cogseed@1.0.2|levn@0.4.1",
+        "cogseed@1.0.2|prelude-ls@1.2.1",
+        "cogseed@1.0.2|type-check@0.4.0",
+        "cogseed@1.0.2|word-wrap@1.2.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@anush008/tokenizers@0.0.0",
+      "ref": "cogseed@1.0.2|@anush008/tokenizers@0.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|@anush008/tokenizers-darwin-universal@0.0.0"
+        "cogseed@1.0.2|@anush008/tokenizers-darwin-universal@0.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@huggingface/hub@2.11.0",
+      "ref": "cogseed@1.0.2|@huggingface/hub@2.11.0",
       "dependsOn": [
-        "cogseed@0.9.0|@huggingface/tasks@0.19.90",
-        "cogseed@0.9.0|cli-progress@3.12.0"
+        "cogseed@1.0.2|@huggingface/tasks@0.19.90",
+        "cogseed@1.0.2|cli-progress@3.12.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|onnxruntime-node@1.21.0",
+      "ref": "cogseed@1.0.2|onnxruntime-node@1.21.0",
       "dependsOn": [
-        "cogseed@0.9.0|global-agent@3.0.0",
-        "cogseed@0.9.0|onnxruntime-common@1.21.0",
-        "cogseed@0.9.0|tar@7.5.22"
+        "cogseed@1.0.2|global-agent@3.0.0",
+        "cogseed@1.0.2|onnxruntime-common@1.21.0",
+        "cogseed@1.0.2|tar@7.5.22"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|progress@2.0.3"
+      "ref": "cogseed@1.0.2|progress@2.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/core@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/core@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/file-ops@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|await-to-js@3.0.0",
-        "cogseed@0.9.0|exif-parser@0.1.12",
-        "cogseed@0.9.0|file-type@21.3.4",
-        "cogseed@0.9.0|mime@3.0.0"
+        "cogseed@1.0.2|@jimp/file-ops@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|await-to-js@3.0.0",
+        "cogseed@1.0.2|exif-parser@0.1.12",
+        "cogseed@1.0.2|file-type@21.3.4",
+        "cogseed@1.0.2|mime@3.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/diff@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/diff@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/plugin-resize@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|pixelmatch@5.3.0"
+        "cogseed@1.0.2|@jimp/plugin-resize@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|pixelmatch@5.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/js-bmp@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/js-bmp@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|bmp-ts@1.0.9"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|bmp-ts@1.0.9"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/js-gif@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/js-gif@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|gifwrap@0.10.1",
-        "cogseed@0.9.0|omggif@1.0.10"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|gifwrap@0.10.1",
+        "cogseed@1.0.2|omggif@1.0.10"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/js-jpeg@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/js-jpeg@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|jpeg-js@0.4.4"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|jpeg-js@0.4.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/js-png@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/js-png@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|pngjs@7.0.0"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|pngjs@7.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/js-tiff@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/js-tiff@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|utif2@4.1.0"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|utif2@4.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-blit@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-blit@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-blur@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-blur@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-circle@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-circle@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-color@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-color@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|tinycolor2@1.6.0",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|tinycolor2@1.6.0",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-contain@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-contain@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-blit@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-resize@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-blit@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-resize@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-cover@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-cover@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-crop@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-resize@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-crop@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-resize@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-crop@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-crop@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-displace@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-displace@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-dither@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-dither@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/types@1.6.1"
+        "cogseed@1.0.2|@jimp/types@1.6.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-fisheye@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-fisheye@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-flip@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-flip@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-hash@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-hash@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/js-bmp@1.6.1",
-        "cogseed@0.9.0|@jimp/js-jpeg@1.6.1",
-        "cogseed@0.9.0|@jimp/js-png@1.6.1",
-        "cogseed@0.9.0|@jimp/js-tiff@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-color@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-resize@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|any-base@1.1.0"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/js-bmp@1.6.1",
+        "cogseed@1.0.2|@jimp/js-jpeg@1.6.1",
+        "cogseed@1.0.2|@jimp/js-png@1.6.1",
+        "cogseed@1.0.2|@jimp/js-tiff@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-color@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-resize@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|any-base@1.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-mask@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-mask@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-print@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-print@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/js-jpeg@1.6.1",
-        "cogseed@0.9.0|@jimp/js-png@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-blit@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|parse-bmfont-ascii@1.0.6",
-        "cogseed@0.9.0|parse-bmfont-binary@1.0.6",
-        "cogseed@0.9.0|parse-bmfont-xml@1.1.6",
-        "cogseed@0.9.0|simple-xml-to-json@1.2.7",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/js-jpeg@1.6.1",
+        "cogseed@1.0.2|@jimp/js-png@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-blit@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|parse-bmfont-ascii@1.0.6",
+        "cogseed@1.0.2|parse-bmfont-binary@1.0.6",
+        "cogseed@1.0.2|parse-bmfont-xml@1.1.6",
+        "cogseed@1.0.2|simple-xml-to-json@1.2.7",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-quantize@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-quantize@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|image-q@4.0.0",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|image-q@4.0.0",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-resize@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-resize@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-rotate@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-rotate@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-crop@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-resize@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-crop@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-resize@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/plugin-threshold@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/plugin-threshold@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/core@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-color@1.6.1",
-        "cogseed@0.9.0|@jimp/plugin-hash@1.6.1",
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|@jimp/utils@1.6.1",
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|@jimp/core@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-color@1.6.1",
+        "cogseed@1.0.2|@jimp/plugin-hash@1.6.1",
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|@jimp/utils@1.6.1",
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/types@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/types@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|zod@3.25.76"
+        "cogseed@1.0.2|zod@3.25.76"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/utils@1.6.1",
+      "ref": "cogseed@1.0.2|@jimp/utils@1.6.1",
       "dependsOn": [
-        "cogseed@0.9.0|@jimp/types@1.6.1",
-        "cogseed@0.9.0|tinycolor2@1.6.0"
+        "cogseed@1.0.2|@jimp/types@1.6.1",
+        "cogseed@1.0.2|tinycolor2@1.6.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@xmldom/xmldom@0.8.15"
+      "ref": "cogseed@1.0.2|@xmldom/xmldom@0.8.15"
     },
     {
-      "ref": "cogseed@0.9.0|argparse@1.0.10",
+      "ref": "cogseed@1.0.2|argparse@1.0.10",
       "dependsOn": [
-        "cogseed@0.9.0|argparse@1.0.10|sprintf-js@1.0.3"
+        "cogseed@1.0.2|argparse@1.0.10|sprintf-js@1.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|argparse@1.0.10|sprintf-js@1.0.3"
+      "ref": "cogseed@1.0.2|argparse@1.0.10|sprintf-js@1.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|base64-js@1.5.1"
+      "ref": "cogseed@1.0.2|base64-js@1.5.1"
     },
     {
-      "ref": "cogseed@0.9.0|bluebird@3.4.7"
+      "ref": "cogseed@1.0.2|bluebird@3.4.7"
     },
     {
-      "ref": "cogseed@0.9.0|dingbat-to-unicode@1.0.1"
+      "ref": "cogseed@1.0.2|dingbat-to-unicode@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|jszip@3.10.1",
+      "ref": "cogseed@1.0.2|jszip@3.10.1",
       "dependsOn": [
-        "cogseed@0.9.0|lie@3.3.0",
-        "cogseed@0.9.0|pako@1.0.11",
-        "cogseed@0.9.0|jszip@3.10.1|readable-stream@2.3.8",
-        "cogseed@0.9.0|setimmediate@1.0.5"
+        "cogseed@1.0.2|lie@3.3.0",
+        "cogseed@1.0.2|pako@1.0.11",
+        "cogseed@1.0.2|jszip@3.10.1|readable-stream@2.3.8",
+        "cogseed@1.0.2|setimmediate@1.0.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|jszip@3.10.1|readable-stream@2.3.8",
+      "ref": "cogseed@1.0.2|jszip@3.10.1|readable-stream@2.3.8",
       "dependsOn": [
-        "cogseed@0.9.0|core-util-is@1.0.3",
-        "cogseed@0.9.0|inherits@2.0.4",
-        "cogseed@0.9.0|isarray@1.0.0",
-        "cogseed@0.9.0|process-nextick-args@2.0.1",
-        "cogseed@0.9.0|jszip@3.10.1|safe-buffer@5.1.2",
-        "cogseed@0.9.0|jszip@3.10.1|string_decoder@1.1.1",
-        "cogseed@0.9.0|util-deprecate@1.0.2"
+        "cogseed@1.0.2|core-util-is@1.0.3",
+        "cogseed@1.0.2|inherits@2.0.4",
+        "cogseed@1.0.2|isarray@1.0.0",
+        "cogseed@1.0.2|process-nextick-args@2.0.1",
+        "cogseed@1.0.2|jszip@3.10.1|safe-buffer@5.1.2",
+        "cogseed@1.0.2|jszip@3.10.1|string_decoder@1.1.1",
+        "cogseed@1.0.2|util-deprecate@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|jszip@3.10.1|safe-buffer@5.1.2"
+      "ref": "cogseed@1.0.2|jszip@3.10.1|safe-buffer@5.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|jszip@3.10.1|string_decoder@1.1.1",
+      "ref": "cogseed@1.0.2|jszip@3.10.1|string_decoder@1.1.1",
       "dependsOn": [
-        "cogseed@0.9.0|jszip@3.10.1|safe-buffer@5.1.2"
+        "cogseed@1.0.2|jszip@3.10.1|safe-buffer@5.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|lop@0.4.2",
+      "ref": "cogseed@1.0.2|lop@0.4.2",
       "dependsOn": [
-        "cogseed@0.9.0|duck@0.1.12",
-        "cogseed@0.9.0|option@0.2.4",
-        "cogseed@0.9.0|underscore@1.13.8"
+        "cogseed@1.0.2|duck@0.1.12",
+        "cogseed@1.0.2|option@0.2.4",
+        "cogseed@1.0.2|underscore@1.13.8"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|path-is-absolute@1.0.1"
+      "ref": "cogseed@1.0.2|path-is-absolute@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|underscore@1.13.8"
+      "ref": "cogseed@1.0.2|underscore@1.13.8"
     },
     {
-      "ref": "cogseed@0.9.0|xmlbuilder@10.1.1"
+      "ref": "cogseed@1.0.2|xmlbuilder@10.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|node-addon-api@7.1.1"
+      "ref": "cogseed@1.0.2|node-addon-api@7.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|@napi-rs/canvas@1.0.7",
+      "ref": "cogseed@1.0.2|@napi-rs/canvas@1.0.7",
       "dependsOn": [
-        "cogseed@0.9.0|@napi-rs/canvas-darwin-arm64@1.0.7"
+        "cogseed@1.0.2|@napi-rs/canvas-darwin-arm64@1.0.7"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|sherpa-onnx-darwin-arm64@1.13.6"
+      "ref": "cogseed@1.0.2|sherpa-onnx-darwin-arm64@1.13.6"
     },
     {
-      "ref": "cogseed@0.9.0|agent-base@7.1.4"
+      "ref": "cogseed@1.0.2|agent-base@7.1.4"
     },
     {
-      "ref": "cogseed@0.9.0|socks@2.8.9",
+      "ref": "cogseed@1.0.2|socks@2.8.9",
       "dependsOn": [
-        "cogseed@0.9.0|ip-address@10.5.0",
-        "cogseed@0.9.0|smart-buffer@4.2.0"
+        "cogseed@1.0.2|ip-address@10.5.0",
+        "cogseed@1.0.2|smart-buffer@4.2.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|sqlite-vec-darwin-arm64@0.1.9"
+      "ref": "cogseed@1.0.2|sqlite-vec-darwin-arm64@0.1.9"
     },
     {
-      "ref": "cogseed@0.9.0|@isaacs/fs-minipass@4.0.1",
+      "ref": "cogseed@1.0.2|@isaacs/fs-minipass@4.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|minipass@7.1.3"
+        "cogseed@1.0.2|minipass@7.1.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|minipass@7.1.3"
+      "ref": "cogseed@1.0.2|minipass@7.1.3"
     },
     {
-      "ref": "cogseed@0.9.0|minizlib@3.1.0",
+      "ref": "cogseed@1.0.2|minizlib@3.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|minipass@7.1.3"
+        "cogseed@1.0.2|minipass@7.1.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|yallist@5.0.0"
+      "ref": "cogseed@1.0.2|yallist@5.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|fsevents@2.3.3"
+      "ref": "cogseed@1.0.2|fsevents@2.3.3"
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/eslint-plugin@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/eslint-plugin@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@eslint-community/regexpp@4.12.2",
-        "cogseed@0.9.0|@typescript-eslint/parser@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/scope-manager@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/type-utils@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/utils@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/visitor-keys@8.67.0",
-        "cogseed@0.9.0|eslint@10.9.0",
-        "cogseed@0.9.0|@typescript-eslint/eslint-plugin@8.67.0|ignore@7.0.6",
-        "cogseed@0.9.0|natural-compare@1.4.0",
-        "cogseed@0.9.0|ts-api-utils@2.5.0",
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|@eslint-community/regexpp@4.12.2",
+        "cogseed@1.0.2|@typescript-eslint/parser@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/scope-manager@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/type-utils@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/utils@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/visitor-keys@8.67.0",
+        "cogseed@1.0.2|eslint@10.9.0",
+        "cogseed@1.0.2|@typescript-eslint/eslint-plugin@8.67.0|ignore@7.0.6",
+        "cogseed@1.0.2|natural-compare@1.4.0",
+        "cogseed@1.0.2|ts-api-utils@2.5.0",
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/eslint-plugin@8.67.0|ignore@7.0.6"
+      "ref": "cogseed@1.0.2|@typescript-eslint/eslint-plugin@8.67.0|ignore@7.0.6"
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/parser@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/parser@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@typescript-eslint/scope-manager@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/types@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/typescript-estree@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/visitor-keys@8.67.0",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|eslint@10.9.0",
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|@typescript-eslint/scope-manager@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/types@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/typescript-estree@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/visitor-keys@8.67.0",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|eslint@10.9.0",
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/typescript-estree@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/typescript-estree@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@typescript-eslint/project-service@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/tsconfig-utils@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/types@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/visitor-keys@8.67.0",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|minimatch@10.2.6",
-        "cogseed@0.9.0|semver@7.8.5",
-        "cogseed@0.9.0|tinyglobby@0.2.17",
-        "cogseed@0.9.0|ts-api-utils@2.5.0",
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|@typescript-eslint/project-service@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/tsconfig-utils@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/types@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/visitor-keys@8.67.0",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|minimatch@10.2.6",
+        "cogseed@1.0.2|semver@7.8.5",
+        "cogseed@1.0.2|tinyglobby@0.2.17",
+        "cogseed@1.0.2|ts-api-utils@2.5.0",
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/utils@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/utils@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@eslint-community/eslint-utils@4.10.1",
-        "cogseed@0.9.0|@typescript-eslint/scope-manager@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/types@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/typescript-estree@8.67.0",
-        "cogseed@0.9.0|eslint@10.9.0",
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|@eslint-community/eslint-utils@4.10.1",
+        "cogseed@1.0.2|@typescript-eslint/scope-manager@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/types@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/typescript-estree@8.67.0",
+        "cogseed@1.0.2|eslint@10.9.0",
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@vitest/expect@4.1.11",
+      "ref": "cogseed@1.0.2|@vitest/expect@4.1.11",
       "dependsOn": [
-        "cogseed@0.9.0|@standard-schema/spec@1.1.0",
-        "cogseed@0.9.0|@types/chai@5.2.3",
-        "cogseed@0.9.0|@vitest/spy@4.1.11",
-        "cogseed@0.9.0|@vitest/utils@4.1.11",
-        "cogseed@0.9.0|chai@6.2.2",
-        "cogseed@0.9.0|tinyrainbow@3.1.0"
+        "cogseed@1.0.2|@standard-schema/spec@1.1.0",
+        "cogseed@1.0.2|@types/chai@5.2.3",
+        "cogseed@1.0.2|@vitest/spy@4.1.11",
+        "cogseed@1.0.2|@vitest/utils@4.1.11",
+        "cogseed@1.0.2|chai@6.2.2",
+        "cogseed@1.0.2|tinyrainbow@3.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@vitest/mocker@4.1.11",
+      "ref": "cogseed@1.0.2|@vitest/mocker@4.1.11",
       "dependsOn": [
-        "cogseed@0.9.0|@vitest/spy@4.1.11",
-        "cogseed@0.9.0|estree-walker@3.0.3",
-        "cogseed@0.9.0|magic-string@0.30.21",
-        "cogseed@0.9.0|vite@8.2.2"
+        "cogseed@1.0.2|@vitest/spy@4.1.11",
+        "cogseed@1.0.2|estree-walker@3.0.3",
+        "cogseed@1.0.2|magic-string@0.30.21",
+        "cogseed@1.0.2|vite@8.2.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@vitest/pretty-format@4.1.11",
+      "ref": "cogseed@1.0.2|@vitest/pretty-format@4.1.11",
       "dependsOn": [
-        "cogseed@0.9.0|tinyrainbow@3.1.0"
+        "cogseed@1.0.2|tinyrainbow@3.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@vitest/runner@4.1.11",
+      "ref": "cogseed@1.0.2|@vitest/runner@4.1.11",
       "dependsOn": [
-        "cogseed@0.9.0|@vitest/utils@4.1.11",
-        "cogseed@0.9.0|pathe@2.0.3"
+        "cogseed@1.0.2|@vitest/utils@4.1.11",
+        "cogseed@1.0.2|pathe@2.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@vitest/snapshot@4.1.11",
+      "ref": "cogseed@1.0.2|@vitest/snapshot@4.1.11",
       "dependsOn": [
-        "cogseed@0.9.0|@vitest/pretty-format@4.1.11",
-        "cogseed@0.9.0|@vitest/utils@4.1.11",
-        "cogseed@0.9.0|magic-string@0.30.21",
-        "cogseed@0.9.0|pathe@2.0.3"
+        "cogseed@1.0.2|@vitest/pretty-format@4.1.11",
+        "cogseed@1.0.2|@vitest/utils@4.1.11",
+        "cogseed@1.0.2|magic-string@0.30.21",
+        "cogseed@1.0.2|pathe@2.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@vitest/spy@4.1.11"
+      "ref": "cogseed@1.0.2|@vitest/spy@4.1.11"
     },
     {
-      "ref": "cogseed@0.9.0|expect-type@1.3.0"
+      "ref": "cogseed@1.0.2|expect-type@1.3.0"
     },
     {
-      "ref": "cogseed@0.9.0|magic-string@0.30.21",
+      "ref": "cogseed@1.0.2|magic-string@0.30.21",
       "dependsOn": [
-        "cogseed@0.9.0|@jridgewell/sourcemap-codec@1.5.5"
+        "cogseed@1.0.2|@jridgewell/sourcemap-codec@1.5.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|pathe@2.0.3"
+      "ref": "cogseed@1.0.2|pathe@2.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|picomatch@4.0.5"
+      "ref": "cogseed@1.0.2|picomatch@4.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|tinybench@2.9.0"
+      "ref": "cogseed@1.0.2|tinybench@2.9.0"
     },
     {
-      "ref": "cogseed@0.9.0|tinyglobby@0.2.17",
+      "ref": "cogseed@1.0.2|tinyglobby@0.2.17",
       "dependsOn": [
-        "cogseed@0.9.0|fdir@6.5.0",
-        "cogseed@0.9.0|picomatch@4.0.5"
+        "cogseed@1.0.2|fdir@6.5.0",
+        "cogseed@1.0.2|picomatch@4.0.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|vite@8.2.2",
+      "ref": "cogseed@1.0.2|vite@8.2.2",
       "dependsOn": [
-        "cogseed@0.9.0|@types/node@25.6.0",
-        "cogseed@0.9.0|esbuild@0.28.2",
-        "cogseed@0.9.0|fsevents@2.3.3",
-        "cogseed@0.9.0|jiti@2.7.0",
-        "cogseed@0.9.0|lightningcss@1.33.0",
-        "cogseed@0.9.0|picomatch@4.0.5",
-        "cogseed@0.9.0|postcss@8.5.26",
-        "cogseed@0.9.0|rolldown@1.2.5",
-        "cogseed@0.9.0|tinyglobby@0.2.17",
-        "cogseed@0.9.0|tsx@4.23.13",
-        "cogseed@0.9.0|yaml@2.9.0"
+        "cogseed@1.0.2|@types/node@25.6.0",
+        "cogseed@1.0.2|esbuild@0.28.2",
+        "cogseed@1.0.2|fsevents@2.3.3",
+        "cogseed@1.0.2|jiti@2.7.0",
+        "cogseed@1.0.2|lightningcss@1.33.0",
+        "cogseed@1.0.2|picomatch@4.0.5",
+        "cogseed@1.0.2|postcss@8.5.26",
+        "cogseed@1.0.2|rolldown@1.2.5",
+        "cogseed@1.0.2|tinyglobby@0.2.17",
+        "cogseed@1.0.2|tsx@4.23.13",
+        "cogseed@1.0.2|yaml@2.9.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|why-is-node-running@2.3.0",
+      "ref": "cogseed@1.0.2|why-is-node-running@2.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|siginfo@2.0.0",
-        "cogseed@0.9.0|stackback@0.0.2"
+        "cogseed@1.0.2|siginfo@2.0.0",
+        "cogseed@1.0.2|stackback@0.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|json-schema-to-ts@3.1.1",
+      "ref": "cogseed@1.0.2|json-schema-to-ts@3.1.1",
       "dependsOn": [
-        "cogseed@0.9.0|@babel/runtime@7.29.7",
-        "cogseed@0.9.0|ts-algebra@2.0.0"
+        "cogseed@1.0.2|@babel/runtime@7.29.7",
+        "cogseed@1.0.2|ts-algebra@2.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-crypto/sha256-browser@5.2.0",
+      "ref": "cogseed@1.0.2|@aws-crypto/sha256-browser@5.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-crypto/sha256-js@5.2.0",
-        "cogseed@0.9.0|@aws-crypto/supports-web-crypto@5.2.0",
-        "cogseed@0.9.0|@aws-crypto/util@5.2.0",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@aws-sdk/util-locate-window@3.965.5",
-        "cogseed@0.9.0|@smithy/util-utf8@2.3.0",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-crypto/sha256-js@5.2.0",
+        "cogseed@1.0.2|@aws-crypto/supports-web-crypto@5.2.0",
+        "cogseed@1.0.2|@aws-crypto/util@5.2.0",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@aws-sdk/util-locate-window@3.965.5",
+        "cogseed@1.0.2|@smithy/util-utf8@2.3.0",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-crypto/sha256-js@5.2.0",
+      "ref": "cogseed@1.0.2|@aws-crypto/sha256-js@5.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-crypto/util@5.2.0",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-crypto/util@5.2.0",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/core@3.974.15",
+      "ref": "cogseed@1.0.2|@aws-sdk/core@3.974.15",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@aws-sdk/xml-builder@3.972.26",
-        "cogseed@0.9.0|@aws/lambda-invoke-store@0.2.4",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/signature-v4@5.4.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|bowser@2.14.1",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@aws-sdk/xml-builder@3.972.26",
+        "cogseed@1.0.2|@aws/lambda-invoke-store@0.2.4",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/signature-v4@5.4.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|bowser@2.14.1",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-node@3.972.47",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-node@3.972.47",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/credential-provider-env@3.972.41",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-http@3.972.43",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-ini@3.972.46",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-process@3.972.41",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-sso@3.972.45",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-web-identity@3.972.45",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/credential-provider-imds@4.3.6",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/credential-provider-env@3.972.41",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-http@3.972.43",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-ini@3.972.46",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-process@3.972.41",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-sso@3.972.45",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-web-identity@3.972.45",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/credential-provider-imds@4.3.6",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/eventstream-handler-node@3.972.18",
+      "ref": "cogseed@1.0.2|@aws-sdk/eventstream-handler-node@3.972.18",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/middleware-eventstream@3.972.14",
+      "ref": "cogseed@1.0.2|@aws-sdk/middleware-eventstream@3.972.14",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/middleware-websocket@3.972.23",
+      "ref": "cogseed@1.0.2|@aws-sdk/middleware-websocket@3.972.23",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/fetch-http-handler@5.4.5",
-        "cogseed@0.9.0|@smithy/signature-v4@5.4.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/fetch-http-handler@5.4.5",
+        "cogseed@1.0.2|@smithy/signature-v4@5.4.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/token-providers@3.1048.0",
+      "ref": "cogseed@1.0.2|@aws-sdk/token-providers@3.1048.0",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/types@3.973.9",
+      "ref": "cogseed@1.0.2|@aws-sdk/types@3.973.9",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/core@3.24.5",
+      "ref": "cogseed@1.0.2|@smithy/core@3.24.5",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-crypto/crc32@5.2.0",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-crypto/crc32@5.2.0",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/fetch-http-handler@5.4.5",
+      "ref": "cogseed@1.0.2|@smithy/fetch-http-handler@5.4.5",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/types@4.14.2",
+      "ref": "cogseed@1.0.2|@smithy/types@4.14.2",
       "dependsOn": [
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|google-auth-library@10.6.2",
+      "ref": "cogseed@1.0.2|google-auth-library@10.6.2",
       "dependsOn": [
-        "cogseed@0.9.0|base64-js@1.5.1",
-        "cogseed@0.9.0|ecdsa-sig-formatter@1.0.11",
-        "cogseed@0.9.0|gaxios@7.1.4",
-        "cogseed@0.9.0|gcp-metadata@8.1.2",
-        "cogseed@0.9.0|google-logging-utils@1.1.3",
-        "cogseed@0.9.0|jws@4.0.1"
+        "cogseed@1.0.2|base64-js@1.5.1",
+        "cogseed@1.0.2|ecdsa-sig-formatter@1.0.11",
+        "cogseed@1.0.2|gaxios@7.1.4",
+        "cogseed@1.0.2|gcp-metadata@8.1.2",
+        "cogseed@1.0.2|google-logging-utils@1.1.3",
+        "cogseed@1.0.2|jws@4.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|p-retry@4.6.2",
+      "ref": "cogseed@1.0.2|p-retry@4.6.2",
       "dependsOn": [
-        "cogseed@0.9.0|@types/retry@0.12.0",
-        "cogseed@0.9.0|retry@0.13.1"
+        "cogseed@1.0.2|@types/retry@0.12.0",
+        "cogseed@1.0.2|retry@0.13.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@opentelemetry/semantic-conventions@1.41.1"
+      "ref": "cogseed@1.0.2|@opentelemetry/semantic-conventions@1.41.1"
     },
     {
-      "ref": "cogseed@0.9.0|ms@2.1.3"
+      "ref": "cogseed@1.0.2|ms@2.1.3"
     },
     {
-      "ref": "cogseed@0.9.0|semver@7.8.5"
+      "ref": "cogseed@1.0.2|semver@7.8.5"
     },
     {
-      "ref": "cogseed@0.9.0|env-paths@2.2.1"
+      "ref": "cogseed@1.0.2|env-paths@2.2.1"
     },
     {
-      "ref": "cogseed@0.9.0|exponential-backoff@3.1.3"
+      "ref": "cogseed@1.0.2|exponential-backoff@3.1.3"
     },
     {
-      "ref": "cogseed@0.9.0|graceful-fs@4.2.11"
+      "ref": "cogseed@1.0.2|graceful-fs@4.2.11"
     },
     {
-      "ref": "cogseed@0.9.0|nopt@9.0.0",
+      "ref": "cogseed@1.0.2|nopt@9.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|abbrev@4.0.0"
+        "cogseed@1.0.2|abbrev@4.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|proc-log@6.1.0"
+      "ref": "cogseed@1.0.2|proc-log@6.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|follow-redirects@1.16.0"
+      "ref": "cogseed@1.0.2|follow-redirects@1.16.0"
     },
     {
-      "ref": "cogseed@0.9.0|form-data@4.0.6",
+      "ref": "cogseed@1.0.2|form-data@4.0.6",
       "dependsOn": [
-        "cogseed@0.9.0|asynckit@0.4.0",
-        "cogseed@0.9.0|combined-stream@1.0.8",
-        "cogseed@0.9.0|es-set-tostringtag@2.1.0",
-        "cogseed@0.9.0|hasown@2.0.4",
-        "cogseed@0.9.0|mime-types@2.1.35"
+        "cogseed@1.0.2|asynckit@0.4.0",
+        "cogseed@1.0.2|combined-stream@1.0.8",
+        "cogseed@1.0.2|es-set-tostringtag@2.1.0",
+        "cogseed@1.0.2|hasown@2.0.4",
+        "cogseed@1.0.2|mime-types@2.1.35"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|proxy-from-env@2.1.0"
+      "ref": "cogseed@1.0.2|proxy-from-env@2.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/aspromise@1.1.2"
+      "ref": "cogseed@1.0.2|@protobufjs/aspromise@1.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/base64@1.1.2"
+      "ref": "cogseed@1.0.2|@protobufjs/base64@1.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/codegen@2.0.5"
+      "ref": "cogseed@1.0.2|@protobufjs/codegen@2.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/eventemitter@1.1.1"
+      "ref": "cogseed@1.0.2|@protobufjs/eventemitter@1.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/fetch@1.1.1",
+      "ref": "cogseed@1.0.2|@protobufjs/fetch@1.1.1",
       "dependsOn": [
-        "cogseed@0.9.0|@protobufjs/aspromise@1.1.2"
+        "cogseed@1.0.2|@protobufjs/aspromise@1.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/float@1.0.2"
+      "ref": "cogseed@1.0.2|@protobufjs/float@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/path@1.1.2"
+      "ref": "cogseed@1.0.2|@protobufjs/path@1.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/pool@1.1.0"
+      "ref": "cogseed@1.0.2|@protobufjs/pool@1.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|@protobufjs/utf8@1.1.1"
+      "ref": "cogseed@1.0.2|@protobufjs/utf8@1.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|long@5.3.2"
+      "ref": "cogseed@1.0.2|long@5.3.2"
     },
     {
-      "ref": "cogseed@0.9.0|es-define-property@1.0.1"
+      "ref": "cogseed@1.0.2|es-define-property@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|side-channel@1.1.1",
+      "ref": "cogseed@1.0.2|side-channel@1.1.1",
       "dependsOn": [
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|object-inspect@1.13.4",
-        "cogseed@0.9.0|side-channel-list@1.0.1",
-        "cogseed@0.9.0|side-channel-map@1.0.1",
-        "cogseed@0.9.0|side-channel-weakmap@1.0.2"
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|object-inspect@1.13.4",
+        "cogseed@1.0.2|side-channel-list@1.0.1",
+        "cogseed@1.0.2|side-channel-map@1.0.1",
+        "cogseed@1.0.2|side-channel-weakmap@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|fast-uri@3.1.7"
+      "ref": "cogseed@1.0.2|fast-uri@3.1.7"
     },
     {
-      "ref": "cogseed@0.9.0|json-schema-traverse@1.0.0"
+      "ref": "cogseed@1.0.2|json-schema-traverse@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|require-from-string@2.0.2"
+      "ref": "cogseed@1.0.2|require-from-string@2.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|object-assign@4.1.1"
+      "ref": "cogseed@1.0.2|object-assign@4.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|vary@1.1.2"
+      "ref": "cogseed@1.0.2|vary@1.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|path-key@3.1.1"
+      "ref": "cogseed@1.0.2|path-key@3.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|shebang-command@2.0.0",
+      "ref": "cogseed@1.0.2|shebang-command@2.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|shebang-regex@3.0.0"
+        "cogseed@1.0.2|shebang-regex@3.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|which@2.0.2",
+      "ref": "cogseed@1.0.2|which@2.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|isexe@2.0.0"
+        "cogseed@1.0.2|isexe@2.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|ip-address@10.5.0"
+      "ref": "cogseed@1.0.2|ip-address@10.5.0"
     },
     {
-      "ref": "cogseed@0.9.0|accepts@2.0.0",
+      "ref": "cogseed@1.0.2|accepts@2.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|accepts@2.0.0|mime-types@3.0.2",
-        "cogseed@0.9.0|negotiator@1.0.0"
+        "cogseed@1.0.2|accepts@2.0.0|mime-types@3.0.2",
+        "cogseed@1.0.2|negotiator@1.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|accepts@2.0.0|mime-types@3.0.2",
+      "ref": "cogseed@1.0.2|accepts@2.0.0|mime-types@3.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|accepts@2.0.0|mime-db@1.54.0"
+        "cogseed@1.0.2|accepts@2.0.0|mime-db@1.54.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|accepts@2.0.0|mime-db@1.54.0"
+      "ref": "cogseed@1.0.2|accepts@2.0.0|mime-db@1.54.0"
     },
     {
-      "ref": "cogseed@0.9.0|body-parser@2.3.0",
+      "ref": "cogseed@1.0.2|body-parser@2.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|bytes@3.1.2",
-        "cogseed@0.9.0|body-parser@2.3.0|content-type@2.1.0",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|http-errors@2.0.1",
-        "cogseed@0.9.0|iconv-lite@0.7.2",
-        "cogseed@0.9.0|on-finished@2.4.1",
-        "cogseed@0.9.0|qs@6.16.0",
-        "cogseed@0.9.0|raw-body@3.0.2",
-        "cogseed@0.9.0|type-is@2.1.0"
+        "cogseed@1.0.2|bytes@3.1.2",
+        "cogseed@1.0.2|body-parser@2.3.0|content-type@2.1.0",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|http-errors@2.0.1",
+        "cogseed@1.0.2|iconv-lite@0.7.2",
+        "cogseed@1.0.2|on-finished@2.4.1",
+        "cogseed@1.0.2|qs@6.16.0",
+        "cogseed@1.0.2|raw-body@3.0.2",
+        "cogseed@1.0.2|type-is@2.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|body-parser@2.3.0|content-type@2.1.0"
+      "ref": "cogseed@1.0.2|body-parser@2.3.0|content-type@2.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|content-disposition@1.1.0"
+      "ref": "cogseed@1.0.2|content-disposition@1.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|cookie-signature@1.2.2"
+      "ref": "cogseed@1.0.2|cookie-signature@1.2.2"
     },
     {
-      "ref": "cogseed@0.9.0|cookie@0.7.2"
+      "ref": "cogseed@1.0.2|cookie@0.7.2"
     },
     {
-      "ref": "cogseed@0.9.0|depd@2.0.0"
+      "ref": "cogseed@1.0.2|depd@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|encodeurl@2.0.0"
+      "ref": "cogseed@1.0.2|encodeurl@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|escape-html@1.0.3"
+      "ref": "cogseed@1.0.2|escape-html@1.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|etag@1.8.1"
+      "ref": "cogseed@1.0.2|etag@1.8.1"
     },
     {
-      "ref": "cogseed@0.9.0|finalhandler@2.1.1",
+      "ref": "cogseed@1.0.2|finalhandler@2.1.1",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|encodeurl@2.0.0",
-        "cogseed@0.9.0|escape-html@1.0.3",
-        "cogseed@0.9.0|on-finished@2.4.1",
-        "cogseed@0.9.0|parseurl@1.3.3",
-        "cogseed@0.9.0|statuses@2.0.2"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|encodeurl@2.0.0",
+        "cogseed@1.0.2|escape-html@1.0.3",
+        "cogseed@1.0.2|on-finished@2.4.1",
+        "cogseed@1.0.2|parseurl@1.3.3",
+        "cogseed@1.0.2|statuses@2.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|fresh@2.0.0"
+      "ref": "cogseed@1.0.2|fresh@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|http-errors@2.0.1",
+      "ref": "cogseed@1.0.2|http-errors@2.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|depd@2.0.0",
-        "cogseed@0.9.0|inherits@2.0.4",
-        "cogseed@0.9.0|setprototypeof@1.2.0",
-        "cogseed@0.9.0|statuses@2.0.2",
-        "cogseed@0.9.0|toidentifier@1.0.1"
+        "cogseed@1.0.2|depd@2.0.0",
+        "cogseed@1.0.2|inherits@2.0.4",
+        "cogseed@1.0.2|setprototypeof@1.2.0",
+        "cogseed@1.0.2|statuses@2.0.2",
+        "cogseed@1.0.2|toidentifier@1.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|merge-descriptors@2.0.0"
+      "ref": "cogseed@1.0.2|merge-descriptors@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|on-finished@2.4.1",
+      "ref": "cogseed@1.0.2|on-finished@2.4.1",
       "dependsOn": [
-        "cogseed@0.9.0|ee-first@1.1.1"
+        "cogseed@1.0.2|ee-first@1.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|once@1.4.0",
+      "ref": "cogseed@1.0.2|once@1.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|wrappy@1.0.2"
+        "cogseed@1.0.2|wrappy@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|parseurl@1.3.3"
+      "ref": "cogseed@1.0.2|parseurl@1.3.3"
     },
     {
-      "ref": "cogseed@0.9.0|proxy-addr@2.0.7",
+      "ref": "cogseed@1.0.2|proxy-addr@2.0.7",
       "dependsOn": [
-        "cogseed@0.9.0|forwarded@0.2.0",
-        "cogseed@0.9.0|ipaddr.js@1.9.1"
+        "cogseed@1.0.2|forwarded@0.2.0",
+        "cogseed@1.0.2|ipaddr.js@1.9.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|range-parser@1.2.1"
+      "ref": "cogseed@1.0.2|range-parser@1.2.1"
     },
     {
-      "ref": "cogseed@0.9.0|router@2.2.0",
+      "ref": "cogseed@1.0.2|router@2.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|depd@2.0.0",
-        "cogseed@0.9.0|is-promise@4.0.0",
-        "cogseed@0.9.0|parseurl@1.3.3",
-        "cogseed@0.9.0|path-to-regexp@8.4.2"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|depd@2.0.0",
+        "cogseed@1.0.2|is-promise@4.0.0",
+        "cogseed@1.0.2|parseurl@1.3.3",
+        "cogseed@1.0.2|path-to-regexp@8.4.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|send@1.2.1",
+      "ref": "cogseed@1.0.2|send@1.2.1",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|encodeurl@2.0.0",
-        "cogseed@0.9.0|escape-html@1.0.3",
-        "cogseed@0.9.0|etag@1.8.1",
-        "cogseed@0.9.0|fresh@2.0.0",
-        "cogseed@0.9.0|http-errors@2.0.1",
-        "cogseed@0.9.0|send@1.2.1|mime-types@3.0.2",
-        "cogseed@0.9.0|ms@2.1.3",
-        "cogseed@0.9.0|on-finished@2.4.1",
-        "cogseed@0.9.0|range-parser@1.2.1",
-        "cogseed@0.9.0|statuses@2.0.2"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|encodeurl@2.0.0",
+        "cogseed@1.0.2|escape-html@1.0.3",
+        "cogseed@1.0.2|etag@1.8.1",
+        "cogseed@1.0.2|fresh@2.0.0",
+        "cogseed@1.0.2|http-errors@2.0.1",
+        "cogseed@1.0.2|send@1.2.1|mime-types@3.0.2",
+        "cogseed@1.0.2|ms@2.1.3",
+        "cogseed@1.0.2|on-finished@2.4.1",
+        "cogseed@1.0.2|range-parser@1.2.1",
+        "cogseed@1.0.2|statuses@2.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|send@1.2.1|mime-types@3.0.2",
+      "ref": "cogseed@1.0.2|send@1.2.1|mime-types@3.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|send@1.2.1|mime-db@1.54.0"
+        "cogseed@1.0.2|send@1.2.1|mime-db@1.54.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|send@1.2.1|mime-db@1.54.0"
+      "ref": "cogseed@1.0.2|send@1.2.1|mime-db@1.54.0"
     },
     {
-      "ref": "cogseed@0.9.0|serve-static@2.2.1",
+      "ref": "cogseed@1.0.2|serve-static@2.2.1",
       "dependsOn": [
-        "cogseed@0.9.0|encodeurl@2.0.0",
-        "cogseed@0.9.0|escape-html@1.0.3",
-        "cogseed@0.9.0|parseurl@1.3.3",
-        "cogseed@0.9.0|send@1.2.1"
+        "cogseed@1.0.2|encodeurl@2.0.0",
+        "cogseed@1.0.2|escape-html@1.0.3",
+        "cogseed@1.0.2|parseurl@1.3.3",
+        "cogseed@1.0.2|send@1.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|statuses@2.0.2"
+      "ref": "cogseed@1.0.2|statuses@2.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|type-is@2.1.0",
+      "ref": "cogseed@1.0.2|type-is@2.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|type-is@2.1.0|content-type@2.0.0",
-        "cogseed@0.9.0|media-typer@1.1.0",
-        "cogseed@0.9.0|type-is@2.1.0|mime-types@3.0.2"
+        "cogseed@1.0.2|type-is@2.1.0|content-type@2.0.0",
+        "cogseed@1.0.2|media-typer@1.1.0",
+        "cogseed@1.0.2|type-is@2.1.0|mime-types@3.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|type-is@2.1.0|content-type@2.0.0"
+      "ref": "cogseed@1.0.2|type-is@2.1.0|content-type@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|type-is@2.1.0|mime-types@3.0.2",
+      "ref": "cogseed@1.0.2|type-is@2.1.0|mime-types@3.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|type-is@2.1.0|mime-db@1.54.0"
+        "cogseed@1.0.2|type-is@2.1.0|mime-db@1.54.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|type-is@2.1.0|mime-db@1.54.0"
+      "ref": "cogseed@1.0.2|type-is@2.1.0|mime-db@1.54.0"
     },
     {
-      "ref": "cogseed@0.9.0|bytes@3.1.2"
+      "ref": "cogseed@1.0.2|bytes@3.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|iconv-lite@0.7.2",
+      "ref": "cogseed@1.0.2|iconv-lite@0.7.2",
       "dependsOn": [
-        "cogseed@0.9.0|safer-buffer@2.1.2"
+        "cogseed@1.0.2|safer-buffer@2.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|unpipe@1.0.0"
+      "ref": "cogseed@1.0.2|unpipe@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|convert-source-map@2.0.0"
+      "ref": "cogseed@1.0.2|convert-source-map@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|@jridgewell/trace-mapping@0.3.31",
+      "ref": "cogseed@1.0.2|@jridgewell/trace-mapping@0.3.31",
       "dependsOn": [
-        "cogseed@0.9.0|@jridgewell/resolve-uri@3.1.2",
-        "cogseed@0.9.0|@jridgewell/sourcemap-codec@1.5.5"
+        "cogseed@1.0.2|@jridgewell/resolve-uri@3.1.2",
+        "cogseed@1.0.2|@jridgewell/sourcemap-codec@1.5.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|estree-walker@3.0.3",
+      "ref": "cogseed@1.0.2|estree-walker@3.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|@types/estree@1.0.9"
+        "cogseed@1.0.2|@types/estree@1.0.9"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|js-tokens@10.0.0"
+      "ref": "cogseed@1.0.2|js-tokens@10.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|make-dir@4.0.0",
+      "ref": "cogseed@1.0.2|make-dir@4.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|semver@7.8.5"
+        "cogseed@1.0.2|semver@7.8.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|supports-color@7.2.0",
+      "ref": "cogseed@1.0.2|supports-color@7.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|has-flag@4.0.0"
+        "cogseed@1.0.2|has-flag@4.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|html-escaper@2.0.2"
+      "ref": "cogseed@1.0.2|html-escaper@2.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@babel/parser@7.29.7",
+      "ref": "cogseed@1.0.2|@babel/parser@7.29.7",
       "dependsOn": [
-        "cogseed@0.9.0|@babel/types@7.29.7"
+        "cogseed@1.0.2|@babel/types@7.29.7"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@babel/types@7.29.7",
+      "ref": "cogseed@1.0.2|@babel/types@7.29.7",
       "dependsOn": [
-        "cogseed@0.9.0|@babel/helper-string-parser@7.29.7",
-        "cogseed@0.9.0|@babel/helper-validator-identifier@7.29.7"
+        "cogseed@1.0.2|@babel/helper-string-parser@7.29.7",
+        "cogseed@1.0.2|@babel/helper-validator-identifier@7.29.7"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|source-map-js@1.2.1"
+      "ref": "cogseed@1.0.2|source-map-js@1.2.1"
     },
     {
-      "ref": "cogseed@0.9.0|file-uri-to-path@1.0.0"
+      "ref": "cogseed@1.0.2|file-uri-to-path@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|detect-libc@2.1.2"
+      "ref": "cogseed@1.0.2|detect-libc@2.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|expand-template@2.0.3"
+      "ref": "cogseed@1.0.2|expand-template@2.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|github-from-package@0.0.0"
+      "ref": "cogseed@1.0.2|github-from-package@0.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|minimist@1.2.8"
+      "ref": "cogseed@1.0.2|minimist@1.2.8"
     },
     {
-      "ref": "cogseed@0.9.0|mkdirp-classic@0.5.3"
+      "ref": "cogseed@1.0.2|mkdirp-classic@0.5.3"
     },
     {
-      "ref": "cogseed@0.9.0|napi-build-utils@2.0.0"
+      "ref": "cogseed@1.0.2|napi-build-utils@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|node-abi@3.89.0",
+      "ref": "cogseed@1.0.2|node-abi@3.89.0",
       "dependsOn": [
-        "cogseed@0.9.0|semver@7.8.5"
+        "cogseed@1.0.2|semver@7.8.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|pump@3.0.4",
+      "ref": "cogseed@1.0.2|pump@3.0.4",
       "dependsOn": [
-        "cogseed@0.9.0|end-of-stream@1.4.5",
-        "cogseed@0.9.0|once@1.4.0"
+        "cogseed@1.0.2|end-of-stream@1.4.5",
+        "cogseed@1.0.2|once@1.4.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|rc@1.2.8",
+      "ref": "cogseed@1.0.2|rc@1.2.8",
       "dependsOn": [
-        "cogseed@0.9.0|deep-extend@0.6.0",
-        "cogseed@0.9.0|ini@1.3.8",
-        "cogseed@0.9.0|minimist@1.2.8",
-        "cogseed@0.9.0|strip-json-comments@2.0.1"
+        "cogseed@1.0.2|deep-extend@0.6.0",
+        "cogseed@1.0.2|ini@1.3.8",
+        "cogseed@1.0.2|minimist@1.2.8",
+        "cogseed@1.0.2|strip-json-comments@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|simple-get@4.0.1",
+      "ref": "cogseed@1.0.2|simple-get@4.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|decompress-response@6.0.0",
-        "cogseed@0.9.0|once@1.4.0",
-        "cogseed@0.9.0|simple-concat@1.0.1"
+        "cogseed@1.0.2|decompress-response@6.0.0",
+        "cogseed@1.0.2|once@1.4.0",
+        "cogseed@1.0.2|simple-concat@1.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|tar-fs@2.1.4",
+      "ref": "cogseed@1.0.2|tar-fs@2.1.4",
       "dependsOn": [
-        "cogseed@0.9.0|chownr@1.1.4",
-        "cogseed@0.9.0|mkdirp-classic@0.5.3",
-        "cogseed@0.9.0|pump@3.0.4",
-        "cogseed@0.9.0|tar-stream@2.2.0"
+        "cogseed@1.0.2|chownr@1.1.4",
+        "cogseed@1.0.2|mkdirp-classic@0.5.3",
+        "cogseed@1.0.2|pump@3.0.4",
+        "cogseed@1.0.2|tar-stream@2.2.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|tunnel-agent@0.6.0",
+      "ref": "cogseed@1.0.2|tunnel-agent@0.6.0",
       "dependsOn": [
-        "cogseed@0.9.0|safe-buffer@5.2.1"
+        "cogseed@1.0.2|safe-buffer@5.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/asar@3.4.1",
+      "ref": "cogseed@1.0.2|@electron/asar@3.4.1",
       "dependsOn": [
-        "cogseed@0.9.0|commander@5.1.0",
-        "cogseed@0.9.0|glob@7.2.3",
-        "cogseed@0.9.0|@electron/asar@3.4.1|minimatch@3.1.5"
+        "cogseed@1.0.2|commander@5.1.0",
+        "cogseed@1.0.2|glob@7.2.3",
+        "cogseed@1.0.2|@electron/asar@3.4.1|minimatch@3.1.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/asar@3.4.1|minimatch@3.1.5",
+      "ref": "cogseed@1.0.2|@electron/asar@3.4.1|minimatch@3.1.5",
       "dependsOn": [
-        "cogseed@0.9.0|@electron/asar@3.4.1|brace-expansion@1.1.18"
+        "cogseed@1.0.2|@electron/asar@3.4.1|brace-expansion@1.1.18"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/asar@3.4.1|brace-expansion@1.1.18",
+      "ref": "cogseed@1.0.2|@electron/asar@3.4.1|brace-expansion@1.1.18",
       "dependsOn": [
-        "cogseed@0.9.0|@electron/asar@3.4.1|balanced-match@1.0.2",
-        "cogseed@0.9.0|concat-map@0.0.1"
+        "cogseed@1.0.2|@electron/asar@3.4.1|balanced-match@1.0.2",
+        "cogseed@1.0.2|concat-map@0.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/asar@3.4.1|balanced-match@1.0.2"
+      "ref": "cogseed@1.0.2|@electron/asar@3.4.1|balanced-match@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@electron/fuses@1.8.0",
+      "ref": "cogseed@1.0.2|@electron/fuses@1.8.0",
       "dependsOn": [
-        "cogseed@0.9.0|chalk@4.1.2",
-        "cogseed@0.9.0|@electron/fuses@1.8.0|fs-extra@9.1.0",
-        "cogseed@0.9.0|minimist@1.2.8"
+        "cogseed@1.0.2|chalk@4.1.2",
+        "cogseed@1.0.2|@electron/fuses@1.8.0|fs-extra@9.1.0",
+        "cogseed@1.0.2|minimist@1.2.8"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/fuses@1.8.0|fs-extra@9.1.0",
+      "ref": "cogseed@1.0.2|@electron/fuses@1.8.0|fs-extra@9.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|at-least-node@1.0.0",
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|jsonfile@6.2.1",
-        "cogseed@0.9.0|universalify@2.0.1"
+        "cogseed@1.0.2|at-least-node@1.0.0",
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|jsonfile@6.2.1",
+        "cogseed@1.0.2|universalify@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/notarize@2.5.0",
+      "ref": "cogseed@1.0.2|@electron/notarize@2.5.0",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|@electron/notarize@2.5.0|fs-extra@9.1.0",
-        "cogseed@0.9.0|promise-retry@2.0.1"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|@electron/notarize@2.5.0|fs-extra@9.1.0",
+        "cogseed@1.0.2|promise-retry@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/notarize@2.5.0|fs-extra@9.1.0",
+      "ref": "cogseed@1.0.2|@electron/notarize@2.5.0|fs-extra@9.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|at-least-node@1.0.0",
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|jsonfile@6.2.1",
-        "cogseed@0.9.0|universalify@2.0.1"
+        "cogseed@1.0.2|at-least-node@1.0.0",
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|jsonfile@6.2.1",
+        "cogseed@1.0.2|universalify@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/osx-sign@1.3.3",
+      "ref": "cogseed@1.0.2|@electron/osx-sign@1.3.3",
       "dependsOn": [
-        "cogseed@0.9.0|compare-version@0.1.2",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|fs-extra@10.1.0",
-        "cogseed@0.9.0|@electron/osx-sign@1.3.3|isbinaryfile@4.0.10",
-        "cogseed@0.9.0|minimist@1.2.8",
-        "cogseed@0.9.0|plist@3.1.0"
+        "cogseed@1.0.2|compare-version@0.1.2",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|fs-extra@10.1.0",
+        "cogseed@1.0.2|@electron/osx-sign@1.3.3|isbinaryfile@4.0.10",
+        "cogseed@1.0.2|minimist@1.2.8",
+        "cogseed@1.0.2|plist@3.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/osx-sign@1.3.3|isbinaryfile@4.0.10"
+      "ref": "cogseed@1.0.2|@electron/osx-sign@1.3.3|isbinaryfile@4.0.10"
     },
     {
-      "ref": "cogseed@0.9.0|@electron/universal@2.0.3",
+      "ref": "cogseed@1.0.2|@electron/universal@2.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|@electron/asar@3.4.1",
-        "cogseed@0.9.0|@malept/cross-spawn-promise@2.0.0",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|dir-compare@4.2.0",
-        "cogseed@0.9.0|@electron/universal@2.0.3|fs-extra@11.4.0",
-        "cogseed@0.9.0|@electron/universal@2.0.3|minimatch@9.0.9",
-        "cogseed@0.9.0|plist@3.1.0"
+        "cogseed@1.0.2|@electron/asar@3.4.1",
+        "cogseed@1.0.2|@malept/cross-spawn-promise@2.0.0",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|dir-compare@4.2.0",
+        "cogseed@1.0.2|@electron/universal@2.0.3|fs-extra@11.4.0",
+        "cogseed@1.0.2|@electron/universal@2.0.3|minimatch@9.0.9",
+        "cogseed@1.0.2|plist@3.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/universal@2.0.3|fs-extra@11.4.0",
+      "ref": "cogseed@1.0.2|@electron/universal@2.0.3|fs-extra@11.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|jsonfile@6.2.1",
-        "cogseed@0.9.0|universalify@2.0.1"
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|jsonfile@6.2.1",
+        "cogseed@1.0.2|universalify@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/universal@2.0.3|minimatch@9.0.9",
+      "ref": "cogseed@1.0.2|@electron/universal@2.0.3|minimatch@9.0.9",
       "dependsOn": [
-        "cogseed@0.9.0|@electron/universal@2.0.3|brace-expansion@2.1.4"
+        "cogseed@1.0.2|@electron/universal@2.0.3|brace-expansion@2.1.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/universal@2.0.3|brace-expansion@2.1.4",
+      "ref": "cogseed@1.0.2|@electron/universal@2.0.3|brace-expansion@2.1.4",
       "dependsOn": [
-        "cogseed@0.9.0|@electron/universal@2.0.3|balanced-match@1.0.2"
+        "cogseed@1.0.2|@electron/universal@2.0.3|balanced-match@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/universal@2.0.3|balanced-match@1.0.2"
+      "ref": "cogseed@1.0.2|@electron/universal@2.0.3|balanced-match@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@malept/flatpak-bundler@0.4.0",
+      "ref": "cogseed@1.0.2|@malept/flatpak-bundler@0.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|@malept/flatpak-bundler@0.4.0|fs-extra@9.1.0",
-        "cogseed@0.9.0|lodash@4.18.1",
-        "cogseed@0.9.0|tmp-promise@3.0.3"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|@malept/flatpak-bundler@0.4.0|fs-extra@9.1.0",
+        "cogseed@1.0.2|lodash@4.18.1",
+        "cogseed@1.0.2|tmp-promise@3.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@malept/flatpak-bundler@0.4.0|fs-extra@9.1.0",
+      "ref": "cogseed@1.0.2|@malept/flatpak-bundler@0.4.0|fs-extra@9.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|at-least-node@1.0.0",
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|jsonfile@6.2.1",
-        "cogseed@0.9.0|universalify@2.0.1"
+        "cogseed@1.0.2|at-least-node@1.0.0",
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|jsonfile@6.2.1",
+        "cogseed@1.0.2|universalify@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@noble/hashes@2.3.0"
+      "ref": "cogseed@1.0.2|@noble/hashes@2.3.0"
     },
     {
-      "ref": "cogseed@0.9.0|@peculiar/webcrypto@1.7.1",
+      "ref": "cogseed@1.0.2|@peculiar/webcrypto@1.7.1",
       "dependsOn": [
-        "cogseed@0.9.0|@peculiar/asn1-schema@2.9.3",
-        "cogseed@0.9.0|@peculiar/json-schema@1.1.12",
-        "cogseed@0.9.0|@peculiar/utils@2.0.3",
-        "cogseed@0.9.0|tslib@2.8.1",
-        "cogseed@0.9.0|webcrypto-core@1.9.2"
+        "cogseed@1.0.2|@peculiar/asn1-schema@2.9.3",
+        "cogseed@1.0.2|@peculiar/json-schema@1.1.12",
+        "cogseed@1.0.2|@peculiar/utils@2.0.3",
+        "cogseed@1.0.2|tslib@2.8.1",
+        "cogseed@1.0.2|webcrypto-core@1.9.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@types/fs-extra@9.0.13",
+      "ref": "cogseed@1.0.2|@types/fs-extra@9.0.13",
       "dependsOn": [
-        "cogseed@0.9.0|@types/node@25.6.0"
+        "cogseed@1.0.2|@types/node@25.6.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|asn1js@3.0.10",
+      "ref": "cogseed@1.0.2|asn1js@3.0.10",
       "dependsOn": [
-        "cogseed@0.9.0|pvtsutils@1.3.6",
-        "cogseed@0.9.0|pvutils@1.2.0",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|pvtsutils@1.3.6",
+        "cogseed@1.0.2|pvutils@1.2.0",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|async-exit-hook@2.0.1"
+      "ref": "cogseed@1.0.2|async-exit-hook@2.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|chromium-pickle-js@0.2.0"
+      "ref": "cogseed@1.0.2|chromium-pickle-js@0.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|dotenv-expand@11.0.7",
+      "ref": "cogseed@1.0.2|dotenv-expand@11.0.7",
       "dependsOn": [
-        "cogseed@0.9.0|dotenv@16.6.1"
+        "cogseed@1.0.2|dotenv@16.6.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|dotenv@16.6.1"
+      "ref": "cogseed@1.0.2|dotenv@16.6.1"
     },
     {
-      "ref": "cogseed@0.9.0|ejs@3.1.10",
+      "ref": "cogseed@1.0.2|ejs@3.1.10",
       "dependsOn": [
-        "cogseed@0.9.0|jake@10.9.4"
+        "cogseed@1.0.2|jake@10.9.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-builder-squirrel-windows@26.15.7",
+      "ref": "cogseed@1.0.2|electron-builder-squirrel-windows@26.15.7",
       "dependsOn": [
-        "cogseed@0.9.0|app-builder-lib@26.15.7",
-        "cogseed@0.9.0|builder-util@26.15.3",
-        "cogseed@0.9.0|electron-winstaller@5.4.0"
+        "cogseed@1.0.2|app-builder-lib@26.15.7",
+        "cogseed@1.0.2|builder-util@26.15.3",
+        "cogseed@1.0.2|electron-winstaller@5.4.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-publish@26.15.3",
+      "ref": "cogseed@1.0.2|electron-publish@26.15.3",
       "dependsOn": [
-        "cogseed@0.9.0|@types/fs-extra@9.0.13",
-        "cogseed@0.9.0|aws4@1.13.2",
-        "cogseed@0.9.0|builder-util-runtime@9.7.0",
-        "cogseed@0.9.0|builder-util@26.15.3",
-        "cogseed@0.9.0|chalk@4.1.2",
-        "cogseed@0.9.0|form-data@4.0.6",
-        "cogseed@0.9.0|fs-extra@10.1.0",
-        "cogseed@0.9.0|lazy-val@1.0.5",
-        "cogseed@0.9.0|electron-publish@26.15.3|mime@2.6.0"
+        "cogseed@1.0.2|@types/fs-extra@9.0.13",
+        "cogseed@1.0.2|aws4@1.13.2",
+        "cogseed@1.0.2|builder-util-runtime@9.7.0",
+        "cogseed@1.0.2|builder-util@26.15.3",
+        "cogseed@1.0.2|chalk@4.1.2",
+        "cogseed@1.0.2|form-data@4.0.6",
+        "cogseed@1.0.2|fs-extra@10.1.0",
+        "cogseed@1.0.2|lazy-val@1.0.5",
+        "cogseed@1.0.2|electron-publish@26.15.3|mime@2.6.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-publish@26.15.3|mime@2.6.0"
+      "ref": "cogseed@1.0.2|electron-publish@26.15.3|mime@2.6.0"
     },
     {
-      "ref": "cogseed@0.9.0|hosted-git-info@4.1.0",
+      "ref": "cogseed@1.0.2|hosted-git-info@4.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|lru-cache@6.0.0"
+        "cogseed@1.0.2|lru-cache@6.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|isbinaryfile@5.0.7"
+      "ref": "cogseed@1.0.2|isbinaryfile@5.0.7"
     },
     {
-      "ref": "cogseed@0.9.0|js-yaml@4.3.2",
+      "ref": "cogseed@1.0.2|js-yaml@4.3.2",
       "dependsOn": [
-        "cogseed@0.9.0|js-yaml@4.3.2|argparse@2.0.1"
+        "cogseed@1.0.2|js-yaml@4.3.2|argparse@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|js-yaml@4.3.2|argparse@2.0.1"
+      "ref": "cogseed@1.0.2|js-yaml@4.3.2|argparse@2.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|json5@2.2.3"
+      "ref": "cogseed@1.0.2|json5@2.2.3"
     },
     {
-      "ref": "cogseed@0.9.0|pkijs@3.4.0",
+      "ref": "cogseed@1.0.2|pkijs@3.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|pkijs@3.4.0|@noble/hashes@1.4.0",
-        "cogseed@0.9.0|asn1js@3.0.10",
-        "cogseed@0.9.0|bytestreamjs@2.0.1",
-        "cogseed@0.9.0|pvtsutils@1.3.6",
-        "cogseed@0.9.0|pvutils@1.2.0",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|pkijs@3.4.0|@noble/hashes@1.4.0",
+        "cogseed@1.0.2|asn1js@3.0.10",
+        "cogseed@1.0.2|bytestreamjs@2.0.1",
+        "cogseed@1.0.2|pvtsutils@1.3.6",
+        "cogseed@1.0.2|pvutils@1.2.0",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|pkijs@3.4.0|@noble/hashes@1.4.0"
+      "ref": "cogseed@1.0.2|pkijs@3.4.0|@noble/hashes@1.4.0"
     },
     {
-      "ref": "cogseed@0.9.0|plist@3.1.0",
+      "ref": "cogseed@1.0.2|plist@3.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|@xmldom/xmldom@0.8.15",
-        "cogseed@0.9.0|base64-js@1.5.1",
-        "cogseed@0.9.0|plist@3.1.0|xmlbuilder@15.1.1"
+        "cogseed@1.0.2|@xmldom/xmldom@0.8.15",
+        "cogseed@1.0.2|base64-js@1.5.1",
+        "cogseed@1.0.2|plist@3.1.0|xmlbuilder@15.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|plist@3.1.0|xmlbuilder@15.1.1"
+      "ref": "cogseed@1.0.2|plist@3.1.0|xmlbuilder@15.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|proper-lockfile@4.1.2",
+      "ref": "cogseed@1.0.2|proper-lockfile@4.1.2",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|proper-lockfile@4.1.2|retry@0.12.0",
-        "cogseed@0.9.0|signal-exit@3.0.7"
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|proper-lockfile@4.1.2|retry@0.12.0",
+        "cogseed@1.0.2|signal-exit@3.0.7"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|proper-lockfile@4.1.2|retry@0.12.0"
+      "ref": "cogseed@1.0.2|proper-lockfile@4.1.2|retry@0.12.0"
     },
     {
-      "ref": "cogseed@0.9.0|resedit@1.7.2",
+      "ref": "cogseed@1.0.2|resedit@1.7.2",
       "dependsOn": [
-        "cogseed@0.9.0|pe-library@0.4.1"
+        "cogseed@1.0.2|pe-library@0.4.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|temp-file@3.4.0",
+      "ref": "cogseed@1.0.2|temp-file@3.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|async-exit-hook@2.0.1",
-        "cogseed@0.9.0|fs-extra@10.1.0"
+        "cogseed@1.0.2|async-exit-hook@2.0.1",
+        "cogseed@1.0.2|fs-extra@10.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|tiny-async-pool@1.3.0",
+      "ref": "cogseed@1.0.2|tiny-async-pool@1.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|tiny-async-pool@1.3.0|semver@5.7.2"
+        "cogseed@1.0.2|tiny-async-pool@1.3.0|semver@5.7.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|tiny-async-pool@1.3.0|semver@5.7.2"
+      "ref": "cogseed@1.0.2|tiny-async-pool@1.3.0|semver@5.7.2"
     },
     {
-      "ref": "cogseed@0.9.0|unzipper@0.12.5",
+      "ref": "cogseed@1.0.2|unzipper@0.12.5",
       "dependsOn": [
-        "cogseed@0.9.0|unzipper@0.12.5|bluebird@3.7.2",
-        "cogseed@0.9.0|duplexer2@0.1.4",
-        "cogseed@0.9.0|unzipper@0.12.5|fs-extra@11.3.1",
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|node-int64@0.4.0"
+        "cogseed@1.0.2|unzipper@0.12.5|bluebird@3.7.2",
+        "cogseed@1.0.2|duplexer2@0.1.4",
+        "cogseed@1.0.2|unzipper@0.12.5|fs-extra@11.3.1",
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|node-int64@0.4.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|unzipper@0.12.5|bluebird@3.7.2"
+      "ref": "cogseed@1.0.2|unzipper@0.12.5|bluebird@3.7.2"
     },
     {
-      "ref": "cogseed@0.9.0|unzipper@0.12.5|fs-extra@11.3.1",
+      "ref": "cogseed@1.0.2|unzipper@0.12.5|fs-extra@11.3.1",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|jsonfile@6.2.1",
-        "cogseed@0.9.0|universalify@2.0.1"
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|jsonfile@6.2.1",
+        "cogseed@1.0.2|universalify@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|sax@1.6.0"
+      "ref": "cogseed@1.0.2|sax@1.6.0"
     },
     {
-      "ref": "cogseed@0.9.0|@types/debug@4.1.13",
+      "ref": "cogseed@1.0.2|@types/debug@4.1.13",
       "dependsOn": [
-        "cogseed@0.9.0|@types/ms@2.1.0"
+        "cogseed@1.0.2|@types/ms@2.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|sanitize-filename@1.6.4",
+      "ref": "cogseed@1.0.2|sanitize-filename@1.6.4",
       "dependsOn": [
-        "cogseed@0.9.0|truncate-utf8-bytes@1.0.2"
+        "cogseed@1.0.2|truncate-utf8-bytes@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|source-map-support@0.5.21",
+      "ref": "cogseed@1.0.2|source-map-support@0.5.21",
       "dependsOn": [
-        "cogseed@0.9.0|buffer-from@1.1.2",
-        "cogseed@0.9.0|source-map@0.6.1"
+        "cogseed@1.0.2|buffer-from@1.1.2",
+        "cogseed@1.0.2|source-map@0.6.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|stat-mode@1.0.0"
+      "ref": "cogseed@1.0.2|stat-mode@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|ansi-styles@4.3.0",
+      "ref": "cogseed@1.0.2|ansi-styles@4.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|color-convert@2.0.1"
+        "cogseed@1.0.2|color-convert@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|jsonfile@6.2.1",
+      "ref": "cogseed@1.0.2|jsonfile@6.2.1",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|universalify@2.0.1"
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|universalify@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|universalify@2.0.1"
+      "ref": "cogseed@1.0.2|universalify@2.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|cliui@8.0.1",
+      "ref": "cogseed@1.0.2|cliui@8.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|string-width@4.2.3",
-        "cogseed@0.9.0|strip-ansi@6.0.1",
-        "cogseed@0.9.0|wrap-ansi@7.0.0"
+        "cogseed@1.0.2|string-width@4.2.3",
+        "cogseed@1.0.2|strip-ansi@6.0.1",
+        "cogseed@1.0.2|wrap-ansi@7.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|escalade@3.2.0"
+      "ref": "cogseed@1.0.2|escalade@3.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|get-caller-file@2.0.5"
+      "ref": "cogseed@1.0.2|get-caller-file@2.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|require-directory@2.1.1"
+      "ref": "cogseed@1.0.2|require-directory@2.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|string-width@4.2.3",
+      "ref": "cogseed@1.0.2|string-width@4.2.3",
       "dependsOn": [
-        "cogseed@0.9.0|emoji-regex@8.0.0",
-        "cogseed@0.9.0|is-fullwidth-code-point@3.0.0",
-        "cogseed@0.9.0|strip-ansi@6.0.1"
+        "cogseed@1.0.2|emoji-regex@8.0.0",
+        "cogseed@1.0.2|is-fullwidth-code-point@3.0.0",
+        "cogseed@1.0.2|strip-ansi@6.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|y18n@5.0.8"
+      "ref": "cogseed@1.0.2|y18n@5.0.8"
     },
     {
-      "ref": "cogseed@0.9.0|yargs-parser@21.1.1"
+      "ref": "cogseed@1.0.2|yargs-parser@21.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|sumchecker@3.0.1",
+      "ref": "cogseed@1.0.2|sumchecker@3.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3"
+        "cogseed@1.0.2|debug@4.4.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|undici-types@7.16.0"
+      "ref": "cogseed@1.0.2|undici-types@7.16.0"
     },
     {
-      "ref": "cogseed@0.9.0|@eslint/object-schema@3.0.5"
+      "ref": "cogseed@1.0.2|@eslint/object-schema@3.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|@types/json-schema@7.0.15"
+      "ref": "cogseed@1.0.2|@types/json-schema@7.0.15"
     },
     {
-      "ref": "cogseed@0.9.0|levn@0.4.1",
+      "ref": "cogseed@1.0.2|levn@0.4.1",
       "dependsOn": [
-        "cogseed@0.9.0|prelude-ls@1.2.1",
-        "cogseed@0.9.0|type-check@0.4.0"
+        "cogseed@1.0.2|prelude-ls@1.2.1",
+        "cogseed@1.0.2|type-check@0.4.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@humanfs/core@0.19.2",
+      "ref": "cogseed@1.0.2|@humanfs/core@0.19.2",
       "dependsOn": [
-        "cogseed@0.9.0|@humanfs/types@0.15.0"
+        "cogseed@1.0.2|@humanfs/types@0.15.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@humanfs/types@0.15.0"
+      "ref": "cogseed@1.0.2|@humanfs/types@0.15.0"
     },
     {
-      "ref": "cogseed@0.9.0|fast-json-stable-stringify@2.1.0"
+      "ref": "cogseed@1.0.2|fast-json-stable-stringify@2.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|uri-js@4.4.1",
+      "ref": "cogseed@1.0.2|uri-js@4.4.1",
       "dependsOn": [
-        "cogseed@0.9.0|punycode@2.3.1"
+        "cogseed@1.0.2|punycode@2.3.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@types/esrecurse@4.3.1"
+      "ref": "cogseed@1.0.2|@types/esrecurse@4.3.1"
     },
     {
-      "ref": "cogseed@0.9.0|esrecurse@4.3.0",
+      "ref": "cogseed@1.0.2|esrecurse@4.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|estraverse@5.3.0"
+        "cogseed@1.0.2|estraverse@5.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|estraverse@5.3.0"
+      "ref": "cogseed@1.0.2|estraverse@5.3.0"
     },
     {
-      "ref": "cogseed@0.9.0|acorn-jsx@5.3.2",
+      "ref": "cogseed@1.0.2|acorn-jsx@5.3.2",
       "dependsOn": [
-        "cogseed@0.9.0|acorn@8.18.0"
+        "cogseed@1.0.2|acorn@8.18.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|acorn@8.18.0"
+      "ref": "cogseed@1.0.2|acorn@8.18.0"
     },
     {
-      "ref": "cogseed@0.9.0|flat-cache@4.0.1",
+      "ref": "cogseed@1.0.2|flat-cache@4.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|flatted@3.4.4",
-        "cogseed@0.9.0|keyv@4.5.4"
+        "cogseed@1.0.2|flatted@3.4.4",
+        "cogseed@1.0.2|keyv@4.5.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|locate-path@6.0.0",
+      "ref": "cogseed@1.0.2|locate-path@6.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|p-locate@5.0.0"
+        "cogseed@1.0.2|p-locate@5.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|path-exists@4.0.0"
+      "ref": "cogseed@1.0.2|path-exists@4.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|is-extglob@2.1.1"
+      "ref": "cogseed@1.0.2|is-extglob@2.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|brace-expansion@5.0.9",
+      "ref": "cogseed@1.0.2|brace-expansion@5.0.9",
       "dependsOn": [
-        "cogseed@0.9.0|balanced-match@4.0.4"
+        "cogseed@1.0.2|balanced-match@4.0.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|deep-is@0.1.4"
+      "ref": "cogseed@1.0.2|deep-is@0.1.4"
     },
     {
-      "ref": "cogseed@0.9.0|fast-levenshtein@2.0.6"
+      "ref": "cogseed@1.0.2|fast-levenshtein@2.0.6"
     },
     {
-      "ref": "cogseed@0.9.0|prelude-ls@1.2.1"
+      "ref": "cogseed@1.0.2|prelude-ls@1.2.1"
     },
     {
-      "ref": "cogseed@0.9.0|type-check@0.4.0",
+      "ref": "cogseed@1.0.2|type-check@0.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|prelude-ls@1.2.1"
+        "cogseed@1.0.2|prelude-ls@1.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|word-wrap@1.2.5"
+      "ref": "cogseed@1.0.2|word-wrap@1.2.5"
     },
     {
-      "ref": "cogseed@0.9.0|@anush008/tokenizers-darwin-universal@0.0.0"
+      "ref": "cogseed@1.0.2|@anush008/tokenizers-darwin-universal@0.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|@huggingface/tasks@0.19.90"
+      "ref": "cogseed@1.0.2|@huggingface/tasks@0.19.90"
     },
     {
-      "ref": "cogseed@0.9.0|cli-progress@3.12.0",
+      "ref": "cogseed@1.0.2|cli-progress@3.12.0",
       "dependsOn": [
-        "cogseed@0.9.0|string-width@4.2.3"
+        "cogseed@1.0.2|string-width@4.2.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|global-agent@3.0.0",
+      "ref": "cogseed@1.0.2|global-agent@3.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|boolean@3.2.0",
-        "cogseed@0.9.0|es6-error@4.1.1",
-        "cogseed@0.9.0|matcher@3.0.0",
-        "cogseed@0.9.0|roarr@2.15.4",
-        "cogseed@0.9.0|semver@7.8.5",
-        "cogseed@0.9.0|serialize-error@7.0.1"
+        "cogseed@1.0.2|boolean@3.2.0",
+        "cogseed@1.0.2|es6-error@4.1.1",
+        "cogseed@1.0.2|matcher@3.0.0",
+        "cogseed@1.0.2|roarr@2.15.4",
+        "cogseed@1.0.2|semver@7.8.5",
+        "cogseed@1.0.2|serialize-error@7.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|onnxruntime-common@1.21.0"
+      "ref": "cogseed@1.0.2|onnxruntime-common@1.21.0"
     },
     {
-      "ref": "cogseed@0.9.0|@jimp/file-ops@1.6.1"
+      "ref": "cogseed@1.0.2|@jimp/file-ops@1.6.1"
     },
     {
-      "ref": "cogseed@0.9.0|await-to-js@3.0.0"
+      "ref": "cogseed@1.0.2|await-to-js@3.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|exif-parser@0.1.12"
+      "ref": "cogseed@1.0.2|exif-parser@0.1.12"
     },
     {
-      "ref": "cogseed@0.9.0|file-type@21.3.4",
+      "ref": "cogseed@1.0.2|file-type@21.3.4",
       "dependsOn": [
-        "cogseed@0.9.0|@tokenizer/inflate@0.4.1",
-        "cogseed@0.9.0|strtok3@10.3.5",
-        "cogseed@0.9.0|token-types@6.1.2",
-        "cogseed@0.9.0|uint8array-extras@1.5.0"
+        "cogseed@1.0.2|@tokenizer/inflate@0.4.1",
+        "cogseed@1.0.2|strtok3@10.3.5",
+        "cogseed@1.0.2|token-types@6.1.2",
+        "cogseed@1.0.2|uint8array-extras@1.5.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|mime@3.0.0"
+      "ref": "cogseed@1.0.2|mime@3.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|pixelmatch@5.3.0",
+      "ref": "cogseed@1.0.2|pixelmatch@5.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|pixelmatch@5.3.0|pngjs@6.0.0"
+        "cogseed@1.0.2|pixelmatch@5.3.0|pngjs@6.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|pixelmatch@5.3.0|pngjs@6.0.0"
+      "ref": "cogseed@1.0.2|pixelmatch@5.3.0|pngjs@6.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|bmp-ts@1.0.9"
+      "ref": "cogseed@1.0.2|bmp-ts@1.0.9"
     },
     {
-      "ref": "cogseed@0.9.0|gifwrap@0.10.1",
+      "ref": "cogseed@1.0.2|gifwrap@0.10.1",
       "dependsOn": [
-        "cogseed@0.9.0|image-q@4.0.0",
-        "cogseed@0.9.0|omggif@1.0.10"
+        "cogseed@1.0.2|image-q@4.0.0",
+        "cogseed@1.0.2|omggif@1.0.10"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|omggif@1.0.10"
+      "ref": "cogseed@1.0.2|omggif@1.0.10"
     },
     {
-      "ref": "cogseed@0.9.0|jpeg-js@0.4.4"
+      "ref": "cogseed@1.0.2|jpeg-js@0.4.4"
     },
     {
-      "ref": "cogseed@0.9.0|pngjs@7.0.0"
+      "ref": "cogseed@1.0.2|pngjs@7.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|utif2@4.1.0",
+      "ref": "cogseed@1.0.2|utif2@4.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|pako@1.0.11"
+        "cogseed@1.0.2|pako@1.0.11"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|tinycolor2@1.6.0"
+      "ref": "cogseed@1.0.2|tinycolor2@1.6.0"
     },
     {
-      "ref": "cogseed@0.9.0|any-base@1.1.0"
+      "ref": "cogseed@1.0.2|any-base@1.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|parse-bmfont-ascii@1.0.6"
+      "ref": "cogseed@1.0.2|parse-bmfont-ascii@1.0.6"
     },
     {
-      "ref": "cogseed@0.9.0|parse-bmfont-binary@1.0.6"
+      "ref": "cogseed@1.0.2|parse-bmfont-binary@1.0.6"
     },
     {
-      "ref": "cogseed@0.9.0|parse-bmfont-xml@1.1.6",
+      "ref": "cogseed@1.0.2|parse-bmfont-xml@1.1.6",
       "dependsOn": [
-        "cogseed@0.9.0|xml-parse-from-string@1.0.1",
-        "cogseed@0.9.0|xml2js@0.5.0"
+        "cogseed@1.0.2|xml-parse-from-string@1.0.1",
+        "cogseed@1.0.2|xml2js@0.5.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|simple-xml-to-json@1.2.7"
+      "ref": "cogseed@1.0.2|simple-xml-to-json@1.2.7"
     },
     {
-      "ref": "cogseed@0.9.0|image-q@4.0.0",
+      "ref": "cogseed@1.0.2|image-q@4.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|image-q@4.0.0|@types/node@16.9.1"
+        "cogseed@1.0.2|image-q@4.0.0|@types/node@16.9.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|image-q@4.0.0|@types/node@16.9.1"
+      "ref": "cogseed@1.0.2|image-q@4.0.0|@types/node@16.9.1"
     },
     {
-      "ref": "cogseed@0.9.0|lie@3.3.0",
+      "ref": "cogseed@1.0.2|lie@3.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|immediate@3.0.6"
+        "cogseed@1.0.2|immediate@3.0.6"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|pako@1.0.11"
+      "ref": "cogseed@1.0.2|pako@1.0.11"
     },
     {
-      "ref": "cogseed@0.9.0|setimmediate@1.0.5"
+      "ref": "cogseed@1.0.2|setimmediate@1.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|duck@0.1.12",
+      "ref": "cogseed@1.0.2|duck@0.1.12",
       "dependsOn": [
-        "cogseed@0.9.0|underscore@1.13.8"
+        "cogseed@1.0.2|underscore@1.13.8"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|option@0.2.4"
+      "ref": "cogseed@1.0.2|option@0.2.4"
     },
     {
-      "ref": "cogseed@0.9.0|@napi-rs/canvas-darwin-arm64@1.0.7"
+      "ref": "cogseed@1.0.2|@napi-rs/canvas-darwin-arm64@1.0.7"
     },
     {
-      "ref": "cogseed@0.9.0|smart-buffer@4.2.0"
+      "ref": "cogseed@1.0.2|smart-buffer@4.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/scope-manager@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/scope-manager@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@typescript-eslint/types@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/visitor-keys@8.67.0"
+        "cogseed@1.0.2|@typescript-eslint/types@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/visitor-keys@8.67.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/type-utils@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/type-utils@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@typescript-eslint/types@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/typescript-estree@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/utils@8.67.0",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|eslint@10.9.0",
-        "cogseed@0.9.0|ts-api-utils@2.5.0",
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|@typescript-eslint/types@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/typescript-estree@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/utils@8.67.0",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|eslint@10.9.0",
+        "cogseed@1.0.2|ts-api-utils@2.5.0",
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/visitor-keys@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/visitor-keys@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@typescript-eslint/types@8.67.0",
-        "cogseed@0.9.0|eslint-visitor-keys@5.0.1"
+        "cogseed@1.0.2|@typescript-eslint/types@8.67.0",
+        "cogseed@1.0.2|eslint-visitor-keys@5.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|ts-api-utils@2.5.0",
+      "ref": "cogseed@1.0.2|ts-api-utils@2.5.0",
       "dependsOn": [
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/types@8.67.0"
+      "ref": "cogseed@1.0.2|@typescript-eslint/types@8.67.0"
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/project-service@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/project-service@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|@typescript-eslint/tsconfig-utils@8.67.0",
-        "cogseed@0.9.0|@typescript-eslint/types@8.67.0",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|@typescript-eslint/tsconfig-utils@8.67.0",
+        "cogseed@1.0.2|@typescript-eslint/types@8.67.0",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@typescript-eslint/tsconfig-utils@8.67.0",
+      "ref": "cogseed@1.0.2|@typescript-eslint/tsconfig-utils@8.67.0",
       "dependsOn": [
-        "cogseed@0.9.0|typescript@6.0.3"
+        "cogseed@1.0.2|typescript@6.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@standard-schema/spec@1.1.0"
+      "ref": "cogseed@1.0.2|@standard-schema/spec@1.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|@types/chai@5.2.3",
+      "ref": "cogseed@1.0.2|@types/chai@5.2.3",
       "dependsOn": [
-        "cogseed@0.9.0|@types/deep-eql@4.0.2",
-        "cogseed@0.9.0|assertion-error@2.0.1"
+        "cogseed@1.0.2|@types/deep-eql@4.0.2",
+        "cogseed@1.0.2|assertion-error@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|chai@6.2.2"
+      "ref": "cogseed@1.0.2|chai@6.2.2"
     },
     {
-      "ref": "cogseed@0.9.0|@jridgewell/sourcemap-codec@1.5.5"
+      "ref": "cogseed@1.0.2|@jridgewell/sourcemap-codec@1.5.5"
     },
     {
-      "ref": "cogseed@0.9.0|fdir@6.5.0",
+      "ref": "cogseed@1.0.2|fdir@6.5.0",
       "dependsOn": [
-        "cogseed@0.9.0|picomatch@4.0.5"
+        "cogseed@1.0.2|picomatch@4.0.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|lightningcss@1.33.0",
+      "ref": "cogseed@1.0.2|lightningcss@1.33.0",
       "dependsOn": [
-        "cogseed@0.9.0|detect-libc@2.1.2",
-        "cogseed@0.9.0|lightningcss-darwin-arm64@1.33.0"
+        "cogseed@1.0.2|detect-libc@2.1.2",
+        "cogseed@1.0.2|lightningcss-darwin-arm64@1.33.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|postcss@8.5.26",
+      "ref": "cogseed@1.0.2|postcss@8.5.26",
       "dependsOn": [
-        "cogseed@0.9.0|nanoid@3.3.18",
-        "cogseed@0.9.0|picocolors@1.1.1",
-        "cogseed@0.9.0|source-map-js@1.2.1"
+        "cogseed@1.0.2|nanoid@3.3.18",
+        "cogseed@1.0.2|picocolors@1.1.1",
+        "cogseed@1.0.2|source-map-js@1.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|rolldown@1.2.5",
+      "ref": "cogseed@1.0.2|rolldown@1.2.5",
       "dependsOn": [
-        "cogseed@0.9.0|@oxc-project/types@0.146.0",
-        "cogseed@0.9.0|@rolldown/binding-darwin-arm64@1.2.5",
-        "cogseed@0.9.0|@rolldown/pluginutils@1.0.1"
+        "cogseed@1.0.2|@oxc-project/types@0.146.0",
+        "cogseed@1.0.2|@rolldown/binding-darwin-arm64@1.2.5",
+        "cogseed@1.0.2|@rolldown/pluginutils@1.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|siginfo@2.0.0"
+      "ref": "cogseed@1.0.2|siginfo@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|stackback@0.0.2"
+      "ref": "cogseed@1.0.2|stackback@0.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@babel/runtime@7.29.7"
+      "ref": "cogseed@1.0.2|@babel/runtime@7.29.7"
     },
     {
-      "ref": "cogseed@0.9.0|ts-algebra@2.0.0"
+      "ref": "cogseed@1.0.2|ts-algebra@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|@aws-crypto/supports-web-crypto@5.2.0",
+      "ref": "cogseed@1.0.2|@aws-crypto/supports-web-crypto@5.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-crypto/util@5.2.0",
+      "ref": "cogseed@1.0.2|@aws-crypto/util@5.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/util-utf8@2.3.0",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/util-utf8@2.3.0",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/util-locate-window@3.965.5",
+      "ref": "cogseed@1.0.2|@aws-sdk/util-locate-window@3.965.5",
       "dependsOn": [
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/util-utf8@2.3.0",
+      "ref": "cogseed@1.0.2|@smithy/util-utf8@2.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/util-buffer-from@2.2.0",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/util-buffer-from@2.2.0",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/xml-builder@3.972.26",
+      "ref": "cogseed@1.0.2|@aws-sdk/xml-builder@3.972.26",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|fast-xml-parser@5.7.3",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|fast-xml-parser@5.7.3",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws/lambda-invoke-store@0.2.4"
+      "ref": "cogseed@1.0.2|@aws/lambda-invoke-store@0.2.4"
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/signature-v4@5.4.5",
+      "ref": "cogseed@1.0.2|@smithy/signature-v4@5.4.5",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|bowser@2.14.1"
+      "ref": "cogseed@1.0.2|bowser@2.14.1"
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-env@3.972.41",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-env@3.972.41",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-http@3.972.43",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-http@3.972.43",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/fetch-http-handler@5.4.5",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-http@3.972.43|@smithy/node-http-handler@4.7.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/fetch-http-handler@5.4.5",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-http@3.972.43|@smithy/node-http-handler@4.7.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-http@3.972.43|@smithy/node-http-handler@4.7.5",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-http@3.972.43|@smithy/node-http-handler@4.7.5",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-ini@3.972.46",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-ini@3.972.46",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-env@3.972.41",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-http@3.972.43",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-login@3.972.45",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-process@3.972.41",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-sso@3.972.45",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-web-identity@3.972.45",
-        "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/credential-provider-imds@4.3.6",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-env@3.972.41",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-http@3.972.43",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-login@3.972.45",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-process@3.972.41",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-sso@3.972.45",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-web-identity@3.972.45",
+        "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/credential-provider-imds@4.3.6",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-process@3.972.41",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-process@3.972.41",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-sso@3.972.45",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-sso@3.972.45",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13",
-        "cogseed@0.9.0|@aws-sdk/credential-provider-sso@3.972.45|@aws-sdk/token-providers@3.1056.0",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13",
+        "cogseed@1.0.2|@aws-sdk/credential-provider-sso@3.972.45|@aws-sdk/token-providers@3.1056.0",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-sso@3.972.45|@aws-sdk/token-providers@3.1056.0",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-sso@3.972.45|@aws-sdk/token-providers@3.1056.0",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-web-identity@3.972.45",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-web-identity@3.972.45",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/credential-provider-imds@4.3.6",
+      "ref": "cogseed@1.0.2|@smithy/credential-provider-imds@4.3.6",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13",
+      "ref": "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-crypto/sha256-browser@5.2.0",
-        "cogseed@0.9.0|@aws-crypto/sha256-js@5.2.0",
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/signature-v4-multi-region@3.996.30",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/fetch-http-handler@5.4.5",
-        "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13|@smithy/node-http-handler@4.7.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-crypto/sha256-browser@5.2.0",
+        "cogseed@1.0.2|@aws-crypto/sha256-js@5.2.0",
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/signature-v4-multi-region@3.996.30",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/fetch-http-handler@5.4.5",
+        "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13|@smithy/node-http-handler@4.7.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13|@smithy/node-http-handler@4.7.5",
+      "ref": "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13|@smithy/node-http-handler@4.7.5",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-crypto/crc32@5.2.0",
+      "ref": "cogseed@1.0.2|@aws-crypto/crc32@5.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-crypto/util@5.2.0",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-crypto/util@5.2.0",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|ecdsa-sig-formatter@1.0.11",
+      "ref": "cogseed@1.0.2|ecdsa-sig-formatter@1.0.11",
       "dependsOn": [
-        "cogseed@0.9.0|safe-buffer@5.2.1"
+        "cogseed@1.0.2|safe-buffer@5.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|gaxios@7.1.4",
+      "ref": "cogseed@1.0.2|gaxios@7.1.4",
       "dependsOn": [
-        "cogseed@0.9.0|extend@3.0.2",
-        "cogseed@0.9.0|https-proxy-agent@7.0.6",
-        "cogseed@0.9.0|node-fetch@3.3.2"
+        "cogseed@1.0.2|extend@3.0.2",
+        "cogseed@1.0.2|https-proxy-agent@7.0.6",
+        "cogseed@1.0.2|node-fetch@3.3.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|gcp-metadata@8.1.2",
+      "ref": "cogseed@1.0.2|gcp-metadata@8.1.2",
       "dependsOn": [
-        "cogseed@0.9.0|gaxios@7.1.4",
-        "cogseed@0.9.0|google-logging-utils@1.1.3",
-        "cogseed@0.9.0|json-bigint@1.0.0"
+        "cogseed@1.0.2|gaxios@7.1.4",
+        "cogseed@1.0.2|google-logging-utils@1.1.3",
+        "cogseed@1.0.2|json-bigint@1.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|google-logging-utils@1.1.3"
+      "ref": "cogseed@1.0.2|google-logging-utils@1.1.3"
     },
     {
-      "ref": "cogseed@0.9.0|jws@4.0.1",
+      "ref": "cogseed@1.0.2|jws@4.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|jwa@2.0.1",
-        "cogseed@0.9.0|safe-buffer@5.2.1"
+        "cogseed@1.0.2|jwa@2.0.1",
+        "cogseed@1.0.2|safe-buffer@5.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@types/retry@0.12.0"
+      "ref": "cogseed@1.0.2|@types/retry@0.12.0"
     },
     {
-      "ref": "cogseed@0.9.0|retry@0.13.1"
+      "ref": "cogseed@1.0.2|retry@0.13.1"
     },
     {
-      "ref": "cogseed@0.9.0|abbrev@4.0.0"
+      "ref": "cogseed@1.0.2|abbrev@4.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|asynckit@0.4.0"
+      "ref": "cogseed@1.0.2|asynckit@0.4.0"
     },
     {
-      "ref": "cogseed@0.9.0|combined-stream@1.0.8",
+      "ref": "cogseed@1.0.2|combined-stream@1.0.8",
       "dependsOn": [
-        "cogseed@0.9.0|delayed-stream@1.0.0"
+        "cogseed@1.0.2|delayed-stream@1.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|es-set-tostringtag@2.1.0",
+      "ref": "cogseed@1.0.2|es-set-tostringtag@2.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|get-intrinsic@1.3.0",
-        "cogseed@0.9.0|has-tostringtag@1.0.2",
-        "cogseed@0.9.0|hasown@2.0.4"
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|get-intrinsic@1.3.0",
+        "cogseed@1.0.2|has-tostringtag@1.0.2",
+        "cogseed@1.0.2|hasown@2.0.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|hasown@2.0.4",
+      "ref": "cogseed@1.0.2|hasown@2.0.4",
       "dependsOn": [
-        "cogseed@0.9.0|function-bind@1.1.2"
+        "cogseed@1.0.2|function-bind@1.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|mime-types@2.1.35",
+      "ref": "cogseed@1.0.2|mime-types@2.1.35",
       "dependsOn": [
-        "cogseed@0.9.0|mime-db@1.52.0"
+        "cogseed@1.0.2|mime-db@1.52.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|es-errors@1.3.0"
+      "ref": "cogseed@1.0.2|es-errors@1.3.0"
     },
     {
-      "ref": "cogseed@0.9.0|object-inspect@1.13.4"
+      "ref": "cogseed@1.0.2|object-inspect@1.13.4"
     },
     {
-      "ref": "cogseed@0.9.0|side-channel-list@1.0.1",
+      "ref": "cogseed@1.0.2|side-channel-list@1.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|object-inspect@1.13.4"
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|object-inspect@1.13.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|side-channel-map@1.0.1",
+      "ref": "cogseed@1.0.2|side-channel-map@1.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|call-bound@1.0.4",
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|get-intrinsic@1.3.0",
-        "cogseed@0.9.0|object-inspect@1.13.4"
+        "cogseed@1.0.2|call-bound@1.0.4",
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|get-intrinsic@1.3.0",
+        "cogseed@1.0.2|object-inspect@1.13.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|side-channel-weakmap@1.0.2",
+      "ref": "cogseed@1.0.2|side-channel-weakmap@1.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|call-bound@1.0.4",
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|get-intrinsic@1.3.0",
-        "cogseed@0.9.0|object-inspect@1.13.4",
-        "cogseed@0.9.0|side-channel-map@1.0.1"
+        "cogseed@1.0.2|call-bound@1.0.4",
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|get-intrinsic@1.3.0",
+        "cogseed@1.0.2|object-inspect@1.13.4",
+        "cogseed@1.0.2|side-channel-map@1.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|shebang-regex@3.0.0"
+      "ref": "cogseed@1.0.2|shebang-regex@3.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|isexe@2.0.0"
+      "ref": "cogseed@1.0.2|isexe@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|negotiator@1.0.0"
+      "ref": "cogseed@1.0.2|negotiator@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|inherits@2.0.4"
+      "ref": "cogseed@1.0.2|inherits@2.0.4"
     },
     {
-      "ref": "cogseed@0.9.0|setprototypeof@1.2.0"
+      "ref": "cogseed@1.0.2|setprototypeof@1.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|toidentifier@1.0.1"
+      "ref": "cogseed@1.0.2|toidentifier@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|ee-first@1.1.1"
+      "ref": "cogseed@1.0.2|ee-first@1.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|wrappy@1.0.2"
+      "ref": "cogseed@1.0.2|wrappy@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|forwarded@0.2.0"
+      "ref": "cogseed@1.0.2|forwarded@0.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|ipaddr.js@1.9.1"
+      "ref": "cogseed@1.0.2|ipaddr.js@1.9.1"
     },
     {
-      "ref": "cogseed@0.9.0|is-promise@4.0.0"
+      "ref": "cogseed@1.0.2|is-promise@4.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|path-to-regexp@8.4.2"
+      "ref": "cogseed@1.0.2|path-to-regexp@8.4.2"
     },
     {
-      "ref": "cogseed@0.9.0|media-typer@1.1.0"
+      "ref": "cogseed@1.0.2|media-typer@1.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|safer-buffer@2.1.2"
+      "ref": "cogseed@1.0.2|safer-buffer@2.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|@jridgewell/resolve-uri@3.1.2"
+      "ref": "cogseed@1.0.2|@jridgewell/resolve-uri@3.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|has-flag@4.0.0"
+      "ref": "cogseed@1.0.2|has-flag@4.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|@babel/helper-string-parser@7.29.7"
+      "ref": "cogseed@1.0.2|@babel/helper-string-parser@7.29.7"
     },
     {
-      "ref": "cogseed@0.9.0|@babel/helper-validator-identifier@7.29.7"
+      "ref": "cogseed@1.0.2|@babel/helper-validator-identifier@7.29.7"
     },
     {
-      "ref": "cogseed@0.9.0|end-of-stream@1.4.5",
+      "ref": "cogseed@1.0.2|end-of-stream@1.4.5",
       "dependsOn": [
-        "cogseed@0.9.0|once@1.4.0"
+        "cogseed@1.0.2|once@1.4.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|deep-extend@0.6.0"
+      "ref": "cogseed@1.0.2|deep-extend@0.6.0"
     },
     {
-      "ref": "cogseed@0.9.0|ini@1.3.8"
+      "ref": "cogseed@1.0.2|ini@1.3.8"
     },
     {
-      "ref": "cogseed@0.9.0|strip-json-comments@2.0.1"
+      "ref": "cogseed@1.0.2|strip-json-comments@2.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|decompress-response@6.0.0",
+      "ref": "cogseed@1.0.2|decompress-response@6.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|decompress-response@6.0.0|mimic-response@3.1.0"
+        "cogseed@1.0.2|decompress-response@6.0.0|mimic-response@3.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|decompress-response@6.0.0|mimic-response@3.1.0"
+      "ref": "cogseed@1.0.2|decompress-response@6.0.0|mimic-response@3.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|simple-concat@1.0.1"
+      "ref": "cogseed@1.0.2|simple-concat@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|chownr@1.1.4"
+      "ref": "cogseed@1.0.2|chownr@1.1.4"
     },
     {
-      "ref": "cogseed@0.9.0|tar-stream@2.2.0",
+      "ref": "cogseed@1.0.2|tar-stream@2.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|bl@4.1.0",
-        "cogseed@0.9.0|end-of-stream@1.4.5",
-        "cogseed@0.9.0|fs-constants@1.0.0",
-        "cogseed@0.9.0|inherits@2.0.4",
-        "cogseed@0.9.0|readable-stream@3.6.2"
+        "cogseed@1.0.2|bl@4.1.0",
+        "cogseed@1.0.2|end-of-stream@1.4.5",
+        "cogseed@1.0.2|fs-constants@1.0.0",
+        "cogseed@1.0.2|inherits@2.0.4",
+        "cogseed@1.0.2|readable-stream@3.6.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|safe-buffer@5.2.1"
+      "ref": "cogseed@1.0.2|safe-buffer@5.2.1"
     },
     {
-      "ref": "cogseed@0.9.0|commander@5.1.0"
+      "ref": "cogseed@1.0.2|commander@5.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|glob@7.2.3",
+      "ref": "cogseed@1.0.2|glob@7.2.3",
       "dependsOn": [
-        "cogseed@0.9.0|fs.realpath@1.0.0",
-        "cogseed@0.9.0|inflight@1.0.6",
-        "cogseed@0.9.0|inherits@2.0.4",
-        "cogseed@0.9.0|glob@7.2.3|minimatch@3.1.5",
-        "cogseed@0.9.0|once@1.4.0",
-        "cogseed@0.9.0|path-is-absolute@1.0.1"
+        "cogseed@1.0.2|fs.realpath@1.0.0",
+        "cogseed@1.0.2|inflight@1.0.6",
+        "cogseed@1.0.2|inherits@2.0.4",
+        "cogseed@1.0.2|glob@7.2.3|minimatch@3.1.5",
+        "cogseed@1.0.2|once@1.4.0",
+        "cogseed@1.0.2|path-is-absolute@1.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|glob@7.2.3|minimatch@3.1.5",
+      "ref": "cogseed@1.0.2|glob@7.2.3|minimatch@3.1.5",
       "dependsOn": [
-        "cogseed@0.9.0|glob@7.2.3|brace-expansion@1.1.18"
+        "cogseed@1.0.2|glob@7.2.3|brace-expansion@1.1.18"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|glob@7.2.3|brace-expansion@1.1.18",
+      "ref": "cogseed@1.0.2|glob@7.2.3|brace-expansion@1.1.18",
       "dependsOn": [
-        "cogseed@0.9.0|glob@7.2.3|balanced-match@1.0.2",
-        "cogseed@0.9.0|concat-map@0.0.1"
+        "cogseed@1.0.2|glob@7.2.3|balanced-match@1.0.2",
+        "cogseed@1.0.2|concat-map@0.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|glob@7.2.3|balanced-match@1.0.2"
+      "ref": "cogseed@1.0.2|glob@7.2.3|balanced-match@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|got@11.8.6",
+      "ref": "cogseed@1.0.2|got@11.8.6",
       "dependsOn": [
-        "cogseed@0.9.0|@sindresorhus/is@4.6.0",
-        "cogseed@0.9.0|@szmarczak/http-timer@4.0.6",
-        "cogseed@0.9.0|@types/cacheable-request@6.0.3",
-        "cogseed@0.9.0|@types/responselike@1.0.3",
-        "cogseed@0.9.0|cacheable-lookup@5.0.4",
-        "cogseed@0.9.0|cacheable-request@7.0.4",
-        "cogseed@0.9.0|decompress-response@6.0.0",
-        "cogseed@0.9.0|http2-wrapper@1.0.3",
-        "cogseed@0.9.0|lowercase-keys@2.0.0",
-        "cogseed@0.9.0|p-cancelable@2.1.1",
-        "cogseed@0.9.0|responselike@2.0.1"
+        "cogseed@1.0.2|@sindresorhus/is@4.6.0",
+        "cogseed@1.0.2|@szmarczak/http-timer@4.0.6",
+        "cogseed@1.0.2|@types/cacheable-request@6.0.3",
+        "cogseed@1.0.2|@types/responselike@1.0.3",
+        "cogseed@1.0.2|cacheable-lookup@5.0.4",
+        "cogseed@1.0.2|cacheable-request@7.0.4",
+        "cogseed@1.0.2|decompress-response@6.0.0",
+        "cogseed@1.0.2|http2-wrapper@1.0.3",
+        "cogseed@1.0.2|lowercase-keys@2.0.0",
+        "cogseed@1.0.2|p-cancelable@2.1.1",
+        "cogseed@1.0.2|responselike@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|promise-retry@2.0.1",
+      "ref": "cogseed@1.0.2|promise-retry@2.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|err-code@2.0.3",
-        "cogseed@0.9.0|promise-retry@2.0.1|retry@0.12.0"
+        "cogseed@1.0.2|err-code@2.0.3",
+        "cogseed@1.0.2|promise-retry@2.0.1|retry@0.12.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|promise-retry@2.0.1|retry@0.12.0"
+      "ref": "cogseed@1.0.2|promise-retry@2.0.1|retry@0.12.0"
     },
     {
-      "ref": "cogseed@0.9.0|compare-version@0.1.2"
+      "ref": "cogseed@1.0.2|compare-version@0.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|dir-compare@4.2.0",
+      "ref": "cogseed@1.0.2|dir-compare@4.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|dir-compare@4.2.0|minimatch@3.1.5",
-        "cogseed@0.9.0|p-limit@3.1.0"
+        "cogseed@1.0.2|dir-compare@4.2.0|minimatch@3.1.5",
+        "cogseed@1.0.2|p-limit@3.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|dir-compare@4.2.0|minimatch@3.1.5",
+      "ref": "cogseed@1.0.2|dir-compare@4.2.0|minimatch@3.1.5",
       "dependsOn": [
-        "cogseed@0.9.0|dir-compare@4.2.0|brace-expansion@1.1.18"
+        "cogseed@1.0.2|dir-compare@4.2.0|brace-expansion@1.1.18"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|dir-compare@4.2.0|brace-expansion@1.1.18",
+      "ref": "cogseed@1.0.2|dir-compare@4.2.0|brace-expansion@1.1.18",
       "dependsOn": [
-        "cogseed@0.9.0|dir-compare@4.2.0|balanced-match@1.0.2",
-        "cogseed@0.9.0|concat-map@0.0.1"
+        "cogseed@1.0.2|dir-compare@4.2.0|balanced-match@1.0.2",
+        "cogseed@1.0.2|concat-map@0.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|dir-compare@4.2.0|balanced-match@1.0.2"
+      "ref": "cogseed@1.0.2|dir-compare@4.2.0|balanced-match@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|lodash@4.18.1"
+      "ref": "cogseed@1.0.2|lodash@4.18.1"
     },
     {
-      "ref": "cogseed@0.9.0|tmp-promise@3.0.3",
+      "ref": "cogseed@1.0.2|tmp-promise@3.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|tmp@0.2.7"
+        "cogseed@1.0.2|tmp@0.2.7"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@peculiar/asn1-schema@2.9.3",
+      "ref": "cogseed@1.0.2|@peculiar/asn1-schema@2.9.3",
       "dependsOn": [
-        "cogseed@0.9.0|@peculiar/utils@2.0.3",
-        "cogseed@0.9.0|asn1js@3.0.10",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@peculiar/utils@2.0.3",
+        "cogseed@1.0.2|asn1js@3.0.10",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@peculiar/json-schema@1.1.12",
+      "ref": "cogseed@1.0.2|@peculiar/json-schema@1.1.12",
       "dependsOn": [
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@peculiar/utils@2.0.3",
+      "ref": "cogseed@1.0.2|@peculiar/utils@2.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|webcrypto-core@1.9.2",
+      "ref": "cogseed@1.0.2|webcrypto-core@1.9.2",
       "dependsOn": [
-        "cogseed@0.9.0|@peculiar/asn1-schema@2.9.3",
-        "cogseed@0.9.0|@peculiar/json-schema@1.1.12",
-        "cogseed@0.9.0|@peculiar/utils@2.0.3",
-        "cogseed@0.9.0|asn1js@3.0.10",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@peculiar/asn1-schema@2.9.3",
+        "cogseed@1.0.2|@peculiar/json-schema@1.1.12",
+        "cogseed@1.0.2|@peculiar/utils@2.0.3",
+        "cogseed@1.0.2|asn1js@3.0.10",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|pvtsutils@1.3.6",
+      "ref": "cogseed@1.0.2|pvtsutils@1.3.6",
       "dependsOn": [
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|pvutils@1.2.0"
+      "ref": "cogseed@1.0.2|pvutils@1.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|jake@10.9.4",
+      "ref": "cogseed@1.0.2|jake@10.9.4",
       "dependsOn": [
-        "cogseed@0.9.0|async@3.2.6",
-        "cogseed@0.9.0|filelist@1.0.6",
-        "cogseed@0.9.0|picocolors@1.1.1"
+        "cogseed@1.0.2|async@3.2.6",
+        "cogseed@1.0.2|filelist@1.0.6",
+        "cogseed@1.0.2|picocolors@1.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-winstaller@5.4.0",
+      "ref": "cogseed@1.0.2|electron-winstaller@5.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|@electron/asar@3.4.1",
-        "cogseed@0.9.0|@electron/windows-sign@1.2.2",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|electron-winstaller@5.4.0|fs-extra@7.0.1",
-        "cogseed@0.9.0|lodash@4.18.1",
-        "cogseed@0.9.0|temp@0.9.4"
+        "cogseed@1.0.2|@electron/asar@3.4.1",
+        "cogseed@1.0.2|@electron/windows-sign@1.2.2",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|electron-winstaller@5.4.0|fs-extra@7.0.1",
+        "cogseed@1.0.2|lodash@4.18.1",
+        "cogseed@1.0.2|temp@0.9.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-winstaller@5.4.0|fs-extra@7.0.1",
+      "ref": "cogseed@1.0.2|electron-winstaller@5.4.0|fs-extra@7.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|electron-winstaller@5.4.0|jsonfile@4.0.0",
-        "cogseed@0.9.0|electron-winstaller@5.4.0|universalify@0.1.2"
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|electron-winstaller@5.4.0|jsonfile@4.0.0",
+        "cogseed@1.0.2|electron-winstaller@5.4.0|universalify@0.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-winstaller@5.4.0|jsonfile@4.0.0",
+      "ref": "cogseed@1.0.2|electron-winstaller@5.4.0|jsonfile@4.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11"
+        "cogseed@1.0.2|graceful-fs@4.2.11"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|electron-winstaller@5.4.0|universalify@0.1.2"
+      "ref": "cogseed@1.0.2|electron-winstaller@5.4.0|universalify@0.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|aws4@1.13.2"
+      "ref": "cogseed@1.0.2|aws4@1.13.2"
     },
     {
-      "ref": "cogseed@0.9.0|lru-cache@6.0.0",
+      "ref": "cogseed@1.0.2|lru-cache@6.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|lru-cache@6.0.0|yallist@4.0.0"
+        "cogseed@1.0.2|lru-cache@6.0.0|yallist@4.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|lru-cache@6.0.0|yallist@4.0.0"
+      "ref": "cogseed@1.0.2|lru-cache@6.0.0|yallist@4.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|bytestreamjs@2.0.1"
+      "ref": "cogseed@1.0.2|bytestreamjs@2.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|signal-exit@3.0.7"
+      "ref": "cogseed@1.0.2|signal-exit@3.0.7"
     },
     {
-      "ref": "cogseed@0.9.0|pe-library@0.4.1"
+      "ref": "cogseed@1.0.2|pe-library@0.4.1"
     },
     {
-      "ref": "cogseed@0.9.0|duplexer2@0.1.4",
+      "ref": "cogseed@1.0.2|duplexer2@0.1.4",
       "dependsOn": [
-        "cogseed@0.9.0|duplexer2@0.1.4|readable-stream@2.3.8"
+        "cogseed@1.0.2|duplexer2@0.1.4|readable-stream@2.3.8"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|duplexer2@0.1.4|readable-stream@2.3.8",
+      "ref": "cogseed@1.0.2|duplexer2@0.1.4|readable-stream@2.3.8",
       "dependsOn": [
-        "cogseed@0.9.0|core-util-is@1.0.3",
-        "cogseed@0.9.0|inherits@2.0.4",
-        "cogseed@0.9.0|isarray@1.0.0",
-        "cogseed@0.9.0|process-nextick-args@2.0.1",
-        "cogseed@0.9.0|duplexer2@0.1.4|safe-buffer@5.1.2",
-        "cogseed@0.9.0|duplexer2@0.1.4|string_decoder@1.1.1",
-        "cogseed@0.9.0|util-deprecate@1.0.2"
+        "cogseed@1.0.2|core-util-is@1.0.3",
+        "cogseed@1.0.2|inherits@2.0.4",
+        "cogseed@1.0.2|isarray@1.0.0",
+        "cogseed@1.0.2|process-nextick-args@2.0.1",
+        "cogseed@1.0.2|duplexer2@0.1.4|safe-buffer@5.1.2",
+        "cogseed@1.0.2|duplexer2@0.1.4|string_decoder@1.1.1",
+        "cogseed@1.0.2|util-deprecate@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|duplexer2@0.1.4|safe-buffer@5.1.2"
+      "ref": "cogseed@1.0.2|duplexer2@0.1.4|safe-buffer@5.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|duplexer2@0.1.4|string_decoder@1.1.1",
+      "ref": "cogseed@1.0.2|duplexer2@0.1.4|string_decoder@1.1.1",
       "dependsOn": [
-        "cogseed@0.9.0|duplexer2@0.1.4|safe-buffer@5.1.2"
+        "cogseed@1.0.2|duplexer2@0.1.4|safe-buffer@5.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|node-int64@0.4.0"
+      "ref": "cogseed@1.0.2|node-int64@0.4.0"
     },
     {
-      "ref": "cogseed@0.9.0|@types/ms@2.1.0"
+      "ref": "cogseed@1.0.2|@types/ms@2.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|truncate-utf8-bytes@1.0.2",
+      "ref": "cogseed@1.0.2|truncate-utf8-bytes@1.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|utf8-byte-length@1.0.5"
+        "cogseed@1.0.2|utf8-byte-length@1.0.5"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|buffer-from@1.1.2"
+      "ref": "cogseed@1.0.2|buffer-from@1.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|source-map@0.6.1"
+      "ref": "cogseed@1.0.2|source-map@0.6.1"
     },
     {
-      "ref": "cogseed@0.9.0|color-convert@2.0.1",
+      "ref": "cogseed@1.0.2|color-convert@2.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|color-name@1.1.4"
+        "cogseed@1.0.2|color-name@1.1.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|strip-ansi@6.0.1",
+      "ref": "cogseed@1.0.2|strip-ansi@6.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|ansi-regex@5.0.1"
+        "cogseed@1.0.2|ansi-regex@5.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|wrap-ansi@7.0.0",
+      "ref": "cogseed@1.0.2|wrap-ansi@7.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|ansi-styles@4.3.0",
-        "cogseed@0.9.0|string-width@4.2.3",
-        "cogseed@0.9.0|strip-ansi@6.0.1"
+        "cogseed@1.0.2|ansi-styles@4.3.0",
+        "cogseed@1.0.2|string-width@4.2.3",
+        "cogseed@1.0.2|strip-ansi@6.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|emoji-regex@8.0.0"
+      "ref": "cogseed@1.0.2|emoji-regex@8.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|is-fullwidth-code-point@3.0.0"
+      "ref": "cogseed@1.0.2|is-fullwidth-code-point@3.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|punycode@2.3.1"
+      "ref": "cogseed@1.0.2|punycode@2.3.1"
     },
     {
-      "ref": "cogseed@0.9.0|flatted@3.4.4"
+      "ref": "cogseed@1.0.2|flatted@3.4.4"
     },
     {
-      "ref": "cogseed@0.9.0|keyv@4.5.4",
+      "ref": "cogseed@1.0.2|keyv@4.5.4",
       "dependsOn": [
-        "cogseed@0.9.0|json-buffer@3.0.1"
+        "cogseed@1.0.2|json-buffer@3.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|p-locate@5.0.0",
+      "ref": "cogseed@1.0.2|p-locate@5.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|p-limit@3.1.0"
+        "cogseed@1.0.2|p-limit@3.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|balanced-match@4.0.4"
+      "ref": "cogseed@1.0.2|balanced-match@4.0.4"
     },
     {
-      "ref": "cogseed@0.9.0|boolean@3.2.0"
+      "ref": "cogseed@1.0.2|boolean@3.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|es6-error@4.1.1"
+      "ref": "cogseed@1.0.2|es6-error@4.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|matcher@3.0.0",
+      "ref": "cogseed@1.0.2|matcher@3.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|escape-string-regexp@4.0.0"
+        "cogseed@1.0.2|escape-string-regexp@4.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|roarr@2.15.4",
+      "ref": "cogseed@1.0.2|roarr@2.15.4",
       "dependsOn": [
-        "cogseed@0.9.0|boolean@3.2.0",
-        "cogseed@0.9.0|detect-node@2.1.0",
-        "cogseed@0.9.0|globalthis@1.0.4",
-        "cogseed@0.9.0|json-stringify-safe@5.0.1",
-        "cogseed@0.9.0|semver-compare@1.0.0",
-        "cogseed@0.9.0|sprintf-js@1.1.3"
+        "cogseed@1.0.2|boolean@3.2.0",
+        "cogseed@1.0.2|detect-node@2.1.0",
+        "cogseed@1.0.2|globalthis@1.0.4",
+        "cogseed@1.0.2|json-stringify-safe@5.0.1",
+        "cogseed@1.0.2|semver-compare@1.0.0",
+        "cogseed@1.0.2|sprintf-js@1.1.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|serialize-error@7.0.1",
+      "ref": "cogseed@1.0.2|serialize-error@7.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|type-fest@0.13.1"
+        "cogseed@1.0.2|type-fest@0.13.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@tokenizer/inflate@0.4.1",
+      "ref": "cogseed@1.0.2|@tokenizer/inflate@0.4.1",
       "dependsOn": [
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|token-types@6.1.2"
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|token-types@6.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|strtok3@10.3.5",
+      "ref": "cogseed@1.0.2|strtok3@10.3.5",
       "dependsOn": [
-        "cogseed@0.9.0|@tokenizer/token@0.3.0"
+        "cogseed@1.0.2|@tokenizer/token@0.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|token-types@6.1.2",
+      "ref": "cogseed@1.0.2|token-types@6.1.2",
       "dependsOn": [
-        "cogseed@0.9.0|@borewit/text-codec@0.2.2",
-        "cogseed@0.9.0|@tokenizer/token@0.3.0",
-        "cogseed@0.9.0|ieee754@1.2.1"
+        "cogseed@1.0.2|@borewit/text-codec@0.2.2",
+        "cogseed@1.0.2|@tokenizer/token@0.3.0",
+        "cogseed@1.0.2|ieee754@1.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|uint8array-extras@1.5.0"
+      "ref": "cogseed@1.0.2|uint8array-extras@1.5.0"
     },
     {
-      "ref": "cogseed@0.9.0|xml-parse-from-string@1.0.1"
+      "ref": "cogseed@1.0.2|xml-parse-from-string@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|xml2js@0.5.0",
+      "ref": "cogseed@1.0.2|xml2js@0.5.0",
       "dependsOn": [
-        "cogseed@0.9.0|sax@1.6.0",
-        "cogseed@0.9.0|xml2js@0.5.0|xmlbuilder@11.0.1"
+        "cogseed@1.0.2|sax@1.6.0",
+        "cogseed@1.0.2|xml2js@0.5.0|xmlbuilder@11.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|xml2js@0.5.0|xmlbuilder@11.0.1"
+      "ref": "cogseed@1.0.2|xml2js@0.5.0|xmlbuilder@11.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|immediate@3.0.6"
+      "ref": "cogseed@1.0.2|immediate@3.0.6"
     },
     {
-      "ref": "cogseed@0.9.0|core-util-is@1.0.3"
+      "ref": "cogseed@1.0.2|core-util-is@1.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|isarray@1.0.0"
+      "ref": "cogseed@1.0.2|isarray@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|process-nextick-args@2.0.1"
+      "ref": "cogseed@1.0.2|process-nextick-args@2.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|util-deprecate@1.0.2"
+      "ref": "cogseed@1.0.2|util-deprecate@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@types/deep-eql@4.0.2"
+      "ref": "cogseed@1.0.2|@types/deep-eql@4.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|assertion-error@2.0.1"
+      "ref": "cogseed@1.0.2|assertion-error@2.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|lightningcss-darwin-arm64@1.33.0"
+      "ref": "cogseed@1.0.2|lightningcss-darwin-arm64@1.33.0"
     },
     {
-      "ref": "cogseed@0.9.0|nanoid@3.3.18"
+      "ref": "cogseed@1.0.2|nanoid@3.3.18"
     },
     {
-      "ref": "cogseed@0.9.0|picocolors@1.1.1"
+      "ref": "cogseed@1.0.2|picocolors@1.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|@oxc-project/types@0.146.0"
+      "ref": "cogseed@1.0.2|@oxc-project/types@0.146.0"
     },
     {
-      "ref": "cogseed@0.9.0|@rolldown/binding-darwin-arm64@1.2.5"
+      "ref": "cogseed@1.0.2|@rolldown/binding-darwin-arm64@1.2.5"
     },
     {
-      "ref": "cogseed@0.9.0|@rolldown/pluginutils@1.0.1"
+      "ref": "cogseed@1.0.2|@rolldown/pluginutils@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/util-buffer-from@2.2.0",
+      "ref": "cogseed@1.0.2|@smithy/util-buffer-from@2.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|@smithy/is-array-buffer@2.2.0",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@smithy/is-array-buffer@2.2.0",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|fast-xml-parser@5.7.3",
+      "ref": "cogseed@1.0.2|fast-xml-parser@5.7.3",
       "dependsOn": [
-        "cogseed@0.9.0|@nodable/entities@2.1.1",
-        "cogseed@0.9.0|fast-xml-builder@1.2.0",
-        "cogseed@0.9.0|path-expression-matcher@1.5.0",
-        "cogseed@0.9.0|strnum@2.3.0"
+        "cogseed@1.0.2|@nodable/entities@2.1.1",
+        "cogseed@1.0.2|fast-xml-builder@1.2.0",
+        "cogseed@1.0.2|path-expression-matcher@1.5.0",
+        "cogseed@1.0.2|strnum@2.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/credential-provider-login@3.972.45",
+      "ref": "cogseed@1.0.2|@aws-sdk/credential-provider-login@3.972.45",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/core@3.974.15",
-        "cogseed@0.9.0|@aws-sdk/nested-clients@3.997.13",
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/core@3.24.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/core@3.974.15",
+        "cogseed@1.0.2|@aws-sdk/nested-clients@3.997.13",
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/core@3.24.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@aws-sdk/signature-v4-multi-region@3.996.30",
+      "ref": "cogseed@1.0.2|@aws-sdk/signature-v4-multi-region@3.996.30",
       "dependsOn": [
-        "cogseed@0.9.0|@aws-sdk/types@3.973.9",
-        "cogseed@0.9.0|@smithy/signature-v4@5.4.5",
-        "cogseed@0.9.0|@smithy/types@4.14.2",
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|@aws-sdk/types@3.973.9",
+        "cogseed@1.0.2|@smithy/signature-v4@5.4.5",
+        "cogseed@1.0.2|@smithy/types@4.14.2",
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|extend@3.0.2"
+      "ref": "cogseed@1.0.2|extend@3.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|node-fetch@3.3.2",
+      "ref": "cogseed@1.0.2|node-fetch@3.3.2",
       "dependsOn": [
-        "cogseed@0.9.0|data-uri-to-buffer@4.0.1",
-        "cogseed@0.9.0|fetch-blob@3.2.0",
-        "cogseed@0.9.0|formdata-polyfill@4.0.10"
+        "cogseed@1.0.2|data-uri-to-buffer@4.0.1",
+        "cogseed@1.0.2|fetch-blob@3.2.0",
+        "cogseed@1.0.2|formdata-polyfill@4.0.10"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|json-bigint@1.0.0",
+      "ref": "cogseed@1.0.2|json-bigint@1.0.0",
       "dependsOn": [
-        "cogseed@0.9.0|bignumber.js@9.3.1"
+        "cogseed@1.0.2|bignumber.js@9.3.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|jwa@2.0.1",
+      "ref": "cogseed@1.0.2|jwa@2.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|buffer-equal-constant-time@1.0.1",
-        "cogseed@0.9.0|ecdsa-sig-formatter@1.0.11",
-        "cogseed@0.9.0|safe-buffer@5.2.1"
+        "cogseed@1.0.2|buffer-equal-constant-time@1.0.1",
+        "cogseed@1.0.2|ecdsa-sig-formatter@1.0.11",
+        "cogseed@1.0.2|safe-buffer@5.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|delayed-stream@1.0.0"
+      "ref": "cogseed@1.0.2|delayed-stream@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|get-intrinsic@1.3.0",
+      "ref": "cogseed@1.0.2|get-intrinsic@1.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|call-bind-apply-helpers@1.0.2",
-        "cogseed@0.9.0|es-define-property@1.0.1",
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|es-object-atoms@1.1.1",
-        "cogseed@0.9.0|function-bind@1.1.2",
-        "cogseed@0.9.0|get-proto@1.0.1",
-        "cogseed@0.9.0|gopd@1.2.0",
-        "cogseed@0.9.0|has-symbols@1.1.0",
-        "cogseed@0.9.0|hasown@2.0.4",
-        "cogseed@0.9.0|math-intrinsics@1.1.0"
+        "cogseed@1.0.2|call-bind-apply-helpers@1.0.2",
+        "cogseed@1.0.2|es-define-property@1.0.1",
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|es-object-atoms@1.1.1",
+        "cogseed@1.0.2|function-bind@1.1.2",
+        "cogseed@1.0.2|get-proto@1.0.1",
+        "cogseed@1.0.2|gopd@1.2.0",
+        "cogseed@1.0.2|has-symbols@1.1.0",
+        "cogseed@1.0.2|hasown@2.0.4",
+        "cogseed@1.0.2|math-intrinsics@1.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|has-tostringtag@1.0.2",
+      "ref": "cogseed@1.0.2|has-tostringtag@1.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|has-symbols@1.1.0"
+        "cogseed@1.0.2|has-symbols@1.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|function-bind@1.1.2"
+      "ref": "cogseed@1.0.2|function-bind@1.1.2"
     },
     {
-      "ref": "cogseed@0.9.0|mime-db@1.52.0"
+      "ref": "cogseed@1.0.2|mime-db@1.52.0"
     },
     {
-      "ref": "cogseed@0.9.0|call-bound@1.0.4",
+      "ref": "cogseed@1.0.2|call-bound@1.0.4",
       "dependsOn": [
-        "cogseed@0.9.0|call-bind-apply-helpers@1.0.2",
-        "cogseed@0.9.0|get-intrinsic@1.3.0"
+        "cogseed@1.0.2|call-bind-apply-helpers@1.0.2",
+        "cogseed@1.0.2|get-intrinsic@1.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|bl@4.1.0",
+      "ref": "cogseed@1.0.2|bl@4.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|buffer@5.7.1",
-        "cogseed@0.9.0|inherits@2.0.4",
-        "cogseed@0.9.0|readable-stream@3.6.2"
+        "cogseed@1.0.2|buffer@5.7.1",
+        "cogseed@1.0.2|inherits@2.0.4",
+        "cogseed@1.0.2|readable-stream@3.6.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|fs-constants@1.0.0"
+      "ref": "cogseed@1.0.2|fs-constants@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|readable-stream@3.6.2",
+      "ref": "cogseed@1.0.2|readable-stream@3.6.2",
       "dependsOn": [
-        "cogseed@0.9.0|inherits@2.0.4",
-        "cogseed@0.9.0|string_decoder@1.3.0",
-        "cogseed@0.9.0|util-deprecate@1.0.2"
+        "cogseed@1.0.2|inherits@2.0.4",
+        "cogseed@1.0.2|string_decoder@1.3.0",
+        "cogseed@1.0.2|util-deprecate@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|fs.realpath@1.0.0"
+      "ref": "cogseed@1.0.2|fs.realpath@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|inflight@1.0.6",
+      "ref": "cogseed@1.0.2|inflight@1.0.6",
       "dependsOn": [
-        "cogseed@0.9.0|once@1.4.0",
-        "cogseed@0.9.0|wrappy@1.0.2"
+        "cogseed@1.0.2|once@1.4.0",
+        "cogseed@1.0.2|wrappy@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|at-least-node@1.0.0"
+      "ref": "cogseed@1.0.2|at-least-node@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|@sindresorhus/is@4.6.0"
+      "ref": "cogseed@1.0.2|@sindresorhus/is@4.6.0"
     },
     {
-      "ref": "cogseed@0.9.0|@szmarczak/http-timer@4.0.6",
+      "ref": "cogseed@1.0.2|@szmarczak/http-timer@4.0.6",
       "dependsOn": [
-        "cogseed@0.9.0|defer-to-connect@2.0.1"
+        "cogseed@1.0.2|defer-to-connect@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@types/cacheable-request@6.0.3",
+      "ref": "cogseed@1.0.2|@types/cacheable-request@6.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|@types/http-cache-semantics@4.2.0",
-        "cogseed@0.9.0|@types/keyv@3.1.4",
-        "cogseed@0.9.0|@types/node@25.6.0",
-        "cogseed@0.9.0|@types/responselike@1.0.3"
+        "cogseed@1.0.2|@types/http-cache-semantics@4.2.0",
+        "cogseed@1.0.2|@types/keyv@3.1.4",
+        "cogseed@1.0.2|@types/node@25.6.0",
+        "cogseed@1.0.2|@types/responselike@1.0.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@types/responselike@1.0.3",
+      "ref": "cogseed@1.0.2|@types/responselike@1.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|@types/node@25.6.0"
+        "cogseed@1.0.2|@types/node@25.6.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|cacheable-lookup@5.0.4"
+      "ref": "cogseed@1.0.2|cacheable-lookup@5.0.4"
     },
     {
-      "ref": "cogseed@0.9.0|cacheable-request@7.0.4",
+      "ref": "cogseed@1.0.2|cacheable-request@7.0.4",
       "dependsOn": [
-        "cogseed@0.9.0|clone-response@1.0.3",
-        "cogseed@0.9.0|get-stream@5.2.0",
-        "cogseed@0.9.0|http-cache-semantics@4.2.0",
-        "cogseed@0.9.0|keyv@4.5.4",
-        "cogseed@0.9.0|lowercase-keys@2.0.0",
-        "cogseed@0.9.0|normalize-url@6.1.0",
-        "cogseed@0.9.0|responselike@2.0.1"
+        "cogseed@1.0.2|clone-response@1.0.3",
+        "cogseed@1.0.2|get-stream@5.2.0",
+        "cogseed@1.0.2|http-cache-semantics@4.2.0",
+        "cogseed@1.0.2|keyv@4.5.4",
+        "cogseed@1.0.2|lowercase-keys@2.0.0",
+        "cogseed@1.0.2|normalize-url@6.1.0",
+        "cogseed@1.0.2|responselike@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|http2-wrapper@1.0.3",
+      "ref": "cogseed@1.0.2|http2-wrapper@1.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|quick-lru@5.1.1",
-        "cogseed@0.9.0|resolve-alpn@1.2.1"
+        "cogseed@1.0.2|quick-lru@5.1.1",
+        "cogseed@1.0.2|resolve-alpn@1.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|lowercase-keys@2.0.0"
+      "ref": "cogseed@1.0.2|lowercase-keys@2.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|p-cancelable@2.1.1"
+      "ref": "cogseed@1.0.2|p-cancelable@2.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|responselike@2.0.1",
+      "ref": "cogseed@1.0.2|responselike@2.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|lowercase-keys@2.0.0"
+        "cogseed@1.0.2|lowercase-keys@2.0.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|err-code@2.0.3"
+      "ref": "cogseed@1.0.2|err-code@2.0.3"
     },
     {
-      "ref": "cogseed@0.9.0|p-limit@3.1.0",
+      "ref": "cogseed@1.0.2|p-limit@3.1.0",
       "dependsOn": [
-        "cogseed@0.9.0|yocto-queue@0.1.0"
+        "cogseed@1.0.2|yocto-queue@0.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|tmp@0.2.7"
+      "ref": "cogseed@1.0.2|tmp@0.2.7"
     },
     {
-      "ref": "cogseed@0.9.0|async@3.2.6"
+      "ref": "cogseed@1.0.2|async@3.2.6"
     },
     {
-      "ref": "cogseed@0.9.0|filelist@1.0.6",
+      "ref": "cogseed@1.0.2|filelist@1.0.6",
       "dependsOn": [
-        "cogseed@0.9.0|filelist@1.0.6|minimatch@5.1.9"
+        "cogseed@1.0.2|filelist@1.0.6|minimatch@5.1.9"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|filelist@1.0.6|minimatch@5.1.9",
+      "ref": "cogseed@1.0.2|filelist@1.0.6|minimatch@5.1.9",
       "dependsOn": [
-        "cogseed@0.9.0|filelist@1.0.6|brace-expansion@2.1.4"
+        "cogseed@1.0.2|filelist@1.0.6|brace-expansion@2.1.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|filelist@1.0.6|brace-expansion@2.1.4",
+      "ref": "cogseed@1.0.2|filelist@1.0.6|brace-expansion@2.1.4",
       "dependsOn": [
-        "cogseed@0.9.0|filelist@1.0.6|balanced-match@1.0.2"
+        "cogseed@1.0.2|filelist@1.0.6|balanced-match@1.0.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|filelist@1.0.6|balanced-match@1.0.2"
+      "ref": "cogseed@1.0.2|filelist@1.0.6|balanced-match@1.0.2"
     },
     {
-      "ref": "cogseed@0.9.0|@electron/windows-sign@1.2.2",
+      "ref": "cogseed@1.0.2|@electron/windows-sign@1.2.2",
       "dependsOn": [
-        "cogseed@0.9.0|cross-dirname@0.1.0",
-        "cogseed@0.9.0|debug@4.4.3",
-        "cogseed@0.9.0|@electron/windows-sign@1.2.2|fs-extra@11.4.0",
-        "cogseed@0.9.0|minimist@1.2.8",
-        "cogseed@0.9.0|postject@1.0.0-alpha.6"
+        "cogseed@1.0.2|cross-dirname@0.1.0",
+        "cogseed@1.0.2|debug@4.4.3",
+        "cogseed@1.0.2|@electron/windows-sign@1.2.2|fs-extra@11.4.0",
+        "cogseed@1.0.2|minimist@1.2.8",
+        "cogseed@1.0.2|postject@1.0.0-alpha.6"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@electron/windows-sign@1.2.2|fs-extra@11.4.0",
+      "ref": "cogseed@1.0.2|@electron/windows-sign@1.2.2|fs-extra@11.4.0",
       "dependsOn": [
-        "cogseed@0.9.0|graceful-fs@4.2.11",
-        "cogseed@0.9.0|jsonfile@6.2.1",
-        "cogseed@0.9.0|universalify@2.0.1"
+        "cogseed@1.0.2|graceful-fs@4.2.11",
+        "cogseed@1.0.2|jsonfile@6.2.1",
+        "cogseed@1.0.2|universalify@2.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|temp@0.9.4",
+      "ref": "cogseed@1.0.2|temp@0.9.4",
       "dependsOn": [
-        "cogseed@0.9.0|mkdirp@0.5.6",
-        "cogseed@0.9.0|rimraf@2.6.3"
+        "cogseed@1.0.2|mkdirp@0.5.6",
+        "cogseed@1.0.2|rimraf@2.6.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|utf8-byte-length@1.0.5"
+      "ref": "cogseed@1.0.2|utf8-byte-length@1.0.5"
     },
     {
-      "ref": "cogseed@0.9.0|color-name@1.1.4"
+      "ref": "cogseed@1.0.2|color-name@1.1.4"
     },
     {
-      "ref": "cogseed@0.9.0|ansi-regex@5.0.1"
+      "ref": "cogseed@1.0.2|ansi-regex@5.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|json-buffer@3.0.1"
+      "ref": "cogseed@1.0.2|json-buffer@3.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|detect-node@2.1.0"
+      "ref": "cogseed@1.0.2|detect-node@2.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|globalthis@1.0.4",
+      "ref": "cogseed@1.0.2|globalthis@1.0.4",
       "dependsOn": [
-        "cogseed@0.9.0|define-properties@1.2.1",
-        "cogseed@0.9.0|gopd@1.2.0"
+        "cogseed@1.0.2|define-properties@1.2.1",
+        "cogseed@1.0.2|gopd@1.2.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|json-stringify-safe@5.0.1"
+      "ref": "cogseed@1.0.2|json-stringify-safe@5.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|semver-compare@1.0.0"
+      "ref": "cogseed@1.0.2|semver-compare@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|sprintf-js@1.1.3"
+      "ref": "cogseed@1.0.2|sprintf-js@1.1.3"
     },
     {
-      "ref": "cogseed@0.9.0|type-fest@0.13.1"
+      "ref": "cogseed@1.0.2|type-fest@0.13.1"
     },
     {
-      "ref": "cogseed@0.9.0|@tokenizer/token@0.3.0"
+      "ref": "cogseed@1.0.2|@tokenizer/token@0.3.0"
     },
     {
-      "ref": "cogseed@0.9.0|@borewit/text-codec@0.2.2"
+      "ref": "cogseed@1.0.2|@borewit/text-codec@0.2.2"
     },
     {
-      "ref": "cogseed@0.9.0|ieee754@1.2.1"
+      "ref": "cogseed@1.0.2|ieee754@1.2.1"
     },
     {
-      "ref": "cogseed@0.9.0|@smithy/is-array-buffer@2.2.0",
+      "ref": "cogseed@1.0.2|@smithy/is-array-buffer@2.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|tslib@2.8.1"
+        "cogseed@1.0.2|tslib@2.8.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|@nodable/entities@2.1.1"
+      "ref": "cogseed@1.0.2|@nodable/entities@2.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|fast-xml-builder@1.2.0",
+      "ref": "cogseed@1.0.2|fast-xml-builder@1.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|path-expression-matcher@1.5.0",
-        "cogseed@0.9.0|xml-naming@0.1.0"
+        "cogseed@1.0.2|path-expression-matcher@1.5.0",
+        "cogseed@1.0.2|xml-naming@0.1.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|path-expression-matcher@1.5.0"
+      "ref": "cogseed@1.0.2|path-expression-matcher@1.5.0"
     },
     {
-      "ref": "cogseed@0.9.0|strnum@2.3.0"
+      "ref": "cogseed@1.0.2|strnum@2.3.0"
     },
     {
-      "ref": "cogseed@0.9.0|data-uri-to-buffer@4.0.1"
+      "ref": "cogseed@1.0.2|data-uri-to-buffer@4.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|fetch-blob@3.2.0",
+      "ref": "cogseed@1.0.2|fetch-blob@3.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|node-domexception@1.0.0",
-        "cogseed@0.9.0|web-streams-polyfill@3.3.3"
+        "cogseed@1.0.2|node-domexception@1.0.0",
+        "cogseed@1.0.2|web-streams-polyfill@3.3.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|formdata-polyfill@4.0.10",
+      "ref": "cogseed@1.0.2|formdata-polyfill@4.0.10",
       "dependsOn": [
-        "cogseed@0.9.0|fetch-blob@3.2.0"
+        "cogseed@1.0.2|fetch-blob@3.2.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|bignumber.js@9.3.1"
+      "ref": "cogseed@1.0.2|bignumber.js@9.3.1"
     },
     {
-      "ref": "cogseed@0.9.0|buffer-equal-constant-time@1.0.1"
+      "ref": "cogseed@1.0.2|buffer-equal-constant-time@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|call-bind-apply-helpers@1.0.2",
+      "ref": "cogseed@1.0.2|call-bind-apply-helpers@1.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|function-bind@1.1.2"
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|function-bind@1.1.2"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|es-object-atoms@1.1.1",
+      "ref": "cogseed@1.0.2|es-object-atoms@1.1.1",
       "dependsOn": [
-        "cogseed@0.9.0|es-errors@1.3.0"
+        "cogseed@1.0.2|es-errors@1.3.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|get-proto@1.0.1",
+      "ref": "cogseed@1.0.2|get-proto@1.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|dunder-proto@1.0.1",
-        "cogseed@0.9.0|es-object-atoms@1.1.1"
+        "cogseed@1.0.2|dunder-proto@1.0.1",
+        "cogseed@1.0.2|es-object-atoms@1.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|gopd@1.2.0"
+      "ref": "cogseed@1.0.2|gopd@1.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|has-symbols@1.1.0"
+      "ref": "cogseed@1.0.2|has-symbols@1.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|math-intrinsics@1.1.0"
+      "ref": "cogseed@1.0.2|math-intrinsics@1.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|buffer@5.7.1",
+      "ref": "cogseed@1.0.2|buffer@5.7.1",
       "dependsOn": [
-        "cogseed@0.9.0|base64-js@1.5.1",
-        "cogseed@0.9.0|ieee754@1.2.1"
+        "cogseed@1.0.2|base64-js@1.5.1",
+        "cogseed@1.0.2|ieee754@1.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|string_decoder@1.3.0",
+      "ref": "cogseed@1.0.2|string_decoder@1.3.0",
       "dependsOn": [
-        "cogseed@0.9.0|safe-buffer@5.2.1"
+        "cogseed@1.0.2|safe-buffer@5.2.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|concat-map@0.0.1"
+      "ref": "cogseed@1.0.2|concat-map@0.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|defer-to-connect@2.0.1"
+      "ref": "cogseed@1.0.2|defer-to-connect@2.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|@types/http-cache-semantics@4.2.0"
+      "ref": "cogseed@1.0.2|@types/http-cache-semantics@4.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|@types/keyv@3.1.4",
+      "ref": "cogseed@1.0.2|@types/keyv@3.1.4",
       "dependsOn": [
-        "cogseed@0.9.0|@types/node@25.6.0"
+        "cogseed@1.0.2|@types/node@25.6.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|clone-response@1.0.3",
+      "ref": "cogseed@1.0.2|clone-response@1.0.3",
       "dependsOn": [
-        "cogseed@0.9.0|mimic-response@1.0.1"
+        "cogseed@1.0.2|mimic-response@1.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|get-stream@5.2.0",
+      "ref": "cogseed@1.0.2|get-stream@5.2.0",
       "dependsOn": [
-        "cogseed@0.9.0|pump@3.0.4"
+        "cogseed@1.0.2|pump@3.0.4"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|http-cache-semantics@4.2.0"
+      "ref": "cogseed@1.0.2|http-cache-semantics@4.2.0"
     },
     {
-      "ref": "cogseed@0.9.0|normalize-url@6.1.0"
+      "ref": "cogseed@1.0.2|normalize-url@6.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|quick-lru@5.1.1"
+      "ref": "cogseed@1.0.2|quick-lru@5.1.1"
     },
     {
-      "ref": "cogseed@0.9.0|resolve-alpn@1.2.1"
+      "ref": "cogseed@1.0.2|resolve-alpn@1.2.1"
     },
     {
-      "ref": "cogseed@0.9.0|yocto-queue@0.1.0"
+      "ref": "cogseed@1.0.2|yocto-queue@0.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|cross-dirname@0.1.0"
+      "ref": "cogseed@1.0.2|cross-dirname@0.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|postject@1.0.0-alpha.6",
+      "ref": "cogseed@1.0.2|postject@1.0.0-alpha.6",
       "dependsOn": [
-        "cogseed@0.9.0|postject@1.0.0-alpha.6|commander@9.5.0"
+        "cogseed@1.0.2|postject@1.0.0-alpha.6|commander@9.5.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|postject@1.0.0-alpha.6|commander@9.5.0"
+      "ref": "cogseed@1.0.2|postject@1.0.0-alpha.6|commander@9.5.0"
     },
     {
-      "ref": "cogseed@0.9.0|mkdirp@0.5.6",
+      "ref": "cogseed@1.0.2|mkdirp@0.5.6",
       "dependsOn": [
-        "cogseed@0.9.0|minimist@1.2.8"
+        "cogseed@1.0.2|minimist@1.2.8"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|rimraf@2.6.3",
+      "ref": "cogseed@1.0.2|rimraf@2.6.3",
       "dependsOn": [
-        "cogseed@0.9.0|glob@7.2.3"
+        "cogseed@1.0.2|glob@7.2.3"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|define-properties@1.2.1",
+      "ref": "cogseed@1.0.2|define-properties@1.2.1",
       "dependsOn": [
-        "cogseed@0.9.0|define-data-property@1.1.4",
-        "cogseed@0.9.0|has-property-descriptors@1.0.2",
-        "cogseed@0.9.0|object-keys@1.1.1"
+        "cogseed@1.0.2|define-data-property@1.1.4",
+        "cogseed@1.0.2|has-property-descriptors@1.0.2",
+        "cogseed@1.0.2|object-keys@1.1.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|xml-naming@0.1.0"
+      "ref": "cogseed@1.0.2|xml-naming@0.1.0"
     },
     {
-      "ref": "cogseed@0.9.0|node-domexception@1.0.0"
+      "ref": "cogseed@1.0.2|node-domexception@1.0.0"
     },
     {
-      "ref": "cogseed@0.9.0|web-streams-polyfill@3.3.3"
+      "ref": "cogseed@1.0.2|web-streams-polyfill@3.3.3"
     },
     {
-      "ref": "cogseed@0.9.0|dunder-proto@1.0.1",
+      "ref": "cogseed@1.0.2|dunder-proto@1.0.1",
       "dependsOn": [
-        "cogseed@0.9.0|call-bind-apply-helpers@1.0.2",
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|gopd@1.2.0"
+        "cogseed@1.0.2|call-bind-apply-helpers@1.0.2",
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|gopd@1.2.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|mimic-response@1.0.1"
+      "ref": "cogseed@1.0.2|mimic-response@1.0.1"
     },
     {
-      "ref": "cogseed@0.9.0|define-data-property@1.1.4",
+      "ref": "cogseed@1.0.2|define-data-property@1.1.4",
       "dependsOn": [
-        "cogseed@0.9.0|es-define-property@1.0.1",
-        "cogseed@0.9.0|es-errors@1.3.0",
-        "cogseed@0.9.0|gopd@1.2.0"
+        "cogseed@1.0.2|es-define-property@1.0.1",
+        "cogseed@1.0.2|es-errors@1.3.0",
+        "cogseed@1.0.2|gopd@1.2.0"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|has-property-descriptors@1.0.2",
+      "ref": "cogseed@1.0.2|has-property-descriptors@1.0.2",
       "dependsOn": [
-        "cogseed@0.9.0|es-define-property@1.0.1"
+        "cogseed@1.0.2|es-define-property@1.0.1"
       ]
     },
     {
-      "ref": "cogseed@0.9.0|object-keys@1.1.1"
+      "ref": "cogseed@1.0.2|object-keys@1.1.1"
     }
   ]
 }

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -32,6 +32,7 @@ import {
   isPathAllowed,
 } from "../../util/path-sandbox";
 import { appendJsonlAtomic, genId12, nowIso, readJsonl, safeId } from "../../storage";
+import { createHash } from "node:crypto";
 import * as path from "node:path";
 import * as fs from "node:fs";
 
@@ -214,6 +215,7 @@ import {
   type KStarDecisionRecord,
   type KStarExpectation,
 } from "../kstar/dispatch-decision";
+import { retainKstarReuseTurnIds } from "../kstar/reuse-turn-ids";
 import {
   buildP3394Level2Manifest,
   normalizeP3394AgentMessage,
@@ -1363,13 +1365,18 @@ interface CidState {
    * conversation bus becomes quiescent. It is intentionally content-free:
    * terminal listeners may feed OS notifications and must never receive
    * prompts, titles, or model output. */
-  taskRun?: {
+  taskRun?: TaskRunState;
+}
+
+interface TaskRunState {
     runId: string;
     startedAtMs: number;
     status: TaskTerminalStatus | null;
     anchorMessageId?: string;
     lastMessageId?: string;
     logicalRunId?: string;
+    taskId?: string;
+    requirementId?: string;
     executionId?: string;
     projectionId?: string;
     forecastId?: string;
@@ -1381,7 +1388,7 @@ interface CidState {
      *  清单，迁移证明就能显式关联到"哪一次真实加载"——不靠时间窗反查，也不靠
      *  execution id 推断粘合。 */
     reuseTurnIds?: string[];
-  };
+    reuseTurnIdsTruncated?: true;
 }
 
 export type TaskTerminalStatus =
@@ -1400,12 +1407,16 @@ export interface TaskTerminalEvent {
   finished_message_id?: string;
   /** Optional execution identity used by terminal proof adapters. */
   logical_run_id?: string;
+  task_id?: string;
+  requirement_id?: string;
   execution_id?: string;
   projection_id?: string;
   forecast_id?: string;
   /** 本次运行里落过 ContextReuseReceipt 的轮次 id（回执键为 `turn-<id>`）。
    *  迁移证明凭这份清单找到真实加载凭证，一一对应，不做推断。 */
   reuse_turn_ids?: string[];
+  /** True when reuse_turn_ids is only the newest retained suffix. */
+  reuse_turn_ids_truncated?: true;
   wake_request_id?: string;
 }
 
@@ -1599,15 +1610,95 @@ function _recordTaskRunOutcome(
   if (!run.status || rank[status] >= rank[run.status]) run.status = status;
 }
 
+function _recordTaskRunReuseTurn(state: CidState, turnId: string): void {
+  const run = state.taskRun;
+  if (!run) return;
+  const retained = retainKstarReuseTurnIds([...(run.reuseTurnIds || []), turnId]);
+  run.reuseTurnIds = retained.reuseTurnIds;
+  if (run.reuseTurnIdsTruncated || retained.truncated) run.reuseTurnIdsTruncated = true;
+}
+
+function _recordTaskRunKstarProvenance(
+  state: CidState,
+  provenance: {
+    taskId?: string;
+    requirementId?: string;
+    projectionId?: string;
+    forecastId?: string;
+    wakeRequestId?: string;
+    executionId?: string;
+  },
+  options: { fillIfAbsent?: boolean } = {},
+): void {
+  const run = state.taskRun;
+  if (!run) return;
+  const fillIfAbsent = options.fillIfAbsent === true;
+  // Passive per-message capture (fillIfAbsent) may only populate fields that
+  // are still unset: once a run's identity is resolved (by the first message's
+  // lifecycle or by an authoritative task decision), later messages of the
+  // same aggregate run must never change it. Authoritative call sites omit the
+  // option and keep the overwrite semantics — they represent real task
+  // decisions (dispatch routing / privileged dispatch approval / terminal
+  // provenance on enqueue).
+  //
+  // A passive fill must additionally never pair an already-frozen task with a
+  // DIFFERENT lifecycle. Passive capture always supplies a complete lifecycle
+  // pair, so filling requirement B (from a moved lifecycle) under frozen task
+  // A is exactly the cross-task contamination the freeze must prevent. When
+  // the run's task is still unset, or the incoming lifecycle resolves to the
+  // SAME task, per-field fill continues (a same-task later capture may still
+  // fill still-unset requirement/projection fields).
+  if (fillIfAbsent && provenance.taskId && run.taskId !== undefined && run.taskId !== provenance.taskId) {
+    return;
+  }
+  if (provenance.taskId && (fillIfAbsent ? run.taskId === undefined : true)) {
+    run.taskId = provenance.taskId;
+    run.logicalRunId = provenance.taskId;
+  }
+  if (provenance.requirementId && (fillIfAbsent ? run.requirementId === undefined : true)) {
+    run.requirementId = provenance.requirementId;
+  }
+  if (provenance.projectionId && (fillIfAbsent ? run.projectionId === undefined : true)) {
+    run.projectionId = provenance.projectionId;
+  }
+  if (provenance.forecastId && (fillIfAbsent ? run.forecastId === undefined : true)) {
+    run.forecastId = provenance.forecastId;
+  }
+  if (provenance.wakeRequestId && (fillIfAbsent ? run.wakeRequestId === undefined : true)) {
+    run.wakeRequestId = provenance.wakeRequestId;
+  }
+  if (provenance.executionId && (fillIfAbsent ? run.executionId === undefined : true)) {
+    run.executionId = provenance.executionId;
+  }
+}
+
+async function _captureCurrentTaskRunKstarProvenance(state: CidState): Promise<void> {
+  if (!state.taskRun) return;
+  try {
+    const { readKstarTaskLifecycle } = await import('../kstar/lifecycle-adapter');
+    const lifecycle = await readKstarTaskLifecycle(state.uid, state.cid);
+    if (!lifecycle.task || !lifecycle.requirement) return;
+    _recordTaskRunKstarProvenance(state, {
+      taskId: lifecycle.task.id,
+      requirementId: lifecycle.requirement.id,
+      ...(lifecycle.projection?.id ? { projectionId: lifecycle.projection.id } : {}),
+      ...(lifecycle.requirement.forecastId ? { forecastId: lifecycle.requirement.forecastId } : {}),
+      ...(lifecycle.wakeRequest?.id ? { wakeRequestId: lifecycle.wakeRequest.id } : {}),
+    }, { fillIfAbsent: true });
+  } catch (error) {
+    log.warn('kstar active-run provenance capture degraded', {
+      cid: maskId(state.cid),
+      error: logErrorRef(error),
+    });
+  }
+}
+
 function _emitTaskRunTerminalIfQuiescent(
   state: CidState,
   stateFile?: StateFile,
 ): void {
   const run = state.taskRun;
   if (!run || !isQuiescent(state.uid, state.cid)) return;
-  // Clear synchronously before notifying. Concurrent status reconciliations
-  // can now observe the run as finished and cannot emit it twice.
-  state.taskRun = undefined;
   const waitingForUser =
     stateFile?.orchestration_ledger?.status === "waiting_for_form" ||
     stateFile?.orchestration_ledger?.status === "waiting_for_agent";
@@ -1617,65 +1708,60 @@ function _emitTaskRunTerminalIfQuiescent(
       : waitingForUser
         ? "waiting_input"
         : run.status || "failed";
+  const frozenReuseTurnIds: readonly string[] | undefined = run.reuseTurnIds === undefined
+    ? undefined
+    : Object.freeze([...run.reuseTurnIds]);
+  const terminalSnapshot = Object.freeze({
+    runId: run.runId,
+    startedAtMs: run.startedAtMs,
+    finishedAtMs: Date.now(),
+    status,
+    anchorMessageId: run.anchorMessageId,
+    lastMessageId: run.lastMessageId,
+    logicalRunId: run.logicalRunId,
+    taskId: run.taskId,
+    requirementId: run.requirementId,
+    executionId: run.executionId,
+    projectionId: run.projectionId,
+    forecastId: run.forecastId,
+    wakeRequestId: run.wakeRequestId,
+    cogseedTaskId: run.cogseedTaskId,
+    reuseTurnIds: frozenReuseTurnIds,
+    reuseTurnIdsTruncated: run.reuseTurnIdsTruncated,
+  });
+  // Freeze every terminal-owned fact before release. Later runs may now start,
+  // but background consumers only see this detached immutable snapshot.
+  state.taskRun = undefined;
   const listeners = [..._taskTerminalListeners];
   trackBackgroundWrite(state, (async () => {
-    // M-6: reuseTurnIds 只在内存。进程重启/崩溃后清单丢失，终态退回无回执
-    // 分支，该次运行的资产永不升档（回执文件本身已落盘 local/kstar/
-    // executions/turn-<turnId>/）。恢复：扫描本会话（targetSessionId=
-    // gconv-<cid>）且在本 run 开始之后落过的回执，按 turn- 前缀还原清单。
-    if (!run.reuseTurnIds?.length) {
-      try {
-        const { listReceipts } = await import('../p3394/context-reuse-receipt');
-        const receipts = await listReceipts(state.uid).catch(() => [] as Array<{ targetSessionId: string; executionId: string; createdAt: string }>);
-        const restored = receipts
-          .filter((receipt) => receipt.targetSessionId === `gconv-${state.cid}`
-            && Date.parse(receipt.createdAt) >= run.startedAtMs)
-          .map((receipt) => receipt.executionId)
-          .filter((executionId) => executionId.startsWith('turn-'))
-          .map((executionId) => executionId.slice('turn-'.length))
-          .filter(Boolean);
-        if (restored.length) run.reuseTurnIds = [...new Set(restored)];
-      } catch (err) {
-        log.warn(`task terminal receipt restore degraded cid=${state.cid}: ${(err as Error).message}`);
-      }
-    }
-    const event: TaskTerminalEvent = {
-      run_id: run.runId,
+    const event: TaskTerminalEvent = Object.freeze({
+      run_id: terminalSnapshot.runId,
       user_id: state.uid,
       conversation_id: state.cid,
-      status,
-      started_at_ms: run.startedAtMs,
-      finished_at_ms: Date.now(),
-      ...(run.anchorMessageId ? { anchor_message_id: run.anchorMessageId } : {}),
-      ...(run.lastMessageId ? { finished_message_id: run.lastMessageId } : {}),
-      ...(run.logicalRunId ? { logical_run_id: run.logicalRunId } : {}),
-      ...(run.executionId ? { execution_id: run.executionId } : {}),
-      ...(run.projectionId ? { projection_id: run.projectionId } : {}),
-      ...(run.forecastId ? { forecast_id: run.forecastId } : {}),
-      ...(run.wakeRequestId ? { wake_request_id: run.wakeRequestId } : {}),
-      ...(run.reuseTurnIds?.length ? { reuse_turn_ids: [...run.reuseTurnIds] } : {}),
-    };
-    if (!event.projection_id || !event.logical_run_id || !event.wake_request_id) {
-      try {
-        const { readKstarTaskLifecycle } = await import('../kstar/lifecycle-adapter');
-        const lifecycle = await readKstarTaskLifecycle(state.uid, state.cid);
-        if (!event.logical_run_id && lifecycle.task?.id) event.logical_run_id = lifecycle.task.id;
-        if (!event.projection_id && lifecycle.projection?.id) event.projection_id = lifecycle.projection.id;
-        if (!event.forecast_id && lifecycle.requirement?.forecastId) event.forecast_id = lifecycle.requirement.forecastId;
-        if (!event.wake_request_id && lifecycle.wakeRequest?.id) event.wake_request_id = lifecycle.wakeRequest.id;
-      } catch (err) {
-        log.warn(`task terminal provenance lookup failed cid=${state.cid}: ${(err as Error).message}`);
-      }
-    }
-    if (!event.logical_run_id) event.logical_run_id = run.runId;
-    if (!event.execution_id) event.execution_id = run.runId;
-    if (run.cogseedTaskId) {
+      status: terminalSnapshot.status,
+      started_at_ms: terminalSnapshot.startedAtMs,
+      finished_at_ms: terminalSnapshot.finishedAtMs,
+      ...(terminalSnapshot.anchorMessageId ? { anchor_message_id: terminalSnapshot.anchorMessageId } : {}),
+      ...(terminalSnapshot.lastMessageId ? { finished_message_id: terminalSnapshot.lastMessageId } : {}),
+      logical_run_id: terminalSnapshot.logicalRunId || terminalSnapshot.taskId || terminalSnapshot.runId,
+      execution_id: terminalSnapshot.executionId || terminalSnapshot.runId,
+      ...(terminalSnapshot.taskId ? { task_id: terminalSnapshot.taskId } : {}),
+      ...(terminalSnapshot.requirementId ? { requirement_id: terminalSnapshot.requirementId } : {}),
+      ...(terminalSnapshot.projectionId ? { projection_id: terminalSnapshot.projectionId } : {}),
+      ...(terminalSnapshot.forecastId ? { forecast_id: terminalSnapshot.forecastId } : {}),
+      ...(terminalSnapshot.wakeRequestId ? { wake_request_id: terminalSnapshot.wakeRequestId } : {}),
+      ...(terminalSnapshot.reuseTurnIds !== undefined
+        ? { reuse_turn_ids: terminalSnapshot.reuseTurnIds as string[] }
+        : {}),
+      ...(terminalSnapshot.reuseTurnIdsTruncated ? { reuse_turn_ids_truncated: true as const } : {}),
+    });
+    if (terminalSnapshot.cogseedTaskId) {
       await observedTaskBridge().finishTask({
         userId: state.uid,
-        taskId: run.cogseedTaskId,
-        status,
+        taskId: terminalSnapshot.cogseedTaskId,
+        status: terminalSnapshot.status,
         ...(event.finished_message_id ? { messageId: event.finished_message_id } : {}),
-        ...(status === 'failed' ? { errorCode: 'group_chat_run_failed' } : {}),
+        ...(terminalSnapshot.status === 'failed' ? { errorCode: 'group_chat_run_failed' } : {}),
       });
     }
     for (const listener of listeners) {
@@ -2282,6 +2368,8 @@ export interface EnqueueParams {
   kstarDecision?: KStarDecisionRecord;
   /** Internal KSTAR terminal provenance used to enrich bus terminal events. */
   kstarTerminalProvenance?: {
+    taskId?: string;
+    requirementId?: string;
     logicalRunId?: string;
     executionId?: string;
     projectionId?: string;
@@ -2325,6 +2413,20 @@ export async function enqueue(params: EnqueueParams): Promise<GroupMessage> {
       runId: genId12(),
       startedAtMs: Date.now(),
       status: null,
+      // reuseTurnIds: [] here is AUTHORITATIVE-EMPTY, not "no receipts were
+      // tracked": downstream consumers treat `reuseTurnIds !== undefined` as a
+      // new-format terminal event and suppress the legacy taskRunId fallback.
+      // This is sound only because the run just opened and records its reuse
+      // turns in-process from here on. Persisted-dispatch recoveries never use
+      // this literal: they re-derive the authoritative list from the durable
+      // receipt via recoverPersistedDispatchReuseTurnIds (mismatch/not-found
+      // both yield []), so [] must not be seeded for runs whose receipt
+      // tracking happens outside this process.
+      reuseTurnIds: [],
+      ...(provenance?.taskId || provenance?.logicalRunId
+        ? { taskId: provenance.taskId || provenance.logicalRunId }
+        : {}),
+      ...(provenance?.requirementId ? { requirementId: provenance.requirementId } : {}),
       ...(provenance?.logicalRunId ? { logicalRunId: provenance.logicalRunId } : {}),
       ...(provenance?.executionId ? { executionId: provenance.executionId } : {}),
       ...(provenance?.projectionId ? { projectionId: provenance.projectionId } : {}),
@@ -2865,14 +2967,16 @@ async function _enqueueBody(
 
   if (state.taskRun && params.kstarTerminalProvenance) {
     const provenance = params.kstarTerminalProvenance;
-    state.taskRun = {
-      ...state.taskRun,
-      ...(provenance.logicalRunId ? { logicalRunId: provenance.logicalRunId } : {}),
+    _recordTaskRunKstarProvenance(state, {
+      ...(provenance.taskId || provenance.logicalRunId
+        ? { taskId: provenance.taskId || provenance.logicalRunId }
+        : {}),
+      ...(provenance.requirementId ? { requirementId: provenance.requirementId } : {}),
       ...(provenance.executionId ? { executionId: provenance.executionId } : {}),
       ...(provenance.projectionId ? { projectionId: provenance.projectionId } : {}),
       ...(provenance.forecastId ? { forecastId: provenance.forecastId } : {}),
       ...(provenance.wakeRequestId ? { wakeRequestId: provenance.wakeRequestId } : {}),
-    };
+    });
   }
 
   // Persist: main jsonl + each recipient + sender (so sender sees own history
@@ -2900,6 +3004,9 @@ async function _enqueueBody(
         sourceMessageId: msg.id,
       });
       if (observed) state.taskRun.cogseedTaskId = observed.taskId;
+    }
+    if (!params.internalControl && (fromActorId === USER_ID || params.externalInbound === true)) {
+      await _captureCurrentTaskRunKstarProvenance(state);
     }
   }
   // Strip the process trail before writing visibility slices: only the user-
@@ -3128,6 +3235,79 @@ export interface RecoverPersistedUserDispatchResult {
   disposition: PersistedUserDispatchRecoveryDisposition;
 }
 
+function stableRecoveredTaskRunId(input: RecoverPersistedUserDispatchInput): string {
+  return createHash('sha256')
+    .update(['persisted-dispatch', input.cid, input.messageId, input.actionRequestId].join('\0'))
+    .digest('hex')
+    .slice(0, 12);
+}
+
+async function recoverPersistedDispatchReuseTurnIds(
+  userId: string,
+  cid: string,
+  actor: Actor,
+  turnId: string,
+): Promise<string[] | undefined> {
+  try {
+    const { readReceipt } = await import('../p3394/context-reuse-receipt');
+    const receipt = await readReceipt(userId, `turn-${turnId}`);
+    if (receipt.targetSessionId !== actorSessionId(cid, actor)) {
+      // A receipt that belongs to another actor's session is unusable for
+      // THIS run. Treat it as authoritative-empty ([]) with a distinct warn,
+      // NOT undefined: undefined would fall back to the legacy taskRunId
+      // path and silently lose the per-turn evidence marker.
+      log.warn('persisted dispatch receipt target mismatch', {
+        cid: maskId(cid),
+        turnId: maskId(turnId),
+      });
+      return [];
+    }
+    return [turnId];
+  } catch (error) {
+    if ((error as Error).message === 'context reuse receipt not found') return [];
+    log.warn('persisted dispatch receipt recovery degraded', {
+      cid: maskId(cid),
+      turnId: maskId(turnId),
+      error: logErrorRef(error),
+    });
+    return undefined;
+  }
+}
+
+async function recoverPersistedDispatchKstarProvenance(
+  userId: string,
+  cid: string,
+  messageId: string,
+): Promise<Pick<TaskRunState, 'taskId' | 'requirementId' | 'logicalRunId' | 'projectionId' | 'forecastId' | 'wakeRequestId'>> {
+  try {
+    const store = await import('../kstar/requirement-store');
+    const tasks = await store.listKstarTasksForConversation(userId, cid);
+    const matches: Array<{ task: Awaited<ReturnType<typeof store.readKstarTask>>; requirement: Awaited<ReturnType<typeof store.readKstarRequirement>> }> = [];
+    for (const task of tasks) {
+      const requirements = await store.listKstarRequirementsForTask(userId, task.id);
+      for (const requirement of requirements) {
+        if (requirement.userMessageIds.includes(messageId)) matches.push({ task, requirement });
+      }
+    }
+    if (matches.length !== 1 || !matches[0].task || !matches[0].requirement) return {};
+    const { task, requirement } = matches[0];
+    return {
+      taskId: task.id,
+      logicalRunId: task.id,
+      requirementId: requirement.id,
+      ...(requirement.projectionId ? { projectionId: requirement.projectionId } : {}),
+      ...(requirement.forecastId ? { forecastId: requirement.forecastId } : {}),
+      ...(requirement.wakeRequestId ? { wakeRequestId: requirement.wakeRequestId } : {}),
+    };
+  } catch (error) {
+    log.warn('persisted dispatch KSTAR provenance recovery degraded', {
+      cid: maskId(cid),
+      error: logErrorRef(error),
+    });
+    return {};
+  }
+}
+
 /** Repair the narrow crash window where a host-owned user message reached the
  * main JSONL but its QueueItem did not reach the in-memory runtime. The caller
  * supplies identities derived from a durable retry claim; this function never
@@ -3211,12 +3391,21 @@ export async function recoverPersistedUserDispatch(
     }
 
     if (!state.taskRun) {
+      const persistedStartedAtMs = Date.parse(msg.ts);
+      const [reuseTurnIds, kstarProvenance] = await Promise.all([
+        recoverPersistedDispatchReuseTurnIds(input.uid, input.cid, actor, input.turnId),
+        recoverPersistedDispatchKstarProvenance(input.uid, input.cid, msg.id),
+      ]);
       state.taskRun = {
-        runId: genId12(),
-        startedAtMs: Date.now(),
+        runId: stableRecoveredTaskRunId(input),
+        startedAtMs: Number.isFinite(persistedStartedAtMs)
+          ? persistedStartedAtMs
+          : Date.now(),
         status: null,
         anchorMessageId: msg.id,
         lastMessageId: msg.id,
+        ...(reuseTurnIds !== undefined ? { reuseTurnIds } : {}),
+        ...kstarProvenance,
       };
     }
     const runtime = ensureRuntime(state);
@@ -4427,6 +4616,27 @@ async function runActorTurnBody(
       // tracked state when it is true.
       hostOpenedTaskThisTurn = routing.openedTask;
       hostOpenedRequirementId = routing.requirementId;
+      if (routing.requirementId) {
+        try {
+          const store = await import('../kstar/requirement-store');
+          const requirement = await store.readKstarRequirement(uid, routing.requirementId);
+          const task = requirement ? await store.readKstarTask(uid, requirement.taskId) : null;
+          if (requirement && task) {
+            _recordTaskRunKstarProvenance(state, {
+              taskId: task.id,
+              requirementId: requirement.id,
+              ...(requirement.projectionId ? { projectionId: requirement.projectionId } : {}),
+              ...(requirement.forecastId ? { forecastId: requirement.forecastId } : {}),
+              ...(requirement.wakeRequestId ? { wakeRequestId: requirement.wakeRequestId } : {}),
+            });
+          }
+        } catch (error) {
+          log.warn('kstar run provenance capture degraded', {
+            cid: maskId(cid),
+            error: logErrorRef(error),
+          });
+        }
+      }
     }
     if (convKind === "space_builder") {
       systemPrompt = await buildSpaceBuilderSystemPrompt(uid);
@@ -4652,10 +4862,9 @@ async function runActorTurnBody(
               },
               { sessionId: `gconv-${cid}` },
             ).catch(() => undefined);
-            if (prepared) turnReuseReceiptPrepared = true;
-            if (state.taskRun) {
-              const turns = state.taskRun.reuseTurnIds || [];
-              if (!turns.includes(item.turnId)) state.taskRun.reuseTurnIds = [...turns, item.turnId];
+            if (prepared) {
+              turnReuseReceiptPrepared = true;
+              _recordTaskRunReuseTurn(state, item.turnId);
             }
           } catch {
             // receipt 落库失败不阻断回合——只是这次不产生迁移凭证。
@@ -4719,10 +4928,9 @@ async function runActorTurnBody(
                 },
                 { sessionId: `gmember-${cid}-${actor.id}` },
               ).catch(() => undefined);
-              if (prepared) turnReuseReceiptPrepared = true;
-              if (state.taskRun) {
-                const turns = state.taskRun.reuseTurnIds || [];
-                if (!turns.includes(item.turnId)) state.taskRun.reuseTurnIds = [...turns, item.turnId];
+              if (prepared) {
+                turnReuseReceiptPrepared = true;
+                _recordTaskRunReuseTurn(state, item.turnId);
               }
             } catch {
               // receipt 落库失败不阻断回合。
@@ -4763,12 +4971,6 @@ async function runActorTurnBody(
           );
           // 回执落成即登记到本次运行：终态事件靠这份清单把迁移证明关联到
           // 真实加载凭证。登记发生在注入的同一处，与回执用同一份事实。
-          if (state.taskRun) {
-            const turns = state.taskRun.reuseTurnIds || [];
-            if (!turns.includes(item.turnId)) {
-              state.taskRun.reuseTurnIds = [...turns, item.turnId];
-            }
-          }
           const inheritedReceipt = await recordInheritedCognitionReuse(
             uid,
             cid,
@@ -4780,7 +4982,10 @@ async function runActorTurnBody(
               truncatedByBudget(selection.selected, rendered),
             ),
           );
-          if (inheritedReceipt) turnReuseReceiptPrepared = true;
+          if (inheritedReceipt) {
+            turnReuseReceiptPrepared = true;
+            _recordTaskRunReuseTurn(state, item.turnId);
+          }
         }
       } catch (error) {
         // 继承注入失败不该让这一轮对话起不来——降级成这次不带继承认知。
@@ -7681,7 +7886,7 @@ function kstarApprovalBlockedToolResult(code: string, message: string): { conten
 async function guardKstarPrivilegedDispatch(
   state: CidState,
   options: { allowHostAutoTracked?: boolean } = {},
-): Promise<{ content: string; isError: true } | { provenance: { logicalRunId?: string; projectionId?: string; forecastId?: string } }> {
+): Promise<{ content: string; isError: true } | { provenance: { taskId?: string; requirementId?: string; logicalRunId?: string; projectionId?: string; forecastId?: string } }> {
   const { readKstarTaskLifecycle } = await import('../kstar/lifecycle-adapter');
   const lifecycle = await readKstarTaskLifecycle(state.uid, state.cid);
   if (!lifecycle.requirement?.projectionId) return { provenance: {} };
@@ -7704,14 +7909,13 @@ async function guardKstarPrivilegedDispatch(
     return { provenance: {} };
   }
   const provenance = {
-    ...(lifecycle.task?.id ? { logicalRunId: lifecycle.task.id } : {}),
+    ...(lifecycle.task?.id ? { taskId: lifecycle.task.id, logicalRunId: lifecycle.task.id } : {}),
+    requirementId: lifecycle.requirement.id,
     projectionId: lifecycle.projection.id,
     forecastId: lifecycle.requirement.forecastId,
   };
   if (state.taskRun) {
-    if (provenance.logicalRunId) state.taskRun.logicalRunId = provenance.logicalRunId;
-    state.taskRun.projectionId = provenance.projectionId;
-    state.taskRun.forecastId = provenance.forecastId;
+    _recordTaskRunKstarProvenance(state, provenance);
     // Keep the durable CogSeed task aligned with the in-memory run provenance
     // so either side can be used as the audit entry point after a restart.
     if (lifecycle.task?.cogseedTaskId) {

--- a/src/main/features/kstar/episode-builder.ts
+++ b/src/main/features/kstar/episode-builder.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { nowIso } from '../../storage';
 import type { RuntimeEventEnvelope, RuntimeRunRequest } from '../cogseed_runtime/protocol';
 import { normalizeCognitionSourceRefs, type CognitionSourceRef } from '../recall/source-service';
+import { retainKstarReuseTurnIds } from './reuse-turn-ids';
 import type { KstarAgentAction, KstarEpisodeRecord, KstarToolCall, KstarTaskStatus } from './types';
 
 const MAX_TEXT = 4_000;
@@ -69,6 +70,10 @@ export interface GroupKstarEpisodeInput extends GroupKstarEpisodeInputRefs {
   wakeRequestId?: string;
   logicalRunId?: string;
   executionId?: string;
+  reuseTurnIds?: string[];
+  reuseTurnIdsTruncated?: true;
+  taskId?: string;
+  requirementId?: string;
   createdAt?: string;
 }
 
@@ -310,6 +315,9 @@ function messagesInRun(input: GroupKstarEpisodeInput): GroupKstarMessageInput[] 
 
 export function buildGroupKstarEpisode(input: GroupKstarEpisodeInput): KstarEpisodeRecord {
   const createdAt = input.createdAt || nowIso();
+  const retainedReuseTurnIds = input.reuseTurnIds === undefined
+    ? undefined
+    : retainKstarReuseTurnIds(input.reuseTurnIds);
   const messages = messagesInRun(input);
   const userMessages = messages.filter((message) => message.from === 'user');
   const actionMessages = messages.filter((message) => message.from !== 'user' && !message.system_kind);
@@ -356,6 +364,12 @@ export function buildGroupKstarEpisode(input: GroupKstarEpisodeInput): KstarEpis
     sessionId: `gconv-${input.conversationId}`,
     sessionKind: 'group_chat',
     taskRunId: input.runId,
+    ...(retainedReuseTurnIds !== undefined ? { reuseTurnIds: retainedReuseTurnIds.reuseTurnIds } : {}),
+    ...(input.reuseTurnIdsTruncated === true || retainedReuseTurnIds?.truncated
+      ? { reuseTurnIdsTruncated: true as const }
+      : {}),
+    ...(input.taskId ? { taskId: input.taskId } : {}),
+    ...(input.requirementId ? { requirementId: input.requirementId } : {}),
     ...(input.logicalRunId ? { logicalRunId: input.logicalRunId } : {}),
     ...(input.executionId ? { executionId: input.executionId } : {}),
     ...(input.projectionId ? { projectionId: input.projectionId } : {}),

--- a/src/main/features/kstar/episode-store.ts
+++ b/src/main/features/kstar/episode-store.ts
@@ -5,6 +5,7 @@ import { createLogger } from '../../logger';
 import { safeId, writeJson } from '../../storage';
 import { fileEditLock } from '../../util/locks';
 import { kstarEpisodePath, kstarRecordPath } from './paths';
+import { isCanonicalKstarReuseTurnIds } from './reuse-turn-ids';
 import {
   KSTAR_SCHEMA_VERSION,
   type KstarEpisodeRecord,
@@ -50,6 +51,10 @@ function validateEpisode(userId: string, episodeId: string, value: unknown): Kst
   assertPlainObject(record.r, 'kstar episode R');
   if (
     typeof record.sessionId !== 'string' || !record.sessionId ||
+    (record.reuseTurnIds !== undefined && !isCanonicalKstarReuseTurnIds(record.reuseTurnIds)) ||
+    (record.reuseTurnIdsTruncated !== undefined && record.reuseTurnIdsTruncated !== true) ||
+    (record.taskId !== undefined && (typeof record.taskId !== 'string' || !safeId(record.taskId))) ||
+    (record.requirementId !== undefined && (typeof record.requirementId !== 'string' || !safeId(record.requirementId))) ||
     typeof record.t.userGoal !== 'string' || !record.t.userGoal ||
     !Array.isArray(record.k.memoryRefs) ||
     !Array.isArray(record.k.contextRefs) ||

--- a/src/main/features/kstar/index.ts
+++ b/src/main/features/kstar/index.ts
@@ -23,3 +23,4 @@ export * from './projection-decision-service';
 export * from './trace-types';
 export * from './trace';
 export * from './failure-service';
+export * from './run-evidence';

--- a/src/main/features/kstar/receipt-relationship.ts
+++ b/src/main/features/kstar/receipt-relationship.ts
@@ -1,0 +1,14 @@
+import type { AssetUsageReceipt } from '../recall/asset-usage-receipt';
+import type { InjectionReceipt } from '../recall/injection-receipt';
+
+export function usageMatchesInjection(
+  usage: AssetUsageReceipt,
+  injection: InjectionReceipt,
+): boolean {
+  return usage.injectionReceiptId === injection.id
+    && usage.taskRunId === injection.taskRunId
+    && usage.projectionId === injection.projectionId
+    && usage.assetId === injection.assetId
+    && usage.assetVersion === injection.assetVersion
+    && usage.boundary === injection.boundary;
+}

--- a/src/main/features/kstar/requirement-state.ts
+++ b/src/main/features/kstar/requirement-state.ts
@@ -31,20 +31,36 @@ function uniqueIds(ids: string[], next: string): string[] {
   return ids.includes(next) ? ids : [...ids, next];
 }
 
-export async function attachKstarEpisodeToCurrentRequirement(
+export async function attachKstarEpisodeToRequirement(
   userId: string,
-  input: { conversationId: string; episodeId: string; projectionId?: string; wakeRequestId?: string },
+  input: {
+    conversationId: string;
+    episodeId: string;
+    taskId?: string;
+    requirementId?: string;
+    projectionId?: string;
+    wakeRequestId?: string;
+  },
+  options: { allowCurrentRequirementFallback?: boolean } = {},
 ): Promise<void> {
   if (!safeId(userId) || !safeId(input.conversationId) || !safeId(input.episodeId)) {
     throw new Error('invalid kstar episode attachment reference');
   }
   if (input.projectionId !== undefined && !safeId(input.projectionId)) throw new Error('invalid kstar episode projection reference');
   if (input.wakeRequestId !== undefined && !safeId(input.wakeRequestId)) throw new Error('invalid kstar episode wake reference');
+  if (input.taskId !== undefined && !safeId(input.taskId)) throw new Error('invalid kstar episode task reference');
+  if (input.requirementId !== undefined && !safeId(input.requirementId)) throw new Error('invalid kstar episode requirement reference');
   const state = await readConversationTaskState(userId, input.conversationId);
-  if (!state?.currentTaskId) return;
-  const task = await readKstarTask(userId, state.currentTaskId);
+  const taskId = input.taskId || state?.currentTaskId;
+  if (!taskId) return;
+  const task = await readKstarTask(userId, taskId);
   if (!task) return;
+  if (task.conversationId !== input.conversationId) throw new Error('kstar episode task conversation mismatch');
   const requirements = await listKstarRequirementsForTask(userId, task.id);
+  const explicitRequirement = input.requirementId
+    ? requirements.find((candidate) => candidate.id === input.requirementId)
+    : undefined;
+  if (input.requirementId && !explicitRequirement) throw new Error('kstar episode requirement does not belong to task');
   const provenanceMatches = requirements.filter((requirement) => {
     if (requirement.status === 'closed' || requirement.status === 'abandoned') return false;
     if (input.projectionId && requirement.projectionId === input.projectionId) return true;
@@ -52,12 +68,28 @@ export async function attachKstarEpisodeToCurrentRequirement(
     return false;
   });
   let requirement: KstarRequirementRecord | null = null;
-  if (provenanceMatches.length === 1) {
+  if (explicitRequirement) {
+    requirement = explicitRequirement;
+  } else if (provenanceMatches.length === 1) {
     requirement = provenanceMatches[0];
   } else if (provenanceMatches.length > 1) {
     throw new Error('multiple kstar requirements match episode provenance');
-  } else if (state.currentRequirementId) {
+  } else if (state.currentRequirementId && options.allowCurrentRequirementFallback !== false) {
     requirement = await readKstarRequirement(userId, state.currentRequirementId);
+    if (requirement && (requirement.status === 'closed' || requirement.status === 'abandoned')) {
+      // A closed/abandoned current requirement is never a fallback target:
+      // drop it so the shared closed/abandoned gate below returns silently
+      // (pre-membership-check behavior) instead of surfacing a foreign-task
+      // membership error for a requirement we would not attach to anyway.
+      requirement = null;
+    } else if (requirement && requirement.taskId !== task.id) {
+      // The current-requirement fallback is only sound when the conversation's
+      // current requirement actually belongs to the task resolved above (the
+      // conversation may have moved to a different task mid-run). Without this
+      // membership check a lost-provenance episode would silently attach to an
+      // unrelated requirement. It applies to an OPEN current requirement only.
+      throw new Error('kstar current requirement does not belong to episode task');
+    }
   }
   if (!requirement || requirement.status === 'closed' || requirement.status === 'abandoned') return;
   if ((input.projectionId || input.wakeRequestId) && provenanceMatches.length === 0) {
@@ -72,4 +104,12 @@ export async function attachKstarEpisodeToCurrentRequirement(
   requirement.episodeIds = uniqueIds(requirement.episodeIds, input.episodeId);
   requirement.updatedAt = nowIso();
   await replaceKstarRequirement(userId, requirement);
+}
+
+/** Backward-compatible current-lifecycle adapter for non-snapshotted callers. */
+export async function attachKstarEpisodeToCurrentRequirement(
+  userId: string,
+  input: { conversationId: string; episodeId: string; projectionId?: string; wakeRequestId?: string },
+): Promise<void> {
+  return attachKstarEpisodeToRequirement(userId, input);
 }

--- a/src/main/features/kstar/reuse-turn-ids.ts
+++ b/src/main/features/kstar/reuse-turn-ids.ts
@@ -1,0 +1,41 @@
+import { safeId } from '../../storage';
+
+export const KSTAR_MAX_REUSE_TURN_IDS = 100;
+export const KSTAR_MAX_REUSE_TURN_ID_LENGTH = 160;
+
+export function isKstarReuseTurnId(value: unknown): value is string {
+  return typeof value === 'string'
+    && value.length <= KSTAR_MAX_REUSE_TURN_ID_LENGTH
+    && safeId(value);
+}
+
+export function normalizeKstarReuseTurnIds(values: readonly unknown[]): string[] {
+  return retainKstarReuseTurnIds(values).reuseTurnIds;
+}
+
+/** Fixed-size retention keeps the newest authoritative receipt ids. Callers
+ * must persist `truncated` so the retained suffix is never mistaken for a
+ * complete ownership set. */
+export function retainKstarReuseTurnIds(values: readonly unknown[]): {
+  reuseTurnIds: string[];
+  truncated: boolean;
+} {
+  const newestFirst: string[] = [];
+  const seen = new Set<string>();
+  let truncated = false;
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    const value = values[index];
+    if (!isKstarReuseTurnId(value) || seen.has(value)) continue;
+    seen.add(value);
+    if (newestFirst.length < KSTAR_MAX_REUSE_TURN_IDS) newestFirst.push(value);
+    else truncated = true;
+  }
+  return { reuseTurnIds: newestFirst.reverse(), truncated };
+}
+
+export function isCanonicalKstarReuseTurnIds(value: unknown): value is string[] {
+  return Array.isArray(value)
+    && value.length <= KSTAR_MAX_REUSE_TURN_IDS
+    && value.every(isKstarReuseTurnId)
+    && new Set(value).size === value.length;
+}

--- a/src/main/features/kstar/run-evidence.ts
+++ b/src/main/features/kstar/run-evidence.ts
@@ -1,0 +1,458 @@
+import { nowIso, safeId } from '../../storage';
+import {
+  listAbilityAssetVersions,
+  type AbilityAssetVersionRecord,
+} from '../recall/asset-service';
+import {
+  listAssetUsageReceipts,
+  type AssetUsageReceipt,
+} from '../recall/asset-usage-receipt';
+import {
+  readContextProjection,
+  type ContextProjectionRecord,
+  type RecallAssetMatchMethod,
+} from '../recall/context-projection';
+import {
+  listInjectionReceipts,
+  type InjectionReceipt,
+} from '../recall/injection-receipt';
+import {
+  listEffectivenessProofs,
+  listTransferProofs,
+  type EffectivenessProofRecord,
+  type TransferProofRecord,
+} from '../recall/proof-service';
+import {
+  listValidationRecords,
+  type ValidationRecord,
+} from '../recall/validation-service';
+import { readKstarEpisode } from './episode-store';
+import {
+  readKstarRequirement,
+  readKstarTask,
+} from './requirement-store';
+import { readKstarReview } from './review-service';
+import { usageMatchesInjection } from './receipt-relationship';
+import type { KstarRequirementRecord } from './requirement-types';
+import type {
+  KstarEpisodeRecord,
+  KstarReviewRecord,
+} from './types';
+
+export interface KstarRunEvidenceInput {
+  taskId: string;
+  taskRunId: string;
+}
+
+export type KstarRunEvidenceGap =
+  | 'task_run_not_linked'
+  | 'projection_not_recorded'
+  | 'asset_version_snapshot_not_recorded'
+  | 'injection_not_recorded'
+  | 'usage_not_recorded'
+  | 'execution_not_recorded'
+  | 'review_not_recorded'
+  | 'reuse_turn_ids_truncated'
+  | 'effectiveness_not_recorded'
+  | 'output_truncated';
+
+export interface KstarRunEvidenceAsset {
+  assetId: string;
+  assetVersion: string;
+  snapshot: AbilityAssetVersionRecord['snapshot'] | null;
+  matches: Array<{
+    projectionId: string;
+    matchScore: number;
+    matchMethod: RecallAssetMatchMethod;
+  }>;
+  injectionReceipts: InjectionReceipt[];
+  usageReceipts: AssetUsageReceipt[];
+}
+
+export interface KstarRunEvidence {
+  taskId: string;
+  taskRunId: string;
+  conversationId: string;
+  requirementIds: string[];
+  projections: ContextProjectionRecord[];
+  injectionReceipts: InjectionReceipt[];
+  usageReceipts: AssetUsageReceipt[];
+  assets: KstarRunEvidenceAsset[];
+  episodes: KstarEpisodeRecord[];
+  reviews: KstarReviewRecord[];
+  transferProofs: TransferProofRecord[];
+  effectivenessProofs: EffectivenessProofRecord[];
+  validations: ValidationRecord[];
+  /** True when any returned collection hit the per-collection cap. */
+  truncated: boolean;
+  gaps: KstarRunEvidenceGap[];
+  generatedAt: string;
+}
+
+function byId<T extends { id: string }>(left: T, right: T): number {
+  return left.id.localeCompare(right.id);
+}
+
+function uniqueById<T extends { id: string }>(records: T[]): T[] {
+  const byRecordId = new Map<string, T>();
+  for (const record of records) {
+    if (!byRecordId.has(record.id)) byRecordId.set(record.id, record);
+  }
+  return [...byRecordId.values()];
+}
+
+function receiptRunIds(episode: KstarEpisodeRecord): string[] {
+  return episode.reuseTurnIds !== undefined
+    ? episode.reuseTurnIds
+    : episode.taskRunId
+      ? [episode.taskRunId]
+      : [];
+}
+
+function assetVersionKey(assetId: string, assetVersion: string): string {
+  return JSON.stringify([assetId, assetVersion]);
+}
+
+function compareAssetVersions(
+  left: Pick<KstarRunEvidenceAsset, 'assetId' | 'assetVersion'>,
+  right: Pick<KstarRunEvidenceAsset, 'assetId' | 'assetVersion'>,
+): number {
+  return left.assetId.localeCompare(right.assetId)
+    || left.assetVersion.localeCompare(right.assetVersion);
+}
+
+/**
+ * Hard cap applied to every returned collection (episodes, projections,
+ * injectionReceipts, usageReceipts, assets, reviews, transferProofs,
+ * effectivenessProofs, validations) so the IPC payload cannot grow without
+ * bound. Real aggregate runs stay far below this. When any collection is
+ * capped the result reports `truncated: true` and adds `output_truncated` to
+ * gaps so callers never mistake the partial payload for complete evidence.
+ */
+const EVIDENCE_COLLECTION_CAP = 1000;
+
+function capped<T>(records: T[]): { records: T[]; truncated: boolean } {
+  return records.length > EVIDENCE_COLLECTION_CAP
+    ? { records: records.slice(0, EVIDENCE_COLLECTION_CAP), truncated: true }
+    : { records, truncated: false };
+}
+
+async function readLinkedProjection(
+  userId: string,
+  projectionId: string,
+  logicalTaskId: string,
+): Promise<ContextProjectionRecord | null> {
+  try {
+    const projection = await readContextProjection(userId, projectionId);
+    return projection.taskRunId === logicalTaskId ? projection : null;
+  } catch (error) {
+    if (error instanceof Error && error.message === 'context projection not found') return null;
+    throw error;
+  }
+}
+
+export async function readKstarRunEvidence(
+  userId: string,
+  input: KstarRunEvidenceInput,
+): Promise<KstarRunEvidence> {
+  if (!input || !safeId(userId) || !safeId(input.taskId) || !safeId(input.taskRunId)) {
+    throw new Error('invalid KSTAR run evidence reference');
+  }
+
+  const task = await readKstarTask(userId, input.taskId);
+  if (!task) throw new Error('kstar task not found');
+
+  // Authoritative Requirements are read directly per id (stable, deduplicated)
+  // so a corrupt referenced record propagates instead of being silently skipped
+  // by the degraded-record listing path.
+  const requirements: KstarRequirementRecord[] = [];
+  const seenRequirementIds = new Set<string>();
+  for (const requirementId of task.requirementIds) {
+    if (seenRequirementIds.has(requirementId)) continue;
+    seenRequirementIds.add(requirementId);
+    const requirement = await readKstarRequirement(userId, requirementId);
+    if (requirement) requirements.push(requirement);
+  }
+  const matchingRequirementIds: string[] = [];
+  const matchingEpisodes: KstarEpisodeRecord[] = [];
+  const linkedProjectionIds = new Set<string>();
+
+  for (const requirement of requirements) {
+    const episodes = (
+      await Promise.all(requirement.episodeIds.map((episodeId) => readKstarEpisode(userId, episodeId)))
+    ).filter((episode): episode is KstarEpisodeRecord => episode?.taskRunId === input.taskRunId);
+    if (!episodes.length) continue;
+
+    matchingRequirementIds.push(requirement.id);
+    matchingEpisodes.push(...episodes);
+    const requirementProjectionIds = new Set([
+      ...requirement.projectionIds,
+      ...(requirement.projectionId ? [requirement.projectionId] : []),
+    ]);
+    for (const episode of episodes) {
+      if (episode.projectionId && requirementProjectionIds.has(episode.projectionId)) {
+        linkedProjectionIds.add(episode.projectionId);
+      }
+    }
+  }
+
+  const episodes = uniqueById(matchingEpisodes).sort(byId);
+  const projections = (
+    await Promise.all([...linkedProjectionIds]
+      .sort()
+      .map((projectionId) => readLinkedProjection(userId, projectionId, task.id)))
+  ).filter((projection): projection is ContextProjectionRecord => Boolean(projection)).sort(byId);
+  const ownedProjectionIds = new Set(projections.map((projection) => projection.id));
+
+  const episodesByReceiptRunId = new Map<string, KstarEpisodeRecord[]>();
+  for (const episode of episodes) {
+    for (const runId of receiptRunIds(episode)) {
+      const current = episodesByReceiptRunId.get(runId) || [];
+      current.push(episode);
+      episodesByReceiptRunId.set(runId, current);
+    }
+  }
+  const receiptRunIdSet = new Set(episodesByReceiptRunId.keys());
+  const loadedInjections = receiptRunIdSet.size === 0
+    ? []
+    : (await listInjectionReceipts(userId))
+      .filter((receipt) => receiptRunIdSet.has(receipt.taskRunId));
+  const injectionReceipts = uniqueById(loadedInjections.filter((receipt) => {
+    const runEpisodes = episodesByReceiptRunId.get(receipt.taskRunId) || [];
+    if (receipt.projectionId) {
+      return ownedProjectionIds.has(receipt.projectionId)
+        && runEpisodes.some((episode) => episode.projectionId === receipt.projectionId);
+    }
+    return runEpisodes.length > 0;
+  })).sort(byId);
+  const injectionsById = new Map(injectionReceipts.map((receipt) => [receipt.id, receipt]));
+
+  const loadedUsage = receiptRunIdSet.size === 0
+    ? []
+    : (await listAssetUsageReceipts(userId))
+      .filter((receipt) => receiptRunIdSet.has(receipt.taskRunId));
+  const usageReceipts = uniqueById(loadedUsage.filter((receipt) => {
+    const injection = injectionsById.get(receipt.injectionReceiptId);
+    return Boolean(
+      injection
+      && usageMatchesInjection(receipt, injection)
+      && ownedProjectionIds.has(receipt.projectionId),
+    );
+  })).sort(byId);
+  const reviews = uniqueById((
+    await Promise.all(episodes.map((episode) => readKstarReview(userId, episode.id)))
+  ).filter((review): review is KstarReviewRecord => Boolean(review))).sort(byId);
+
+  const assetVersions = new Map<string, { assetId: string; assetVersion: string }>();
+  let hasMissingProjectionAssetVersion = false;
+  const includeAssetVersion = (assetId: string, assetVersion: string): void => {
+    const key = assetVersionKey(assetId, assetVersion);
+    if (!assetVersions.has(key)) assetVersions.set(key, { assetId, assetVersion });
+  };
+  for (const projection of projections) {
+    for (const assetId of projection.assetIds) {
+      const lockedVersion = projection.assetVersions?.[assetId];
+      if (lockedVersion) includeAssetVersion(assetId, lockedVersion);
+      else hasMissingProjectionAssetVersion = true;
+    }
+  }
+  for (const receipt of injectionReceipts) {
+    includeAssetVersion(receipt.assetId, receipt.assetVersion);
+  }
+  for (const receipt of usageReceipts) {
+    includeAssetVersion(receipt.assetId, receipt.assetVersion);
+  }
+  const requestedAssetVersions = [...assetVersions.values()].sort(compareAssetVersions);
+  const snapshotsByAssetId = new Map<
+    string,
+    Map<string, AbilityAssetVersionRecord['snapshot']>
+  >();
+  await Promise.all([...new Set(requestedAssetVersions.map(({ assetId }) => assetId))]
+    .map(async (assetId) => {
+      const versions = await listAbilityAssetVersions(userId, assetId);
+      snapshotsByAssetId.set(
+        assetId,
+        new Map(versions.map((record) => [record.version, record.snapshot])),
+      );
+    }));
+  const assets = requestedAssetVersions
+    .map(({ assetId, assetVersion }): KstarRunEvidenceAsset => ({
+      assetId,
+      assetVersion,
+      snapshot: snapshotsByAssetId.get(assetId)?.get(assetVersion) ?? null,
+      matches: projections
+        .filter((projection) => projection.assetVersions?.[assetId] === assetVersion)
+        .flatMap((projection) => (projection.assetMatches || [])
+          .filter((match) => match.assetId === assetId)
+          .map((match) => ({
+            projectionId: projection.id,
+            matchScore: match.matchScore,
+            matchMethod: match.matchMethod,
+          })))
+        .sort((left, right) => left.projectionId.localeCompare(right.projectionId)
+          || left.matchMethod.localeCompare(right.matchMethod)
+          || left.matchScore - right.matchScore),
+      injectionReceipts: injectionReceipts.filter((receipt) => (
+        receipt.assetId === assetId && receipt.assetVersion === assetVersion
+      )),
+      usageReceipts: usageReceipts.filter((receipt) => (
+        receipt.assetId === assetId && receipt.assetVersion === assetVersion
+      )),
+    }));
+
+  const proofExecutionIdsByProjection = new Map<string, Set<string>>();
+  for (const episode of episodes) {
+    if (!episode.projectionId || !ownedProjectionIds.has(episode.projectionId)) continue;
+    const executionIds = proofExecutionIdsByProjection.get(episode.projectionId) || new Set<string>();
+    for (const executionId of [episode.executionId, episode.taskRunId, input.taskRunId]) {
+      if (executionId && safeId(executionId)) executionIds.add(executionId);
+    }
+    proofExecutionIdsByProjection.set(episode.projectionId, executionIds);
+  }
+  const transferProofs = proofExecutionIdsByProjection.size === 0
+    ? []
+    : (await listTransferProofs(userId))
+      .filter((proof) => proofExecutionIdsByProjection.get(proof.projectionId)?.has(proof.executionId))
+      .sort(byId);
+  const ownedTransferProofIds = new Set(transferProofs.map((proof) => proof.id));
+  const effectivenessProofs = ownedTransferProofIds.size === 0
+    ? []
+    : (await listEffectivenessProofs(userId))
+      .filter((proof) => ownedTransferProofIds.has(proof.transferProofId))
+      .sort(byId);
+
+  const ownedAssetIds = new Set(assets.map((asset) => asset.assetId));
+  const transferAssetIdsByExecution = new Map<string, Set<string>>();
+  for (const proof of transferProofs) {
+    const assetIds = transferAssetIdsByExecution.get(proof.executionId) || new Set<string>();
+    for (const asset of proof.assetVersions) {
+      if (ownedAssetIds.has(asset.assetId)) assetIds.add(asset.assetId);
+    }
+    transferAssetIdsByExecution.set(proof.executionId, assetIds);
+  }
+  const validations = transferAssetIdsByExecution.size === 0
+    ? []
+    : (await listValidationRecords(userId))
+      .filter((validation) => transferAssetIdsByExecution
+        .get(validation.taskRunId)?.has(validation.assetId))
+      .sort(byId);
+
+  // Conservative per-owner gap semantics: presence of evidence for one owner
+  // must not hide missing evidence for another owner of the same aggregate run.
+  const ownedEpisodes = episodes.filter((episode) => (
+    Boolean(episode.projectionId) && ownedProjectionIds.has(episode.projectionId)
+  ));
+  const reviewedEpisodeIds = new Set(reviews.map((review) => review.episodeId));
+  const hasAuthoritativeReceiptRunIds = (episode: KstarEpisodeRecord): boolean => (
+    episode.reuseTurnIds !== undefined
+      ? episode.reuseTurnIds.length > 0
+      : Boolean(episode.taskRunId)
+  );
+  const expectsInjections = ownedEpisodes.some(hasAuthoritativeReceiptRunIds);
+  const ownedInjectionChain = injectionReceipts.filter((receipt) => Boolean(receipt.projectionId));
+  const injectionWithoutUsage = ownedInjectionChain.some((injection) => (
+    !usageReceipts.some((usage) => usageMatchesInjection(usage, injection))
+  ));
+  const transferProofWithoutEffectiveness = transferProofs.some((proof) => (
+    !effectivenessProofs.some((effectiveness) => effectiveness.transferProofId === proof.id)
+  ));
+  // The legacy no-transfer-proof fallback is scoped to OWNED Episodes: a
+  // terminal Episode whose linked Projection is missing/mismatched (unowned),
+  // or a non-terminal owned Episode, must not manufacture an effectiveness
+  // expectation. `ownedEpisodes` empty => expectsEffectiveness false => the
+  // fallback stays silent.
+  const expectsEffectiveness = ownedEpisodes.some((episode) => (
+    episode.r.status === 'completed' || episode.r.status === 'failed'
+  ));
+
+  const gaps: KstarRunEvidenceGap[] = [];
+  if (!episodes.length) gaps.push('task_run_not_linked');
+  if (!projections.length) gaps.push('projection_not_recorded');
+  if (hasMissingProjectionAssetVersion || assets.some((asset) => asset.snapshot === null)) {
+    gaps.push('asset_version_snapshot_not_recorded');
+  }
+  if (!episodes.length) {
+    // No authoritative Episode: nothing at all was recorded for this run, so
+    // every evidence-type gap is reported (execution_not_recorded included).
+    gaps.push('injection_not_recorded');
+    gaps.push('usage_not_recorded');
+    gaps.push('execution_not_recorded');
+    gaps.push('review_not_recorded');
+    gaps.push('effectiveness_not_recorded');
+  } else {
+    // injection_not_recorded is deliberately aggregate-run scoped: a single
+    // user-triggered run accumulates one cumulative reuseTurnIds list and emits
+    // one terminal per run, and owned Episodes of one run inherit overlapping
+    // lists. Masking a hypothetical disjoint per-Episode list (one owner with
+    // zero resolved injections while another resolves one) is the intended
+    // contract, so the run-level signal stays a single gate on the run.
+    if (expectsInjections && injectionReceipts.length === 0) gaps.push('injection_not_recorded');
+    if (injectionWithoutUsage) gaps.push('usage_not_recorded');
+    if (ownedEpisodes.some((episode) => !reviewedEpisodeIds.has(episode.id))) {
+      gaps.push('review_not_recorded');
+    }
+    if (ownedEpisodes.some((episode) => episode.reuseTurnIdsTruncated === true)) {
+      gaps.push('reuse_turn_ids_truncated');
+    }
+    if (transferProofWithoutEffectiveness || (transferProofs.length === 0 && expectsEffectiveness)) {
+      gaps.push('effectiveness_not_recorded');
+    }
+  }
+
+  const keptEpisodes = capped(episodes);
+  const keptProjections = capped(projections);
+  const keptInjectionReceipts = capped(injectionReceipts);
+  const keptUsageReceipts = capped(usageReceipts);
+  const keptAssets = capped(assets);
+  const keptReviews = capped(reviews);
+  const keptTransferProofs = capped(transferProofs);
+  const keptEffectivenessProofs = capped(effectivenessProofs);
+  const keptValidations = capped(validations);
+  let truncated = [
+    keptEpisodes,
+    keptProjections,
+    keptInjectionReceipts,
+    keptUsageReceipts,
+    keptAssets,
+    keptReviews,
+    keptTransferProofs,
+    keptEffectivenessProofs,
+    keptValidations,
+  ].some((entry) => entry.truncated);
+  const outputAssets = keptAssets.records.map((asset) => {
+    // Cap the nested per-asset sub-lists too so one Asset cannot carry an
+    // unbounded payload even when the top-level collection is capped.
+    const matches = capped(asset.matches);
+    const injectionReceipts = capped(asset.injectionReceipts);
+    const usageReceipts = capped(asset.usageReceipts);
+    if (matches.truncated || injectionReceipts.truncated || usageReceipts.truncated) {
+      truncated = true;
+    }
+    return {
+      ...asset,
+      matches: matches.records,
+      injectionReceipts: injectionReceipts.records,
+      usageReceipts: usageReceipts.records,
+    };
+  });
+  if (truncated) gaps.push('output_truncated');
+
+  return {
+    taskId: task.id,
+    taskRunId: input.taskRunId,
+    conversationId: task.conversationId,
+    requirementIds: [...new Set(matchingRequirementIds)].sort(),
+    projections: keptProjections.records,
+    injectionReceipts: keptInjectionReceipts.records,
+    usageReceipts: keptUsageReceipts.records,
+    assets: outputAssets,
+    episodes: keptEpisodes.records,
+    reviews: keptReviews.records,
+    transferProofs: keptTransferProofs.records,
+    effectivenessProofs: keptEffectivenessProofs.records,
+    validations: keptValidations.records,
+    truncated,
+    gaps,
+    generatedAt: nowIso(),
+  };
+}

--- a/src/main/features/kstar/run-evidence.ts
+++ b/src/main/features/kstar/run-evidence.ts
@@ -165,22 +165,44 @@ export async function readKstarRunEvidence(
   // Authoritative Requirements are read directly per id (stable, deduplicated)
   // so a corrupt referenced record propagates instead of being silently skipped
   // by the degraded-record listing path.
+  const requirementRefs = capped([...new Set(task.requirementIds)].sort());
+  let traversalTruncated = requirementRefs.truncated;
   const requirements: KstarRequirementRecord[] = [];
   const seenRequirementIds = new Set<string>();
-  for (const requirementId of task.requirementIds) {
+  for (const requirementId of requirementRefs.records) {
     if (seenRequirementIds.has(requirementId)) continue;
     seenRequirementIds.add(requirementId);
     const requirement = await readKstarRequirement(userId, requirementId);
-    if (requirement) requirements.push(requirement);
+    if (!requirement) continue;
+    if (requirement.taskId !== task.id || requirement.conversationId !== task.conversationId) {
+      throw new Error('kstar requirement does not belong to task');
+    }
+    requirements.push(requirement);
   }
   const matchingRequirementIds: string[] = [];
   const matchingEpisodes: KstarEpisodeRecord[] = [];
   const linkedProjectionIds = new Set<string>();
+  let remainingEpisodeRefs = EVIDENCE_COLLECTION_CAP;
 
   for (const requirement of requirements) {
-    const episodes = (
-      await Promise.all(requirement.episodeIds.map((episodeId) => readKstarEpisode(userId, episodeId)))
-    ).filter((episode): episode is KstarEpisodeRecord => episode?.taskRunId === input.taskRunId);
+    const episodeIds = [...new Set(requirement.episodeIds)].sort();
+    const retainedEpisodeIds = episodeIds.slice(0, remainingEpisodeRefs);
+    if (retainedEpisodeIds.length < episodeIds.length) traversalTruncated = true;
+    remainingEpisodeRefs -= retainedEpisodeIds.length;
+    const loadedEpisodes = await Promise.all(
+      retainedEpisodeIds.map((episodeId) => readKstarEpisode(userId, episodeId)),
+    );
+    const episodes: KstarEpisodeRecord[] = [];
+    for (const episode of loadedEpisodes) {
+      if (!episode) continue;
+      if (
+        (episode.taskId !== undefined && episode.taskId !== task.id)
+        || (episode.requirementId !== undefined && episode.requirementId !== requirement.id)
+      ) {
+        throw new Error('kstar episode does not belong to requirement');
+      }
+      if (episode.taskRunId === input.taskRunId) episodes.push(episode);
+    }
     if (!episodes.length) continue;
 
     matchingRequirementIds.push(requirement.id);
@@ -408,7 +430,7 @@ export async function readKstarRunEvidence(
   const keptTransferProofs = capped(transferProofs);
   const keptEffectivenessProofs = capped(effectivenessProofs);
   const keptValidations = capped(validations);
-  let truncated = [
+  let truncated = traversalTruncated || [
     keptEpisodes,
     keptProjections,
     keptInjectionReceipts,

--- a/src/main/features/kstar/secondary-attribution.ts
+++ b/src/main/features/kstar/secondary-attribution.ts
@@ -7,6 +7,7 @@ import {
 } from '../recall/source-service';
 import type { AssetUsageReceipt } from '../recall/asset-usage-receipt';
 import type { InjectionReceipt } from '../recall/injection-receipt';
+import { usageMatchesInjection } from './receipt-relationship';
 import type { KstarAttributionDetail, KstarEpisodeRecord } from './types';
 
 export const KSTAR_SECONDARY_ATTRIBUTIONS = [
@@ -170,18 +171,24 @@ function matchesEnvironment(value: string): boolean {
 
 function scopedInjections(context: DeterministicAttributionContext): InjectionReceipt[] {
   const { episode } = context;
+  const runIds = new Set(episode.reuseTurnIds !== undefined
+    ? episode.reuseTurnIds
+    : episode.taskRunId ? [episode.taskRunId] : []);
   return (context.injectionReceipts || []).filter((receipt) => (
-    (!episode.taskRunId || receipt.taskRunId === episode.taskRunId)
+    runIds.has(receipt.taskRunId)
     && (!episode.projectionId || receipt.projectionId === episode.projectionId)
   ));
 }
 
-function scopedUsage(context: DeterministicAttributionContext): AssetUsageReceipt[] {
-  const { episode } = context;
-  return (context.usageReceipts || []).filter((receipt) => (
-    (!episode.taskRunId || receipt.taskRunId === episode.taskRunId)
-    && (!episode.projectionId || receipt.projectionId === episode.projectionId)
-  ));
+function scopedUsage(
+  context: DeterministicAttributionContext,
+  injections: readonly InjectionReceipt[],
+): AssetUsageReceipt[] {
+  const injectionsById = new Map(injections.map((receipt) => [receipt.id, receipt]));
+  return (context.usageReceipts || []).filter((receipt) => {
+    const injection = injectionsById.get(receipt.injectionReceiptId);
+    return injection !== undefined && usageMatchesInjection(receipt, injection);
+  });
 }
 
 /** Derive one highest-priority secondary cause from persisted facts. This is
@@ -193,7 +200,7 @@ export function deriveDeterministicAttributionDetails(
   const { episode } = context;
   const metadata = metadataText(episode);
   const injections = scopedInjections(context);
-  const usage = scopedUsage(context);
+  const usage = scopedUsage(context, injections);
   const assetIds = new Set(episode.k.abilityAssetRefs.filter((id) => safeId(id)));
 
   if (context.userGoalChanged) return detail(episode, 'user_goal_changed', 0.98);

--- a/src/main/features/kstar/task-closure.ts
+++ b/src/main/features/kstar/task-closure.ts
@@ -145,13 +145,22 @@ async function finishClosure(
     injectionReceipts: [],
     usageReceipts: [],
   };
-  if (episode.taskRunId) {
+  const receiptRunIds = episode.reuseTurnIds !== undefined
+    ? [...new Set(episode.reuseTurnIds)]
+    : episode.taskRunId
+      ? [episode.taskRunId]
+      : [];
+  if (receiptRunIds.length) {
     try {
+      const receiptRunIdSet = new Set(receiptRunIds);
       const [injectionReceipts, usageReceipts] = await Promise.all([
-        listInjectionReceipts(userId, episode.taskRunId),
-        listAssetUsageReceipts(userId, episode.taskRunId),
+        listInjectionReceipts(userId),
+        listAssetUsageReceipts(userId),
       ]);
-      attributionReceipts = { injectionReceipts, usageReceipts };
+      attributionReceipts = {
+        injectionReceipts: injectionReceipts.filter((receipt) => receiptRunIdSet.has(receipt.taskRunId)),
+        usageReceipts: usageReceipts.filter((receipt) => receiptRunIdSet.has(receipt.taskRunId)),
+      };
     } catch (error) {
       log.warn('kstar attribution receipt read degraded', {
         userId,
@@ -409,12 +418,17 @@ async function enrichEpisodeFromRequirementEvidence(
   userId: string,
   conversationId: string,
   episode: KstarEpisodeRecord,
+  requirementId?: string,
 ): Promise<KstarEpisodeRecord> {
   try {
-    const state = await readConversationTaskState(userId, conversationId);
-    const requirement = state?.currentRequirementId
-      ? await readKstarRequirement(userId, state.currentRequirementId)
+    const state = requirementId ? null : await readConversationTaskState(userId, conversationId);
+    const resolvedRequirementId = requirementId || state?.currentRequirementId;
+    const requirement = resolvedRequirementId
+      ? await readKstarRequirement(userId, resolvedRequirementId)
       : null;
+    if (requirement && requirement.conversationId !== conversationId) {
+      throw new Error('KSTAR requirement conversation mismatch');
+    }
     const evidence = requirement?.completionEvidence;
     if (!evidence) return episode;
     const r = { ...episode.r };
@@ -480,7 +494,22 @@ export async function captureGroupKstarClosure(input: GroupKstarClosureInput): P
     ...(teachingRefs.length ? { userTeachingSignalRefs: teachingRefs } : {}),
     ...(executionRefs.length ? { executionEvaluationRefs: executionRefs } : {}),
   });
-  let episode = await enrichEpisodeFromRequirementEvidence(input.userId, input.conversationId, built);
+  // New-format snapshot terminal events carry reuse_turn_ids ([] here is
+  // authoritative-empty, not "unknown"). When such an event reaches capture
+  // WITHOUT its task/requirement identity (transient provenance loss), the
+  // post-run current lifecycle may already belong to a LATER requirement — do
+  // not enrich from it. True legacy events (reuse_turn_ids undefined) keep the
+  // current-state fallback for backward compatibility.
+  const hasSnapshotFormat = built.reuseTurnIds !== undefined;
+  const degradedSnapshotWithoutRequirement = hasSnapshotFormat && !input.requirementId;
+  let episode = degradedSnapshotWithoutRequirement
+    ? built
+    : await enrichEpisodeFromRequirementEvidence(
+        input.userId,
+        input.conversationId,
+        built,
+        input.requirementId,
+      );
   // 空间归属：episode 构建链路（buildGroupKstarEpisode）不透传 workspaceId，
   // 这里从会话的 space_id 补齐——KStar 沉淀的资产才挂得到空间（空间资产
   // tab 按 asset.spaceId 过滤；否则全局可见但空间里看不到）。runtime 链路
@@ -525,20 +554,40 @@ export async function captureGroupKstarClosure(input: GroupKstarClosureInput): P
       conversationId: input.conversationId,
     });
   });
-  try {
-    const { attachKstarEpisodeToCurrentRequirement } = await import('./requirement-state');
-    await attachKstarEpisodeToCurrentRequirement(input.userId, {
-      conversationId: input.conversationId,
-      episodeId: episode.id,
-      ...(input.projectionId ? { projectionId: input.projectionId } : {}),
-      ...(input.wakeRequestId ? { wakeRequestId: input.wakeRequestId } : {}),
-    });
-  } catch (error) {
-    log.warn('kstar requirement episode attachment degraded', {
+  const degradedSnapshotWithoutIdentity = hasSnapshotFormat
+    && !input.taskId
+    && !input.requirementId
+    && !input.projectionId
+    && !input.wakeRequestId;
+  if (degradedSnapshotWithoutRequirement) {
+    // Snapshot episodes without a requirement identity can bind ONLY through a
+    // resolved projection/wake provenance match under the explicitly provided
+    // task — never through the post-run current-lifecycle fallback. Surface
+    // them so unattached degraded episodes stay observable (identifiers only,
+    // no private text).
+    log.warn('kstar snapshot episode has no requirement identity; attachment limited to provenance match', {
       userId: input.userId,
       episodeId: episode.id,
-      error: (error as Error).message,
     });
+  }
+  if (!degradedSnapshotWithoutIdentity) {
+    try {
+      const { attachKstarEpisodeToRequirement } = await import('./requirement-state');
+      await attachKstarEpisodeToRequirement(input.userId, {
+        conversationId: input.conversationId,
+        episodeId: episode.id,
+        ...(input.taskId ? { taskId: input.taskId } : {}),
+        ...(input.requirementId ? { requirementId: input.requirementId } : {}),
+        ...(input.projectionId ? { projectionId: input.projectionId } : {}),
+        ...(input.wakeRequestId ? { wakeRequestId: input.wakeRequestId } : {}),
+      }, { allowCurrentRequirementFallback: !hasSnapshotFormat });
+    } catch (error) {
+      log.warn('kstar requirement episode attachment degraded', {
+        userId: input.userId,
+        episodeId: episode.id,
+        error: (error as Error).message,
+      });
+    }
   }
   try {
     const { drainKstarTaskState } = await import('./task-aggregate');
@@ -651,7 +700,11 @@ export function startGroupKstarClosure(runtime: GroupKstarClosureRuntime = {}): 
           finishedAtMs: event.finished_at_ms,
           messages,
           ...(event.logical_run_id ? { logicalRunId: event.logical_run_id } : {}),
+          ...(event.task_id ? { taskId: event.task_id } : {}),
+          ...(event.requirement_id ? { requirementId: event.requirement_id } : {}),
           ...(event.execution_id ? { executionId: event.execution_id } : {}),
+          ...(event.reuse_turn_ids !== undefined ? { reuseTurnIds: event.reuse_turn_ids } : {}),
+          ...(event.reuse_turn_ids_truncated ? { reuseTurnIdsTruncated: true } : {}),
           ...(event.projection_id ? { projectionId: event.projection_id } : {}),
           ...(event.forecast_id ? { forecastId: event.forecast_id } : {}),
         });

--- a/src/main/features/kstar/types.ts
+++ b/src/main/features/kstar/types.ts
@@ -37,6 +37,13 @@ export interface KstarEpisodeRecord extends KstarJsonRecord {
   sessionId: string;
   sessionKind?: string;
   taskRunId?: string;
+  /** Per-turn run ids whose receipts are authoritatively associated with this aggregate run. */
+  reuseTurnIds?: string[];
+  /** True when reuseTurnIds is only the newest retained suffix, not complete ownership. */
+  reuseTurnIdsTruncated?: true;
+  /** Immutable lifecycle identities captured before the aggregate run was released. */
+  taskId?: string;
+  requirementId?: string;
   requestId?: string;
   runtimeSessionId?: string;
   /** Provenance hints for group-chat captures when a terminal event can be tied to a wake request. */

--- a/src/main/features/recall/terminal-proof.ts
+++ b/src/main/features/recall/terminal-proof.ts
@@ -21,6 +21,8 @@ export interface RecallTaskTerminalEvent {
    *  这是"资产被真实加载"的唯一凭证入口——PRD 3.6 的 Transfer Verified 要求
    *  真实加载 + 生成 Receipt，没有这份清单就只证明了任务跑完。 */
   reuse_turn_ids?: string[];
+  /** Retained ids are incomplete and therefore cannot authorize promotion. */
+  reuse_turn_ids_truncated?: true;
   started_at_ms: number;
   finished_at_ms: number;
 }
@@ -143,7 +145,9 @@ export async function handleRecallTaskTerminal(event: RecallTaskTerminalEvent): 
     return { handled: false, reason: 'no_confirmed_projection' };
   }
 
-  const { existing, receipts } = await loadedExistingAssets(event.user_id, event.reuse_turn_ids || []);
+  const { existing, receipts } = event.reuse_turn_ids_truncated
+    ? { existing: [], receipts: [] }
+    : await loadedExistingAssets(event.user_id, event.reuse_turn_ids || []);
 
   let proof = await findTransferProof(event.user_id, projection.id, executionId);
   if (!proof) {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -66,6 +66,7 @@ import * as kstarTaskClosure from '../features/kstar/task-closure';
 import * as kstarReviewService from '../features/kstar/review-service';
 import * as kstarTrace from '../features/kstar/trace';
 import * as kstarFailures from '../features/kstar/failure-service';
+import * as kstarRunEvidence from '../features/kstar/run-evidence';
 import * as recallProofs from '../features/recall/proof-service';
 import * as recallTree from '../features/recall/tree-service';
 import * as formalAssets from '../features/recall/formal-assets';
@@ -2769,6 +2770,13 @@ const invokeHandlers: Record<string, InvokeHandler> = {
     } catch (error) {
       return { ok: false, error: (error as Error).message };
     }
+  },
+  'kstar.runEvidence.read': async ({ taskId, taskRunId } = {}, ctx) => {
+    if (!safeId(taskId) || !safeId(taskRunId)) throw new Error('invalid kstar run evidence input');
+    return {
+      ok: true,
+      evidence: await kstarRunEvidence.readKstarRunEvidence(ctx.userId, { taskId, taskRunId }),
+    };
   },
   'recall.projections.card': async ({ projectionId } = {}, ctx) => { if (!safeId(projectionId)) throw new Error('invalid projection id'); return { ok: true, card: await recallProjectionCard.buildProjectionCard(ctx.userId, projectionId) }; },
   'recall.projections.postCard': async ({ cid, projectionId } = {}, ctx) => { if (!safeId(cid) || !safeId(projectionId)) throw new Error('invalid projection message'); return { ok: true, ...(await recallProjectionMessage.postProjectionCardMessage(ctx.userId, { cid, projectionId }, { send: async (payload) => ({ id: (await groupChat.sendCommanderMessage({ userId: ctx.userId, cid, text: String(payload.text || ''), ...(payload.card ? { recall_projection_card: { projectionId: payload.card.projectionId } } : {}) })).msg?.id || '' }) })) }; },

--- a/test/main/features/group_chat/bus-integration.test.ts
+++ b/test/main/features/group_chat/bus-integration.test.ts
@@ -5986,6 +5986,274 @@ describe("group_chat bus integration › task terminal boundary", () => {
     unsubscribe();
   }, 10_000);
 
+  it("freezes terminal provenance before releasing the active run", async () => {
+    const cid = newCid();
+    const state = await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) => terminals.push(event));
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [{ type: "__wait_for_abort__" }]);
+    await bus.enqueue({ uid: TEST_UID, cid, fromActorId: "user", text: `@${AGENT_NAME} freeze this run` });
+    expect(await waitUntil(() => !bus.isQuiescent(TEST_UID, cid))).toBe(true);
+    const active = bus._cidStateForTest(TEST_UID, cid) as any;
+    Object.assign(active.taskRun, {
+      taskId: "task-frozen",
+      requirementId: "requirement-frozen",
+      projectionId: "projection-frozen",
+      reuseTurnIds: ["receipt-turn-frozen"],
+    });
+
+    await bus.abort(TEST_UID, cid);
+    await waitForQuiescent(TEST_UID, cid, 3000);
+    expect(await waitUntil(() => terminals.length === 1)).toBe(true);
+
+    expect(bus._cidStateForTest(TEST_UID, cid)?.taskRun).toBeUndefined();
+    expect(terminals[0]).toMatchObject({
+      task_id: "task-frozen",
+      requirement_id: "requirement-frozen",
+      projection_id: "projection-frozen",
+      reuse_turn_ids: ["receipt-turn-frozen"],
+    });
+    expect(Object.isFrozen(terminals[0])).toBe(true);
+    expect(Object.isFrozen(terminals[0].reuse_turn_ids)).toBe(true);
+    unsubscribe();
+  }, 10_000);
+
+  it("keeps the first resolved KSTAR run identity across later user messages (passive capture only fills absent fields)", async () => {
+    const cid = newCid();
+    const state =
+      await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const store = await import("../../../../src/main/features/kstar/requirement-store");
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) =>
+      terminals.push(event),
+    );
+
+    // Task A + requirement A are the conversation lifecycle when the aggregate
+    // run opens; the first user message's passive capture resolves A.
+    const taskA = store.createKstarTaskRecord(TEST_UID, { conversationId: cid, title: "First task" });
+    const reqA = store.createKstarRequirementRecord(TEST_UID, {
+      taskId: taskA.id,
+      conversationId: cid,
+      userMessageIds: ["msg-fix1-a"],
+      title: "First requirement",
+      goalText: "Produce A",
+    });
+    await store.replaceKstarTask(TEST_UID, { ...taskA, requirementIds: [reqA.id], currentRequirementId: reqA.id });
+    await store.replaceKstarRequirement(TEST_UID, reqA);
+    await store.writeConversationTaskState(TEST_UID, {
+      ...store.createInitialConversationTaskState(TEST_UID, cid),
+      currentTaskId: taskA.id,
+      currentRequirementId: reqA.id,
+      taskComplete: false,
+    });
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "__wait_for_abort__" },
+      { type: "__wait_for_abort__" },
+    ]);
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: `@${AGENT_NAME} first message of the run`,
+    });
+    let active = bus._cidStateForTest(TEST_UID, cid) as any;
+    expect(active.taskRun).toBeTruthy();
+    expect(active.taskRun.taskId).toBe(taskA.id);
+    expect(active.taskRun.requirementId).toBe(reqA.id);
+
+    // Before the SECOND user message of the same aggregate run, the
+    // conversation moves to task B + requirement B. Passive per-message
+    // provenance capture must NOT overwrite the identity already resolved for
+    // this run (authoritative task decisions are the only overwrite source).
+    const taskB = store.createKstarTaskRecord(TEST_UID, { conversationId: cid, title: "Second task" });
+    const reqB = store.createKstarRequirementRecord(TEST_UID, {
+      taskId: taskB.id,
+      conversationId: cid,
+      userMessageIds: ["msg-fix1-b"],
+      title: "Second requirement",
+      goalText: "Produce B",
+    });
+    await store.replaceKstarTask(TEST_UID, { ...taskB, requirementIds: [reqB.id], currentRequirementId: reqB.id });
+    await store.replaceKstarRequirement(TEST_UID, reqB);
+    const movedState = await store.readConversationTaskState(TEST_UID, cid);
+    await store.replaceConversationTaskState(TEST_UID, {
+      ...movedState!,
+      currentTaskId: taskB.id,
+      currentRequirementId: reqB.id,
+      taskComplete: false,
+    });
+
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: `@${AGENT_NAME} second message of the run`,
+    });
+    active = bus._cidStateForTest(TEST_UID, cid) as any;
+    expect(active.taskRun.runId).toBeTruthy();
+    expect(active.taskRun.taskId).toBe(taskA.id);
+    expect(active.taskRun.requirementId).toBe(reqA.id);
+
+    await bus.abort(TEST_UID, cid);
+    await waitForQuiescent(TEST_UID, cid, 4000);
+    expect(await waitUntil(() => terminals.length >= 1)).toBe(true);
+
+    expect(terminals[0]).toMatchObject({
+      task_id: taskA.id,
+      requirement_id: reqA.id,
+    });
+    expect(terminals[0].task_id).not.toBe(taskB.id);
+    unsubscribe();
+  }, 15_000);
+
+  it("never pairs an authoritatively frozen task with a later requirement from a moved lifecycle (passive fill skips cross-task provenance)", async () => {
+    const cid = newCid();
+    const state =
+      await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const store = await import("../../../../src/main/features/kstar/requirement-store");
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) =>
+      terminals.push(event),
+    );
+
+    // Task A + requirement A records exist (the frozen run's task), but the
+    // conversation lifecycle ALREADY resolves to a different task B +
+    // requirement B when the aggregate run opens.
+    const taskA = store.createKstarTaskRecord(TEST_UID, { conversationId: cid, title: "Frozen task" });
+    const reqA = store.createKstarRequirementRecord(TEST_UID, {
+      taskId: taskA.id,
+      conversationId: cid,
+      userMessageIds: ["msg-frozen-a"],
+      title: "Frozen requirement",
+      goalText: "Produce A",
+    });
+    await store.replaceKstarTask(TEST_UID, { ...taskA, requirementIds: [reqA.id], currentRequirementId: reqA.id });
+    await store.replaceKstarRequirement(TEST_UID, reqA);
+    const taskB = store.createKstarTaskRecord(TEST_UID, { conversationId: cid, title: "Moved lifecycle task" });
+    const reqB = store.createKstarRequirementRecord(TEST_UID, {
+      taskId: taskB.id,
+      conversationId: cid,
+      userMessageIds: ["msg-moved-b"],
+      title: "Moved requirement",
+      goalText: "Produce B",
+    });
+    await store.replaceKstarTask(TEST_UID, { ...taskB, requirementIds: [reqB.id], currentRequirementId: reqB.id });
+    await store.replaceKstarRequirement(TEST_UID, reqB);
+    await store.writeConversationTaskState(TEST_UID, {
+      ...store.createInitialConversationTaskState(TEST_UID, cid),
+      currentTaskId: taskB.id,
+      currentRequirementId: reqB.id,
+      taskComplete: false,
+    });
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "__wait_for_abort__" },
+      { type: "__wait_for_abort__" },
+    ]);
+    // The run opens behind an AUTHORITATIVE task decision for task A while
+    // requirementId is not yet known (enqueue seed before the requirement is
+    // resolved). The passive per-message capture on the same enqueue sees the
+    // moved lifecycle (B/requirement B) and must not pair frozen task A with
+    // requirement B.
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: `@${AGENT_NAME} first message of the run`,
+      kstarTerminalProvenance: { taskId: taskA.id },
+    });
+    let active = bus._cidStateForTest(TEST_UID, cid) as any;
+    expect(active.taskRun).toBeTruthy();
+    expect(active.taskRun.taskId).toBe(taskA.id);
+
+    // The SECOND user message of the same aggregate run runs the passive fill
+    // capture again while the lifecycle still resolves to task B. The frozen
+    // task A must not gain requirement B (or any requirement from another
+    // task's lifecycle).
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: `@${AGENT_NAME} second message of the run`,
+    });
+    active = bus._cidStateForTest(TEST_UID, cid) as any;
+    expect(active.taskRun.runId).toBeTruthy();
+    expect(active.taskRun.taskId).toBe(taskA.id);
+    expect(active.taskRun.requirementId).toBeUndefined();
+
+    await bus.abort(TEST_UID, cid);
+    await waitForQuiescent(TEST_UID, cid, 4000);
+    expect(await waitUntil(() => terminals.length >= 1)).toBe(true);
+
+    expect(terminals[0]).toMatchObject({ task_id: taskA.id });
+    expect(terminals[0].task_id).not.toBe(taskB.id);
+    expect(terminals[0].requirement_id).toBeUndefined();
+    expect(terminals[0].requirement_id).not.toBe(reqB.id);
+    unsubscribe();
+  }, 15_000);
+
+  it("propagates reuse-turn truncation through a real aborted terminal cycle", async () => {
+    const cid = newCid();
+    const state = await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const {
+      KSTAR_MAX_REUSE_TURN_IDS,
+      retainKstarReuseTurnIds,
+    } = await import("../../../../src/main/features/kstar/reuse-turn-ids");
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) =>
+      terminals.push(event),
+    );
+
+    // A run that records more than KSTAR_MAX_REUSE_TURN_IDS distinct receipts
+    // leaves the taskRun in exactly this shape: the newest
+    // KSTAR_MAX_REUSE_TURN_IDS ids retained by retainKstarReuseTurnIds plus
+    // the truncated marker. Re-derive that state with the production helper so
+    // the seeded list is the canonical post-recording suffix (the terminal
+    // emitter mirrors the taskRun list as-is; real recording never stores more
+    // than KSTAR_MAX_REUSE_TURN_IDS entries).
+    const overLimitTurns = Array.from(
+      { length: KSTAR_MAX_REUSE_TURN_IDS + 1 },
+      (_, index) => `turn-trunc-${String(index).padStart(3, "0")}`,
+    );
+    const retained = retainKstarReuseTurnIds(overLimitTurns);
+    expect(retained.truncated).toBe(true);
+    expect(retained.reuseTurnIds).toHaveLength(KSTAR_MAX_REUSE_TURN_IDS);
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "__wait_for_abort__" },
+    ]);
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: `@${AGENT_NAME} run that truncates reuse turns`,
+    });
+    expect(await waitUntil(() => !bus.isQuiescent(TEST_UID, cid))).toBe(true);
+    const active = bus._cidStateForTest(TEST_UID, cid) as any;
+    Object.assign(active.taskRun, {
+      reuseTurnIds: retained.reuseTurnIds,
+      reuseTurnIdsTruncated: true,
+    });
+
+    await bus.abort(TEST_UID, cid);
+    await waitForQuiescent(TEST_UID, cid, 3000);
+    expect(await waitUntil(() => terminals.length === 1)).toBe(true);
+
+    expect(terminals[0].reuse_turn_ids_truncated).toBe(true);
+    expect(terminals[0].reuse_turn_ids).toEqual(retained.reuseTurnIds);
+    expect(terminals[0].reuse_turn_ids.length).toBeLessThanOrEqual(
+      KSTAR_MAX_REUSE_TURN_IDS,
+    );
+    expect(Object.isFrozen(terminals[0].reuse_turn_ids)).toBe(true);
+    unsubscribe();
+  }, 10_000);
+
   it("classifies model errors as failed", async () => {
     const cid = newCid();
     const state =
@@ -6103,6 +6371,394 @@ describe("group_chat bus integration › task terminal boundary", () => {
     expect(await waitUntil(() => terminals.length === 1)).toBe(true);
 
     expect(terminals[0].status).toBe("cancelled");
+    unsubscribe();
+  }, 10_000);
+
+  it("restores persisted reuse turns when recovering a persisted user dispatch", async () => {
+    const cid = newCid();
+    const messageId = "msg-recovered-dispatch";
+    const actionRequestId = "request-recovered-dispatch";
+    const turnId = "recovered-dispatch-turn";
+    const state =
+      await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const layout = await import("../../../../src/main/util/project-layout");
+    const storage = await import("../../../../src/main/storage");
+    const receipts = await import(
+      "../../../../src/main/features/p3394/context-reuse-receipt"
+    );
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) =>
+      terminals.push(event),
+    );
+
+    const persistedMessageTs = new Date().toISOString();
+    const messageFile = layout.conversationMessageFile(TEST_UID, cid);
+    fs.mkdirSync(path.dirname(messageFile), { recursive: true });
+    await storage.appendJsonlAtomic(messageFile, {
+      id: messageId,
+      ts: persistedMessageTs,
+      from: "user",
+      to: [AGENT_ID],
+      text: "resume the persisted task",
+      action_request_id: actionRequestId,
+    });
+    expect(
+      await waitUntil(() => Date.now() > Date.parse(persistedMessageTs)),
+    ).toBe(true);
+    const recoveredTargetSessionId = state.buildGmemberSessionId(cid, AGENT_ID);
+    const receipt = await receipts.prepareReceipt(
+      TEST_UID,
+      {
+        executionId: `turn-${turnId}`,
+        targetSessionId: recoveredTargetSessionId,
+        reusedRefs: ["asset:recovered@v1"],
+        omittedRefs: [],
+        permissionMode: "read-only",
+        allowedScopes: ["cognition:projection"],
+        boundary: "real",
+      },
+      { sessionId: recoveredTargetSessionId },
+    );
+    expect(Date.parse(receipt.createdAt)).toBeGreaterThan(
+      Date.parse(persistedMessageTs),
+    );
+    expect(
+      await waitUntil(() => Date.now() > Date.parse(receipt.createdAt)),
+    ).toBe(true);
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "final", text: "recovered task completed" },
+    ]);
+
+    await expect(bus.recoverPersistedUserDispatch({
+      uid: TEST_UID,
+      cid,
+      messageId,
+      actionRequestId,
+      recipientId: AGENT_ID,
+      turnId,
+    })).resolves.toMatchObject({ disposition: "redispatched" });
+    await waitForQuiescent(TEST_UID, cid, 3000);
+    expect(await waitUntil(() => terminals.length === 1)).toBe(true);
+
+    expect(terminals[0].reuse_turn_ids).toEqual([turnId]);
+    expect(terminals[0].started_at_ms).toBe(Date.parse(persistedMessageTs));
+    unsubscribe();
+  }, 10_000);
+
+  it("emits an authoritative empty reuse turn list when a recovered dispatch has no receipt", async () => {
+    const cid = newCid();
+    const messageId = "msg-recovered-dispatch-no-receipt";
+    const actionRequestId = "request-recovered-dispatch-no-receipt";
+    const turnId = "recovered-dispatch-no-receipt-turn";
+    const state =
+      await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const layout = await import("../../../../src/main/util/project-layout");
+    const storage = await import("../../../../src/main/storage");
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) =>
+      terminals.push(event),
+    );
+
+    const messageFile = layout.conversationMessageFile(TEST_UID, cid);
+    fs.mkdirSync(path.dirname(messageFile), { recursive: true });
+    await storage.appendJsonlAtomic(messageFile, {
+      id: messageId,
+      ts: new Date().toISOString(),
+      from: "user",
+      to: [AGENT_ID],
+      text: "resume the persisted task without any reuse receipt",
+      action_request_id: actionRequestId,
+    });
+    // Deliberately no prepareReceipt for `turn-<turnId>`: recovery must then
+    // resolve the reuse-turn list authoritatively to [] (receipt "not found")
+    // instead of omitting the property from the terminal event.
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "final", text: "recovered task completed" },
+    ]);
+
+    await expect(bus.recoverPersistedUserDispatch({
+      uid: TEST_UID,
+      cid,
+      messageId,
+      actionRequestId,
+      recipientId: AGENT_ID,
+      turnId,
+    })).resolves.toMatchObject({ disposition: "redispatched" });
+    await waitForQuiescent(TEST_UID, cid, 3000);
+    expect(await waitUntil(() => terminals.length === 1)).toBe(true);
+
+    expect(terminals[0]).toHaveProperty("reuse_turn_ids");
+    expect(terminals[0].reuse_turn_ids).toEqual([]);
+    unsubscribe();
+  }, 10_000);
+
+  it("emits an authoritative empty reuse turn list when the recovered dispatch receipt targets a different session", async () => {
+    const cid = newCid();
+    const messageId = "msg-recovered-dispatch-mismatch";
+    const actionRequestId = "request-recovered-dispatch-mismatch";
+    const turnId = "recovered-dispatch-mismatch-turn";
+    const state =
+      await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const layout = await import("../../../../src/main/util/project-layout");
+    const storage = await import("../../../../src/main/storage");
+    const receipts = await import(
+      "../../../../src/main/features/p3394/context-reuse-receipt"
+    );
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) =>
+      terminals.push(event),
+    );
+
+    const messageFile = layout.conversationMessageFile(TEST_UID, cid);
+    fs.mkdirSync(path.dirname(messageFile), { recursive: true });
+    await storage.appendJsonlAtomic(messageFile, {
+      id: messageId,
+      ts: new Date().toISOString(),
+      from: "user",
+      to: [AGENT_ID],
+      text: "resume the persisted task with a mismatched receipt",
+      action_request_id: actionRequestId,
+    });
+    // A receipt EXISTS for `turn-<turnId>` but targets the commander/gconv
+    // session — NOT the recovered agent's member session. Such a receipt is
+    // unusable for this run: recovery must treat it as authoritative-empty []
+    // (never undefined → legacy taskRunId fallback with no marker).
+    await receipts.prepareReceipt(
+      TEST_UID,
+      {
+        executionId: `turn-${turnId}`,
+        targetSessionId: `gconv-${cid}`,
+        reusedRefs: ["asset:mismatched@v1"],
+        omittedRefs: [],
+        permissionMode: "read-only",
+        allowedScopes: ["cognition:projection"],
+        boundary: "real",
+      },
+      { sessionId: `gconv-${cid}` },
+    );
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "final", text: "recovered task completed despite mismatch" },
+    ]);
+
+    await expect(bus.recoverPersistedUserDispatch({
+      uid: TEST_UID,
+      cid,
+      messageId,
+      actionRequestId,
+      recipientId: AGENT_ID,
+      turnId,
+    })).resolves.toMatchObject({ disposition: "redispatched" });
+    await waitForQuiescent(TEST_UID, cid, 3000);
+    expect(await waitUntil(() => terminals.length === 1)).toBe(true);
+
+    expect(terminals[0]).toHaveProperty("reuse_turn_ids");
+    expect(terminals[0].reuse_turn_ids).toEqual([]);
+    unsubscribe();
+  }, 10_000);
+
+  it("reuses the same aggregate run id when the same persisted dispatch is recovered again", async () => {
+    const cid = newCid();
+    const messageId = "msg-stable-recovery";
+    const actionRequestId = "request-stable-recovery";
+    const turnId = "stable-recovery-turn";
+    const state = await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const layout = await import("../../../../src/main/util/project-layout");
+    const storage = await import("../../../../src/main/storage");
+    const messageFile = layout.conversationMessageFile(TEST_UID, cid);
+    fs.mkdirSync(path.dirname(messageFile), { recursive: true });
+    const sourceMessage = {
+      id: messageId,
+      ts: "2026-09-10T00:00:00.000Z",
+      from: "user",
+      to: [AGENT_ID],
+      text: "recover this exact dispatch",
+      action_request_id: actionRequestId,
+    };
+    await storage.appendJsonlAtomic(messageFile, sourceMessage);
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [{ type: "__wait_for_abort__" }]);
+    await bus.recoverPersistedUserDispatch({ uid: TEST_UID, cid, messageId, actionRequestId, recipientId: AGENT_ID, turnId });
+    expect(await waitUntil(() => !bus.isQuiescent(TEST_UID, cid))).toBe(true);
+    const firstRunId = bus._cidStateForTest(TEST_UID, cid)?.taskRun?.runId;
+    expect(firstRunId).toEqual(expect.any(String));
+
+    await bus.dropConv(TEST_UID, cid);
+    fs.writeFileSync(messageFile, `${JSON.stringify(sourceMessage)}\n`, "utf8");
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [{ type: "__wait_for_abort__" }]);
+    await bus.recoverPersistedUserDispatch({ uid: TEST_UID, cid, messageId, actionRequestId, recipientId: AGENT_ID, turnId });
+    expect(await waitUntil(() => !bus.isQuiescent(TEST_UID, cid))).toBe(true);
+    const secondRunId = bus._cidStateForTest(TEST_UID, cid)?.taskRun?.runId;
+
+    expect(secondRunId).toBe(firstRunId);
+  }, 10_000);
+
+  it("does not assign a later run's receipt to a legacy unknown run by time-window scanning", async () => {
+    const cid = newCid();
+    const futureTurnId = "adjacent-future-turn";
+    const state = await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const receipts = await import("../../../../src/main/features/p3394/context-reuse-receipt");
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) => terminals.push(event));
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [{ type: "__wait_for_abort__" }]);
+    await bus.enqueue({ uid: TEST_UID, cid, fromActorId: "user", text: `@${AGENT_NAME} legacy unknown run` });
+    expect(await waitUntil(() => !bus.isQuiescent(TEST_UID, cid))).toBe(true);
+    const first = bus._cidStateForTest(TEST_UID, cid) as any;
+    first.taskRun.reuseTurnIds = undefined;
+    await receipts.prepareReceipt(TEST_UID, {
+      executionId: `turn-${futureTurnId}`,
+      targetSessionId: `gconv-${cid}`,
+      reusedRefs: ["asset:future@v1"],
+      omittedRefs: [],
+      permissionMode: "read-only",
+      allowedScopes: ["cognition:projection"],
+      boundary: "real",
+    }, { sessionId: `gconv-${cid}` });
+
+    await bus.abort(TEST_UID, cid);
+    await waitForQuiescent(TEST_UID, cid, 3000);
+    expect(await waitUntil(() => terminals.length === 1)).toBe(true);
+
+    expect(terminals[0]).not.toHaveProperty("reuse_turn_ids");
+    unsubscribe();
+  }, 10_000);
+
+  it("keeps a released run's frozen terminal snapshot isolated from a later run's receipts", async () => {
+    const cid = newCid();
+    const state = await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const terminals: any[] = [];
+    let releaseRun1Delivery: () => void = () => {};
+    // The listener captures each terminal event synchronously, but keeps run
+    // 1's delivery promise pending (the bus never awaits listener return
+    // values) so run 2 can start and finish while run 1's delivery is still
+    // held open. This is an explicit barrier, not a sleep. The race window
+    // covered: run 2 records its receipts and emits its own terminal while run
+    // 1's terminal delivery is still in the hands of a blocked listener. The
+    // window NOT covered (deliberately excluded by the barrier): run 1's
+    // dispatch itself happening after run 2 starts — we wait for run 1's
+    // capture before starting run 2, and production dispatches synchronously
+    // once the run is quiescent.
+    const run1DeliveryHeld = new Promise<void>((resolve) => {
+      releaseRun1Delivery = resolve;
+    });
+    const unsubscribe = bus.subscribeTaskTerminals((event) => {
+      terminals.push(event);
+      return terminals.length === 1 ? run1DeliveryHeld : undefined;
+    });
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "__wait_for_abort__" },
+    ]);
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: `@${AGENT_NAME} first isolated run`,
+    });
+    expect(await waitUntil(() => !bus.isQuiescent(TEST_UID, cid))).toBe(true);
+    const run1 = bus._cidStateForTest(TEST_UID, cid) as any;
+    expect(run1.taskRun).toBeTruthy();
+    const run1Id = run1.taskRun.runId;
+    Object.assign(run1.taskRun, { reuseTurnIds: ["turn-first-isolated-run"] });
+
+    // Run 1 aborts and its terminal event is captured while its delivery stays
+    // held open below; wait for the capture so run 2 cannot overtake run 1.
+    await bus.abort(TEST_UID, cid);
+    expect(await waitUntil(() => terminals.length === 1, 10_000)).toBe(true);
+
+    // Run 2 records its own receipt on a brand-new taskRun and aborts while
+    // run 1's terminal delivery is still blocked.
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "__wait_for_abort__" },
+    ]);
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: `@${AGENT_NAME} second isolated run`,
+    });
+    expect(await waitUntil(() => !bus.isQuiescent(TEST_UID, cid))).toBe(true);
+    const run2 = bus._cidStateForTest(TEST_UID, cid) as any;
+    expect(run2.taskRun).toBeTruthy();
+    expect(run2.taskRun.runId).not.toBe(run1Id);
+    Object.assign(run2.taskRun, { reuseTurnIds: ["turn-second-isolated-run"] });
+
+    await bus.abort(TEST_UID, cid);
+    await waitForQuiescent(TEST_UID, cid, 3000);
+    expect(await waitUntil(() => terminals.length === 2, 10_000)).toBe(true);
+
+    // Release run 1's delivery only after run 2 has fully aborted.
+    releaseRun1Delivery();
+    await run1DeliveryHeld;
+
+    // The frozen snapshot handed to run 1's listener carries ONLY run 1's
+    // receipt id; run 2's receipt id, recorded while that delivery was still
+    // held open, must never leak into it.
+    expect(terminals[0].reuse_turn_ids).toEqual(["turn-first-isolated-run"]);
+    expect(terminals[0].reuse_turn_ids).not.toContain(
+      "turn-second-isolated-run",
+    );
+    expect(terminals[1].reuse_turn_ids).toEqual(["turn-second-isolated-run"]);
+    expect(terminals[1].reuse_turn_ids).not.toContain(
+      "turn-first-isolated-run",
+    );
+    expect(terminals[1].run_id).not.toBe(terminals[0].run_id);
+    expect(Object.isFrozen(terminals[0])).toBe(true);
+    unsubscribe();
+  }, 10_000);
+
+  it("preserves an explicitly empty reuse turn list on the terminal event", async () => {
+    const cid = newCid();
+    const state =
+      await import("../../../../src/main/features/group_chat/state");
+    const bus = await import("../../../../src/main/features/group_chat/bus");
+    const terminals: any[] = [];
+    const unsubscribe = bus.subscribeTaskTerminals((event) =>
+      terminals.push(event),
+    );
+
+    _setScript(state.buildGmemberSessionId(cid, AGENT_ID), [
+      { type: "__wait_for_abort__" },
+    ]);
+    await bus.enqueue({
+      uid: TEST_UID,
+      cid,
+      fromActorId: "user",
+      text: `@${AGENT_NAME} wait without loading reusable context`,
+    });
+    expect(await waitUntil(() => !bus.isQuiescent(TEST_UID, cid))).toBe(true);
+    const active = bus._cidStateForTest(TEST_UID, cid);
+    expect(active?.taskRun).toBeTruthy();
+    const { prepareReceipt } = await import(
+      "../../../../src/main/features/p3394/context-reuse-receipt"
+    );
+    await prepareReceipt(
+      TEST_UID,
+      {
+        executionId: "turn-legacy-recoverable",
+        targetSessionId: `gconv-${cid}`,
+        reusedRefs: ["asset:legacy@v1"],
+        omittedRefs: [],
+        permissionMode: "read-only",
+        allowedScopes: ["cognition:projection"],
+        boundary: "real",
+      },
+      { sessionId: `gconv-${cid}` },
+    );
+
+    await bus.abort(TEST_UID, cid);
+    await waitForQuiescent(TEST_UID, cid, 3000);
+    expect(await waitUntil(() => terminals.length === 1)).toBe(true);
+
+    expect(terminals[0]).toHaveProperty("reuse_turn_ids");
+    expect(terminals[0].reuse_turn_ids).toEqual([]);
     unsubscribe();
   }, 10_000);
 });
@@ -8581,4 +9237,3 @@ describe("group_chat bus › desktop message broadcaster", () => {
     // is the pre-fix steady state for external inbound paths.
   });
 });
-

--- a/test/main/features/kstar/episode-builder.test.ts
+++ b/test/main/features/kstar/episode-builder.test.ts
@@ -159,5 +159,32 @@ describe('KSTAR episode builders', () => {
     expect(episode.a.agentActions).toEqual([expect.objectContaining({ sequence: 0, actor: 'commander', action: 'Plan completed.', status: 'ok' })]);
     expect(episode.evidenceRefs).toContainEqual(expect.objectContaining({ kind: 'conversation', id: 'msg-user' }));
     expect(episode.evidenceRefs).not.toContainEqual(expect.objectContaining({ id: 'msg-old' }));
+    expect(episode).not.toHaveProperty('reuseTurnIds');
+  });
+
+  it('retains the newest unique safe reuse turn ids and records overflow', async () => {
+    const { buildGroupKstarEpisode } = await import('../../../../src/main/features/kstar/episode-builder');
+    const boundedTurnIds = Array.from({ length: 102 }, (_, index) => `turn-${index}`);
+    const episode = buildGroupKstarEpisode({
+      userId: 'builder-user',
+      runId: 'run-reuse-turns',
+      conversationId: 'cid-reuse-turns',
+      status: 'completed',
+      startedAtMs: Date.parse('2026-08-05T00:00:00.000Z'),
+      finishedAtMs: Date.parse('2026-08-05T00:01:00.000Z'),
+      messages: [
+        { id: 'msg-reuse', ts: '2026-08-05T00:00:01.000Z', from: 'user', text: 'Use prior context.' },
+      ],
+      reuseTurnIds: [
+        boundedTurnIds[0],
+        '../unsafe',
+        'x'.repeat(161),
+        boundedTurnIds[0],
+        ...boundedTurnIds.slice(1),
+      ],
+    });
+
+    expect(episode.reuseTurnIds).toEqual(boundedTurnIds.slice(-100));
+    expect(episode.reuseTurnIdsTruncated).toBe(true);
   });
 });

--- a/test/main/features/kstar/episode-store.test.ts
+++ b/test/main/features/kstar/episode-store.test.ts
@@ -75,6 +75,32 @@ describe('KSTAR episode store', () => {
     })).rejects.toThrow(/conflict/i);
   });
 
+  it('rejects oversized reuse turn ids and lists', async () => {
+    const { store } = await modules();
+    const record = sampleEpisode('kstar-user-a');
+
+    await expect(store.writeKstarEpisode('kstar-user-a', {
+      ...record,
+      reuseTurnIds: ['x'.repeat(161)],
+    })).rejects.toThrow(/malformed kstar episode/i);
+    await expect(store.writeKstarEpisode('kstar-user-a', {
+      ...record,
+      reuseTurnIds: Array.from({ length: 101 }, (_, index) => `turn-${index}`),
+    })).rejects.toThrow(/malformed kstar episode/i);
+  });
+
+  it('round-trips the explicit reuse-turn truncation fact', async () => {
+    const { store } = await modules();
+    const record = {
+      ...sampleEpisode('kstar-user-a', 'kse-run-truncated'),
+      reuseTurnIds: Array.from({ length: 100 }, (_, index) => `turn-${index + 5}`),
+      reuseTurnIdsTruncated: true as const,
+    };
+
+    await expect(store.writeKstarEpisode('kstar-user-a', record)).resolves.toEqual(record);
+    await expect(store.readKstarEpisode('kstar-user-a', record.id)).resolves.toEqual(record);
+  });
+
   it('rejects unsafe path segments before path construction', async () => {
     const { paths } = await modules();
     for (const invalid of ['../escape', 'nested/value', 'bad.value', '', ' user ', 'user\\id']) {

--- a/test/main/features/kstar/kstar-closure-acceptance-scenario.test.ts
+++ b/test/main/features/kstar/kstar-closure-acceptance-scenario.test.ts
@@ -4,7 +4,8 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { GroupKstarMessageInput } from '../../../../src/main/features/kstar/episode-builder';
-import type { KstarEpisodeRecord } from '../../../../src/main/features/kstar/types';
+import type { KstarReviewInfer } from '../../../../src/main/features/kstar/task-closure';
+import type { KstarEpisodeRecord, KstarTaskStatus } from '../../../../src/main/features/kstar/types';
 
 // Keep semantic lookup deterministic so this scenario exercises the persisted
 // lifecycle rather than the availability of a local embedding model.
@@ -15,13 +16,26 @@ vi.mock('../../../../src/main/features/kb_embed', () => ({
   },
 }));
 
+const semanticReviewMock = vi.hoisted(() => ({
+  reviewCandidateSemantically: vi.fn(),
+}));
+
+vi.mock('../../../../src/main/features/cognition/semantic-review', () => ({
+  reviewCandidateSemantically: semanticReviewMock.reviewCandidateSemantically,
+}));
+
 const USER_ID = 'kstar-closure-scenario-user';
 const CONVERSATION_ID = 'cid-kstar-closure-scenario';
 const WORKSPACE_ID = 'workspace-kstar-closure';
-const RUN_ID = 'run-kstar-closure-scenario';
+const AGGREGATE_RUN_ID = 'run-kstar-closure-aggregate';
+const TURN_ID = 'turn-kstar-closure-real';
+const NEGATIVE_AGGREGATE_RUN_ID = 'run-kstar-closure-missing-evidence';
+const NEGATIVE_TURN_ID = 'turn-kstar-closure-missing-evidence';
 const USER_MESSAGE_ID = 'msg-kstar-closure-user';
 const AGENT_MESSAGE_ID = 'msg-kstar-closure-agent';
 const TOOL_ID = 'tool-kstar-closure-read';
+const LOCKED_ASSET_STATEMENT = 'Preserve verified file evidence before finalizing a task result.';
+const REVISED_ASSET_STATEMENT = 'Use the newer replacement workflow for future task results.';
 const STARTED_AT = Date.parse('2026-09-07T00:00:00.000Z');
 const FINISHED_AT = Date.parse('2026-09-07T00:01:00.000Z');
 
@@ -30,6 +44,8 @@ let previousWorkspaceRoot: string | undefined;
 
 beforeEach(async () => {
   vi.resetModules();
+  semanticReviewMock.reviewCandidateSemantically.mockReset();
+  semanticReviewMock.reviewCandidateSemantically.mockResolvedValue({ ok: true, findings: [] });
   workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cogseed-kstar-closure-acceptance-'));
   previousWorkspaceRoot = process.env.COGSEED_WORKSPACE_ROOT;
   process.env.COGSEED_WORKSPACE_ROOT = workspaceRoot;
@@ -42,7 +58,7 @@ afterEach(async () => {
 });
 
 async function modules() {
-  const [candidates, assets, refs, projections, promptInjection, injections, usage, closure, requirements, trace, episodes] =
+  const [candidates, assets, refs, projections, promptInjection, injections, usage, closure, requirements, trace, episodes, runEvidence] =
     await Promise.all([
       import('../../../../src/main/features/recall/candidate-service'),
       import('../../../../src/main/features/recall/asset-service'),
@@ -55,15 +71,16 @@ async function modules() {
       import('../../../../src/main/features/kstar/requirement-store'),
       import('../../../../src/main/features/kstar/trace'),
       import('../../../../src/main/features/kstar/episode-store'),
+      import('../../../../src/main/features/kstar/run-evidence'),
     ]);
-  return { candidates, assets, refs, projections, promptInjection, injections, usage, closure, requirements, trace, episodes };
+  return { candidates, assets, refs, projections, promptInjection, injections, usage, closure, requirements, trace, episodes, runEvidence };
 }
 
 async function createTransferValidatedAsset(): Promise<Awaited<ReturnType<(typeof import('../../../../src/main/features/recall/asset-service'))['readAbilityAsset']>>> {
   const { candidates, assets, refs } = await modules();
   const candidate = await candidates.saveRecallCandidate(USER_ID, {
-    judgment: 'Preserve verified file evidence before finalizing a task result.',
-    value: 'Preserve verified file evidence before finalizing a task result.',
+    judgment: LOCKED_ASSET_STATEMENT,
+    value: LOCKED_ASSET_STATEMENT,
     summary: 'Preserve verified file evidence',
     suggestedType: 'rule',
     suggestedScope: 'general',
@@ -73,6 +90,7 @@ async function createTransferValidatedAsset(): Promise<Awaited<ReturnType<(typeo
     evidenceRefs: [{ kind: 'execution', id: 'exec-kstar-closure-candidate' }],
   });
   const promoted = await candidates.autoApplyRecallCandidate(USER_ID, candidate.id, { provenance: 'kstar' });
+  expect(semanticReviewMock.reviewCandidateSemantically).toHaveBeenCalledTimes(1);
   if (!promoted.asset) throw new Error('KSTAR scenario asset was not promoted');
   const asset = await assets.setAbilityAssetMaturity(USER_ID, promoted.asset.id, 'transfer_validated');
   await refs.addWorkspaceAssetReference(USER_ID, {
@@ -83,18 +101,18 @@ async function createTransferValidatedAsset(): Promise<Awaited<ReturnType<(typeo
   return asset;
 }
 
-async function createTaskRequirement(projectionId: string) {
+async function createTaskRequirement(titleSuffix: string) {
   const { requirements } = await modules();
   const task = requirements.createKstarTaskRecord(USER_ID, {
     conversationId: CONVERSATION_ID,
     workspaceId: WORKSPACE_ID,
-    title: 'KSTAR closure acceptance scenario',
+    title: `KSTAR closure acceptance scenario ${titleSuffix}`,
   });
   const requirement = requirements.createKstarRequirementRecord(USER_ID, {
     taskId: task.id,
     conversationId: CONVERSATION_ID,
     userMessageIds: [USER_MESSAGE_ID],
-    title: 'Persist the verified closure facts',
+    title: `Persist the verified closure facts ${titleSuffix}`,
     goalText: 'Persist the verified closure facts for the completed task.',
     rHat: {
       summary: 'The verified closure facts are persisted.',
@@ -103,8 +121,6 @@ async function createTaskRequirement(projectionId: string) {
       confidence: 1,
     },
   });
-  requirement.projectionId = projectionId;
-  requirement.projectionIds = [projectionId];
   await requirements.replaceKstarRequirement(USER_ID, requirement);
   await requirements.replaceKstarTask(USER_ID, {
     ...task,
@@ -117,6 +133,20 @@ async function createTaskRequirement(projectionId: string) {
     currentRequirementId: requirement.id,
   });
   return { task, requirement };
+}
+
+async function bindProjectionToRequirement(
+  requirement: Awaited<ReturnType<typeof createTaskRequirement>>['requirement'],
+  projectionId: string,
+) {
+  const { requirements } = await modules();
+  const bound = {
+    ...requirement,
+    projectionId,
+    projectionIds: [projectionId],
+  };
+  await requirements.replaceKstarRequirement(USER_ID, bound);
+  return bound;
 }
 
 function deterministicReview(_userId: string, episode: KstarEpisodeRecord) {
@@ -138,46 +168,128 @@ function deterministicReview(_userId: string, episode: KstarEpisodeRecord) {
   });
 }
 
+function conservativeReview(_userId: string, episode: KstarEpisodeRecord) {
+  return Promise.resolve({
+    review: {
+      expectedResult: episode.t.userGoal,
+      actualResult: episode.r.finalText || 'The task did not produce a verified result.',
+      deltaR: 'unknown' as const,
+      deltaA: 'unknown' as const,
+      outcome: 'unclear' as const,
+      attribution: 'unclear' as const,
+      reason: 'No Host-observable evidence proved that the cited asset affected the result.',
+      confidence: 0,
+      evidenceRefs: episode.evidenceRefs,
+    },
+    reviewState: 'unknown' as const,
+    inferenceMethod: 'deterministic' as const,
+    needsConfirmation: false,
+  });
+}
+
+async function createInjectedScenario(input: {
+  titleSuffix: string;
+  turnId: string;
+  purpose: string;
+  taskText: string;
+  injectionMessageId: string;
+}) {
+  const { assets, projections, promptInjection, injections } = await modules();
+  const asset = await createTransferValidatedAsset();
+  const { task, requirement } = await createTaskRequirement(input.titleSuffix);
+  const projection = await projections.previewContextProjection(USER_ID, {
+    taskRunId: task.id,
+    workspaceId: WORKSPACE_ID,
+    purpose: input.purpose,
+    authorization: 'workspace_policy',
+    confirm: true,
+  });
+  await bindProjectionToRequirement(requirement, projection.id);
+  const promptContext = await promptInjection.buildRecallTurnPromptContext(USER_ID, {
+    cid: CONVERSATION_ID,
+    taskRunId: input.turnId,
+    taskText: input.taskText,
+    workspaceId: WORKSPACE_ID,
+    committedProjectionId: projection.id,
+  });
+  const citation = promptContext.citations.find((item) => item.assetId === asset.id);
+  if (!citation) throw new Error('KSTAR scenario asset was not injected');
+  const injection = await injections.recordInjectionReceipt(USER_ID, {
+    taskRunId: input.turnId,
+    projectionId: projection.id,
+    assetId: citation.assetId,
+    assetVersion: citation.version,
+    boundary: 'real',
+    status: 'injected',
+    messageId: input.injectionMessageId,
+  });
+  const liveAsset = await assets.updateAbilityAsset(USER_ID, asset.id, {
+    statement: REVISED_ASSET_STATEMENT,
+    reason: 'exercise the historical Projection snapshot',
+    actor: 'user',
+  });
+  return { asset, task, requirement, projection, promptContext, citation, injection, liveAsset };
+}
+
+async function captureScenarioClosure(input: {
+  logicalTaskId: string;
+  aggregateRunId: string;
+  turnId: string;
+  projectionId: string;
+  executionId: string;
+  status: KstarTaskStatus;
+  messages: GroupKstarMessageInput[];
+  inferReview: KstarReviewInfer;
+  createdAt: string;
+}) {
+  const { closure } = await modules();
+  return closure.captureGroupKstarClosure({
+    userId: USER_ID,
+    runId: input.aggregateRunId,
+    conversationId: CONVERSATION_ID,
+    projectionId: input.projectionId,
+    logicalRunId: input.logicalTaskId,
+    executionId: input.executionId,
+    reuseTurnIds: [input.turnId],
+    status: input.status,
+    startedAtMs: STARTED_AT,
+    finishedAtMs: FINISHED_AT,
+    messages: input.messages,
+    inferReview: input.inferReview,
+    createdAt: input.createdAt,
+  });
+}
+
 describe('KSTAR closure acceptance scenario', () => {
   it('persists a real Recall-to-KSTAR closed loop without leaking tool data', async () => {
-    const { projections, promptInjection, injections, usage, closure, requirements, trace, episodes } = await modules();
-    const asset = await createTransferValidatedAsset();
-
-    const projection = await projections.previewContextProjection(USER_ID, {
-      taskRunId: RUN_ID,
-      workspaceId: WORKSPACE_ID,
+    const { injections, usage, requirements, trace, episodes, runEvidence } = await modules();
+    const {
+      asset,
+      task,
+      requirement,
+      projection,
+      promptContext,
+      citation,
+      injection,
+      liveAsset,
+    } = await createInjectedScenario({
+      titleSuffix: 'with observable evidence',
+      turnId: TURN_ID,
       purpose: 'review',
-      authorization: 'workspace_policy',
-      confirm: true,
+      taskText: 'Persist the verified closure facts for the completed task.',
+      injectionMessageId: AGENT_MESSAGE_ID,
     });
     expect(projection.status).toBe('confirmed');
+    expect(projection.taskRunId).toBe(task.id);
     expect(projection.assetIds).toContain(asset.id);
-
-    const { task, requirement } = await createTaskRequirement(projection.id);
-    const promptContext = await promptInjection.buildRecallTurnPromptContext(USER_ID, {
-      cid: CONVERSATION_ID,
-      taskRunId: RUN_ID,
-      taskText: 'Persist the verified closure facts for the completed task.',
-      workspaceId: WORKSPACE_ID,
-      committedProjectionId: projection.id,
-    });
-    const citation = promptContext.citations.find((item) => item.assetId === asset.id);
+    expect(projection.assetVersions?.[asset.id]).toBe(asset.version);
     expect(citation).toMatchObject({
       assetId: asset.id,
       version: asset.version,
       projectionId: projection.id,
     });
     expect(promptContext.promptBlock).toContain(asset.statement);
-
-    const injection = await injections.recordInjectionReceipt(USER_ID, {
-      taskRunId: RUN_ID,
-      projectionId: projection.id,
-      assetId: citation!.assetId,
-      assetVersion: citation!.version,
-      boundary: 'real',
-      status: 'injected',
-      messageId: AGENT_MESSAGE_ID,
-    });
+    expect(liveAsset.version).not.toBe(asset.version);
 
     const privateToolPath = '/private/kstar-closure-secret.txt';
     const privateToolOutput = 'private tool output must never be persisted';
@@ -194,9 +306,9 @@ describe('KSTAR closure acceptance scenario', () => {
         text: 'The verified closure facts were persisted.',
         ts: '2026-09-07T00:00:40.000Z',
         recall_citations: [{
-          asset_id: citation!.assetId,
-          version: citation!.version,
-          projection_id: citation!.projectionId,
+          asset_id: citation.assetId,
+          version: citation.version,
+          projection_id: citation.projectionId,
         }],
         process: [
           {
@@ -227,25 +339,95 @@ describe('KSTAR closure acceptance scenario', () => {
       },
     ];
 
-    const result = await closure.captureGroupKstarClosure({
-      userId: USER_ID,
-      runId: RUN_ID,
-      conversationId: CONVERSATION_ID,
+    const result = await captureScenarioClosure({
+      logicalTaskId: task.id,
+      aggregateRunId: AGGREGATE_RUN_ID,
+      turnId: TURN_ID,
       projectionId: projection.id,
-      logicalRunId: 'logical-kstar-closure-scenario',
       executionId: 'exec-kstar-closure-scenario',
       status: 'completed',
-      startedAtMs: STARTED_AT,
-      finishedAtMs: FINISHED_AT,
       messages,
       inferReview: deterministicReview,
       createdAt: '2026-09-07T00:01:01.000Z',
     });
 
+    const evidence = await runEvidence.readKstarRunEvidence(USER_ID, {
+      taskId: task.id,
+      taskRunId: AGGREGATE_RUN_ID,
+    });
+    expect(evidence.projections).toEqual([
+      expect.objectContaining({ id: projection.id, status: 'confirmed', taskRunId: task.id }),
+    ]);
+    expect(evidence.requirementIds).toEqual([requirement.id]);
+    expect(evidence.assets).toEqual([
+      expect.objectContaining({
+        assetId: asset.id,
+        assetVersion: asset.version,
+        snapshot: expect.objectContaining({
+          version: asset.version,
+          statement: LOCKED_ASSET_STATEMENT,
+        }),
+        injectionReceipts: [injection],
+        usageReceipts: [expect.objectContaining({
+          taskRunId: injection.taskRunId,
+          projectionId: injection.projectionId,
+          assetId: injection.assetId,
+          assetVersion: injection.assetVersion,
+          injectionReceiptId: injection.id,
+          boundary: injection.boundary,
+          status: 'applied',
+          evidenceKind: 'tool_call',
+          evidenceRefs: [expect.objectContaining({
+            kind: 'execution_evaluation',
+            id: result.episode.id,
+            subtype: 'execution',
+          })],
+        })],
+      }),
+    ]);
+    expect(evidence.injectionReceipts).toEqual([
+      expect.objectContaining({
+        id: injection.id,
+        taskRunId: TURN_ID,
+        boundary: 'real',
+        status: 'injected',
+      }),
+    ]);
+    expect(evidence.usageReceipts).toEqual([
+      expect.objectContaining({
+        taskRunId: injection.taskRunId,
+        projectionId: injection.projectionId,
+        assetId: injection.assetId,
+        assetVersion: injection.assetVersion,
+        injectionReceiptId: injection.id,
+        boundary: injection.boundary,
+        status: 'applied',
+        evidenceKind: 'tool_call',
+        evidenceRefs: [expect.objectContaining({ id: result.episode.id })],
+      }),
+    ]);
+    expect(evidence.episodes).toEqual([
+      expect.objectContaining({
+        id: result.episode.id,
+        taskRunId: AGGREGATE_RUN_ID,
+        reuseTurnIds: [TURN_ID],
+        r: expect.objectContaining({ status: 'completed' }),
+      }),
+    ]);
+    expect(evidence.reviews).toEqual([
+      expect.objectContaining({ id: result.review.id, episodeId: result.episode.id }),
+    ]);
+    expect(result.review.id).not.toBe(result.episode.id);
+    expect(evidence.transferProofs).toEqual([]);
+    expect(evidence.effectivenessProofs).toEqual([]);
+    expect(evidence.validations).toEqual([]);
+    expect(evidence.gaps).toEqual(['effectiveness_not_recorded']);
+
     expect(result.episode).toMatchObject({
-      id: `kse-${RUN_ID}`,
+      id: `kse-${AGGREGATE_RUN_ID}`,
       projectionId: projection.id,
-      taskRunId: RUN_ID,
+      taskRunId: AGGREGATE_RUN_ID,
+      reuseTurnIds: [TURN_ID],
       k: { abilityAssetRefs: [asset.id] },
       r: { status: 'completed', finalText: 'The verified closure facts were persisted.', toolCallCount: 1 },
     });
@@ -274,11 +456,11 @@ describe('KSTAR closure acceptance scenario', () => {
     const storedRequirement = await requirements.readKstarRequirement(USER_ID, requirement.id);
     expect(storedRequirement?.episodeIds).toContain(result.episode.id);
 
-    const storedInjections = await injections.listInjectionReceipts(USER_ID, RUN_ID);
+    const storedInjections = await injections.listInjectionReceipts(USER_ID, TURN_ID);
     expect(storedInjections).toEqual([expect.objectContaining({ id: injection.id, boundary: 'real', status: 'injected' })]);
-    const storedUsage = await usage.listAssetUsageReceipts(USER_ID, RUN_ID);
+    const storedUsage = await usage.listAssetUsageReceipts(USER_ID, TURN_ID);
     expect(storedUsage).toEqual([expect.objectContaining({
-      taskRunId: RUN_ID,
+      taskRunId: TURN_ID,
       projectionId: projection.id,
       assetId: asset.id,
       assetVersion: asset.version,
@@ -293,6 +475,9 @@ describe('KSTAR closure acceptance scenario', () => {
     expect(persistedReceiptData).not.toContain(privateToolOutput);
     expect(JSON.stringify(storedEpisodes)).not.toContain(privateToolPath);
     expect(JSON.stringify(storedEpisodes)).not.toContain(privateToolOutput);
+    expect(JSON.stringify(evidence)).not.toContain(privateToolPath);
+    expect(JSON.stringify(evidence)).not.toContain(privateToolOutput);
+    expect(JSON.stringify(evidence)).not.toContain(REVISED_ASSET_STATEMENT);
 
     const kstarTrace = await trace.readKstarTrace(USER_ID, { taskId: task.id });
     const stages = new Set(kstarTrace.nodes.map((node) => node.stage));
@@ -312,5 +497,221 @@ describe('KSTAR closure acceptance scenario', () => {
         completeness: 'complete',
       }),
     ]));
+  });
+
+  it('keeps cited asset usage unknown when a failed run has no Host-observable success evidence', async () => {
+    const { injections, usage, requirements, runEvidence } = await modules();
+    const {
+      asset,
+      task,
+      requirement,
+      projection,
+      promptContext,
+      citation,
+      injection,
+    } = await createInjectedScenario({
+      titleSuffix: 'without observable evidence',
+      turnId: NEGATIVE_TURN_ID,
+      purpose: 'review missing execution evidence',
+      taskText: 'Try to persist the closure facts without claiming unverified success.',
+      injectionMessageId: 'msg-kstar-closure-agent-missing-evidence',
+    });
+    expect(projection).toMatchObject({
+      status: 'confirmed',
+      taskRunId: task.id,
+      assetVersions: { [asset.id]: asset.version },
+    });
+    expect(citation).toMatchObject({
+      assetId: asset.id,
+      version: asset.version,
+      projectionId: projection.id,
+    });
+    expect(promptContext.promptBlock).toContain(LOCKED_ASSET_STATEMENT);
+
+    const result = await captureScenarioClosure({
+      logicalTaskId: task.id,
+      aggregateRunId: NEGATIVE_AGGREGATE_RUN_ID,
+      turnId: NEGATIVE_TURN_ID,
+      projectionId: projection.id,
+      executionId: 'exec-kstar-closure-missing-evidence',
+      status: 'failed',
+      messages: [
+        {
+          id: USER_MESSAGE_ID,
+          from: 'user',
+          text: 'Try to persist the closure facts without claiming unverified success.',
+          ts: '2026-09-07T00:00:01.000Z',
+        },
+        {
+          id: 'msg-kstar-closure-agent-missing-evidence',
+          from: 'agent-a',
+          text: 'I referenced the verified-evidence guidance, but the action failed.',
+          ts: '2026-09-07T00:00:40.000Z',
+          recall_citations: [{
+            asset_id: citation.assetId,
+            version: citation.version,
+            projection_id: citation.projectionId,
+          }],
+          failure_kind: 'tool_error',
+          failure_code: 'verification_failed',
+          process: [
+            {
+              type: 'event',
+              event: {
+                stream: 'tool',
+                data: {
+                  phase: 'completed',
+                  id: 'tool-kstar-closure-failed',
+                  name: 'read_file',
+                  isError: true,
+                },
+              },
+            },
+          ],
+        },
+      ],
+      inferReview: conservativeReview,
+      createdAt: '2026-09-07T00:01:01.000Z',
+    });
+
+    // Persist a neighboring successful aggregate run for the same logical
+    // Task and Projection so the D03 read must isolate by aggregate run and
+    // then follow only that Episode's authoritative per-turn receipt ids.
+    const neighboringInjection = await injections.recordInjectionReceipt(USER_ID, {
+      taskRunId: TURN_ID,
+      projectionId: projection.id,
+      assetId: citation.assetId,
+      assetVersion: citation.version,
+      boundary: 'real',
+      status: 'injected',
+      messageId: AGENT_MESSAGE_ID,
+    });
+    const neighboringResult = await captureScenarioClosure({
+      logicalTaskId: task.id,
+      aggregateRunId: AGGREGATE_RUN_ID,
+      turnId: TURN_ID,
+      projectionId: projection.id,
+      executionId: 'exec-kstar-closure-neighboring-success',
+      status: 'completed',
+      messages: [
+        {
+          id: USER_MESSAGE_ID,
+          from: 'user',
+          text: 'Persist a neighboring verified run.',
+          ts: '2026-09-07T00:00:01.000Z',
+        },
+        {
+          id: AGENT_MESSAGE_ID,
+          from: 'agent-a',
+          text: 'The neighboring verified run completed.',
+          ts: '2026-09-07T00:00:40.000Z',
+          recall_citations: [{
+            asset_id: citation.assetId,
+            version: citation.version,
+            projection_id: citation.projectionId,
+          }],
+          process: [{
+            type: 'event',
+            event: {
+              stream: 'tool',
+              data: { phase: 'completed', id: TOOL_ID, name: 'read_file' },
+            },
+          }],
+        },
+      ],
+      inferReview: deterministicReview,
+      createdAt: '2026-09-07T00:01:02.000Z',
+    });
+    expect(await usage.listAssetUsageReceipts(USER_ID, TURN_ID)).toEqual([
+      expect.objectContaining({
+        injectionReceiptId: neighboringInjection.id,
+        status: 'applied',
+        evidenceKind: 'tool_call',
+      }),
+    ]);
+    const storedRequirement = await requirements.readKstarRequirement(USER_ID, requirement.id);
+    expect(storedRequirement?.episodeIds).toEqual(expect.arrayContaining([
+      result.episode.id,
+      neighboringResult.episode.id,
+    ]));
+
+    const evidence = await runEvidence.readKstarRunEvidence(USER_ID, {
+      taskId: task.id,
+      taskRunId: NEGATIVE_AGGREGATE_RUN_ID,
+    });
+    expect(evidence.requirementIds).toEqual([requirement.id]);
+    expect(evidence.projections).toEqual([
+      expect.objectContaining({ id: projection.id, status: 'confirmed', taskRunId: task.id }),
+    ]);
+    expect(evidence.injectionReceipts).toEqual([
+      expect.objectContaining({
+        id: injection.id,
+        taskRunId: NEGATIVE_TURN_ID,
+        boundary: 'real',
+        status: 'injected',
+      }),
+    ]);
+    expect(evidence.usageReceipts).toEqual([
+      expect.objectContaining({
+        taskRunId: injection.taskRunId,
+        projectionId: injection.projectionId,
+        assetId: injection.assetId,
+        assetVersion: injection.assetVersion,
+        injectionReceiptId: injection.id,
+        boundary: injection.boundary,
+        status: 'usage_unknown',
+        evidenceKind: 'none',
+        evidenceRefs: [],
+      }),
+    ]);
+    expect(evidence.assets).toEqual([
+      expect.objectContaining({
+        assetId: asset.id,
+        assetVersion: asset.version,
+        snapshot: expect.objectContaining({
+          version: asset.version,
+          statement: LOCKED_ASSET_STATEMENT,
+        }),
+        injectionReceipts: [injection],
+        usageReceipts: [expect.objectContaining({ status: 'usage_unknown' })],
+      }),
+    ]);
+    expect(evidence.episodes).toEqual([
+      expect.objectContaining({
+        id: result.episode.id,
+        taskRunId: NEGATIVE_AGGREGATE_RUN_ID,
+        reuseTurnIds: [NEGATIVE_TURN_ID],
+        r: expect.objectContaining({ status: 'failed' }),
+      }),
+    ]);
+    expect(evidence.reviews).toEqual([
+      expect.objectContaining({
+        id: result.review.id,
+        episodeId: result.episode.id,
+        outcome: 'unclear',
+        attribution: 'unclear',
+        deltaR: 'unknown',
+        deltaA: 'unknown',
+      }),
+    ]);
+    expect(evidence.reviews[0].outcome).not.toBe('better_than_expected');
+    expect(evidence.transferProofs).toEqual([]);
+    expect(evidence.effectivenessProofs).toEqual([]);
+    expect(evidence.validations).toEqual([]);
+    expect(evidence.gaps).toEqual(['effectiveness_not_recorded']);
+
+    const usageReceipt = evidence.usageReceipts[0];
+    expect(usageReceipt.status).not.toBe('applied');
+    for (const synthesizedField of ['successful', 'applied', 'better', 'outcome']) {
+      expect(usageReceipt).not.toHaveProperty(synthesizedField);
+    }
+    const serialized = JSON.stringify(evidence);
+    expect(serialized).not.toContain('"status":"applied"');
+    expect(serialized).not.toContain('better_than_expected');
+    expect(serialized).not.toContain(REVISED_ASSET_STATEMENT);
+    expect(serialized).not.toContain(AGGREGATE_RUN_ID);
+    expect(serialized).not.toContain(TURN_ID);
+    expect(serialized).not.toContain(neighboringInjection.id);
+    expect(serialized).not.toContain(neighboringResult.episode.id);
   });
 });

--- a/test/main/features/kstar/requirement-state.test.ts
+++ b/test/main/features/kstar/requirement-state.test.ts
@@ -81,4 +81,317 @@ describe('KSTAR requirement state transitions', () => {
       wakeRequestId: 'wake-ambiguous',
     })).rejects.toThrow(/multiple kstar requirements match/i);
   });
+
+  it('attaches an episode to an explicitly addressed open requirement and records the episode id', async () => {
+    const { state, store } = await modules();
+    const task = store.createKstarTaskRecord('user-a', { conversationId: 'cid-attach-ok', title: 'Attachment task' });
+    const requirement = store.createKstarRequirementRecord('user-a', {
+      taskId: task.id,
+      conversationId: 'cid-attach-ok',
+      userMessageIds: ['msg-attach-ok'],
+      title: 'Attachment requirement',
+      goalText: 'Record one episode',
+    });
+    await store.replaceKstarTask('user-a', {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+    await store.replaceKstarRequirement('user-a', { ...requirement, projectionId: 'proj-attach-ok' });
+
+    await state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-attach-ok',
+      episodeId: 'ep-attach-ok',
+      taskId: task.id,
+      requirementId: requirement.id,
+    });
+
+    const updated = await store.readKstarRequirement('user-a', requirement.id);
+    expect(updated?.episodeIds).toEqual(['ep-attach-ok']);
+  });
+
+  it('rejects an episode whose explicit task belongs to a different conversation', async () => {
+    const { state, store } = await modules();
+    const task = store.createKstarTaskRecord('user-a', { conversationId: 'cid-task-owner', title: 'Owner task' });
+    await store.replaceKstarTask('user-a', task);
+
+    await expect(state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-other-conversation',
+      episodeId: 'ep-conversation-mismatch',
+      taskId: task.id,
+    })).rejects.toThrow(/kstar episode task conversation mismatch/i);
+  });
+
+  it('rejects an explicit requirement that does not belong to the addressed task', async () => {
+    const { state, store } = await modules();
+    const task = store.createKstarTaskRecord('user-a', { conversationId: 'cid-req-owner', title: 'Requirement owner task' });
+    const own = store.createKstarRequirementRecord('user-a', {
+      taskId: task.id,
+      conversationId: 'cid-req-owner',
+      userMessageIds: ['msg-req-owner'],
+      title: 'Owned requirement',
+      goalText: 'Belongs to the task',
+    });
+    const otherTask = store.createKstarTaskRecord('user-a', { conversationId: 'cid-req-owner', title: 'Other task' });
+    const foreign = store.createKstarRequirementRecord('user-a', {
+      taskId: otherTask.id,
+      conversationId: 'cid-req-owner',
+      userMessageIds: ['msg-req-foreign'],
+      title: 'Foreign requirement',
+      goalText: 'Belongs to another task',
+    });
+    await store.replaceKstarTask('user-a', {
+      ...task,
+      requirementIds: [own.id],
+      currentRequirementId: own.id,
+    });
+    await store.replaceKstarRequirement('user-a', { ...own, projectionId: 'proj-req-owner' });
+    await store.replaceKstarRequirement('user-a', { ...foreign, projectionId: 'proj-req-foreign' });
+
+    await expect(state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-req-owner',
+      episodeId: 'ep-req-foreign',
+      taskId: task.id,
+      requirementId: foreign.id,
+    })).rejects.toThrow(/kstar episode requirement does not belong to task/i);
+  });
+
+  it('rejects an episode attachment when several open requirements match the projection', async () => {
+    const { state, store } = await modules();
+    const task = store.createKstarTaskRecord('user-a', { conversationId: 'cid-ambiguous-episode', title: 'Ambiguous episode task' });
+    const matched: string[] = [];
+    for (const messageId of ['msg-ambiguous-episode-a', 'msg-ambiguous-episode-b']) {
+      const requirement = store.createKstarRequirementRecord('user-a', {
+        taskId: task.id,
+        conversationId: 'cid-ambiguous-episode',
+        userMessageIds: [messageId],
+        title: 'Ambiguous requirement',
+        goalText: 'Two open requirements share the projection',
+      });
+      await store.replaceKstarRequirement('user-a', { ...requirement, projectionId: 'proj-ambiguous-episode' });
+      matched.push(requirement.id);
+    }
+    await store.replaceKstarTask('user-a', {
+      ...task,
+      requirementIds: matched,
+      currentRequirementId: matched[0],
+    });
+
+    await expect(state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-ambiguous-episode',
+      episodeId: 'ep-ambiguous-episode',
+      taskId: task.id,
+      projectionId: 'proj-ambiguous-episode',
+    })).rejects.toThrow(/multiple kstar requirements match episode provenance/i);
+  });
+
+  it('rejects an episode whose projection matches neither an open requirement nor the current fallback', async () => {
+    const { state, store } = await modules();
+    const task = store.createKstarTaskRecord('user-a', { conversationId: 'cid-no-provenance', title: 'No provenance task' });
+    const current = store.createKstarRequirementRecord('user-a', {
+      taskId: task.id,
+      conversationId: 'cid-no-provenance',
+      userMessageIds: ['msg-no-provenance'],
+      title: 'Current requirement',
+      goalText: 'Fallback target with a different projection',
+    });
+    await store.replaceKstarTask('user-a', {
+      ...task,
+      requirementIds: [current.id],
+      currentRequirementId: current.id,
+    });
+    await store.replaceKstarRequirement('user-a', { ...current, projectionId: 'proj-current' });
+    await store.writeConversationTaskState('user-a', {
+      ...store.createInitialConversationTaskState('user-a', 'cid-no-provenance'),
+      currentTaskId: task.id,
+      currentRequirementId: current.id,
+      taskComplete: false,
+    });
+
+    await expect(state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-no-provenance',
+      episodeId: 'ep-no-provenance',
+      taskId: task.id,
+      projectionId: 'proj-other',
+    })).rejects.toThrow(/no kstar requirement matches episode provenance/i);
+  });
+
+  it('does not attach an episode to a closed requirement', async () => {
+    const { state, store } = await modules();
+    const task = store.createKstarTaskRecord('user-a', { conversationId: 'cid-closed-episode', title: 'Closed task' });
+    const closed = store.createKstarRequirementRecord('user-a', {
+      taskId: task.id,
+      conversationId: 'cid-closed-episode',
+      userMessageIds: ['msg-closed-episode'],
+      title: 'Closed requirement',
+      goalText: 'Must refuse new episodes',
+    });
+    await store.replaceKstarTask('user-a', {
+      ...task,
+      requirementIds: [closed.id],
+      currentRequirementId: closed.id,
+    });
+    await store.replaceKstarRequirement('user-a', {
+      ...closed,
+      projectionId: 'proj-closed-episode',
+      status: 'closed',
+      closedAt: '2026-09-01T00:00:00.000Z',
+    });
+
+    await expect(state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-closed-episode',
+      episodeId: 'ep-closed-episode',
+      taskId: task.id,
+      requirementId: closed.id,
+    })).resolves.toBeUndefined();
+
+    const updated = await store.readKstarRequirement('user-a', closed.id);
+    expect(updated?.status).toBe('closed');
+    expect(updated?.episodeIds).toEqual([]);
+  });
+
+  it('rejects the current-requirement fallback when the current requirement belongs to a different task than the resolved episode task', async () => {
+    const { state, store } = await modules();
+    // Task A is the episode's resolved task (input.taskId), but the
+    // conversation has since moved to task B: the current requirement must
+    // not become the attachment target without a membership check.
+    const taskA = store.createKstarTaskRecord('user-a', { conversationId: 'cid-fallback-member', title: 'Resolved episode task' });
+    const own = store.createKstarRequirementRecord('user-a', {
+      taskId: taskA.id,
+      conversationId: 'cid-fallback-member',
+      userMessageIds: ['msg-fallback-own'],
+      title: 'Owned requirement',
+      goalText: 'Open but unmatched',
+    });
+    const taskB = store.createKstarTaskRecord('user-a', { conversationId: 'cid-fallback-member', title: 'Current task' });
+    const foreign = store.createKstarRequirementRecord('user-a', {
+      taskId: taskB.id,
+      conversationId: 'cid-fallback-member',
+      userMessageIds: ['msg-fallback-current'],
+      title: 'Current requirement',
+      goalText: 'Belongs to the current (different) task',
+    });
+    await store.replaceKstarTask('user-a', { ...taskA, requirementIds: [own.id], currentRequirementId: own.id });
+    await store.replaceKstarRequirement('user-a', own);
+    await store.replaceKstarTask('user-a', { ...taskB, requirementIds: [foreign.id], currentRequirementId: foreign.id });
+    await store.replaceKstarRequirement('user-a', foreign);
+    await store.writeConversationTaskState('user-a', {
+      ...store.createInitialConversationTaskState('user-a', 'cid-fallback-member'),
+      currentTaskId: taskB.id,
+      currentRequirementId: foreign.id,
+      taskComplete: false,
+    });
+
+    await expect(state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-fallback-member',
+      episodeId: 'ep-fallback-member',
+      taskId: taskA.id,
+    })).rejects.toThrow(/kstar current requirement does not belong to episode task/i);
+
+    expect((await store.readKstarRequirement('user-a', foreign.id))?.episodeIds).toEqual([]);
+    expect((await store.readKstarRequirement('user-a', own.id))?.episodeIds).toEqual([]);
+  });
+
+  it('attaches through the current-requirement fallback when the current requirement belongs to the resolved task', async () => {
+    const { state, store } = await modules();
+    const task = store.createKstarTaskRecord('user-a', { conversationId: 'cid-fallback-ok', title: 'Resolved task' });
+    const current = store.createKstarRequirementRecord('user-a', {
+      taskId: task.id,
+      conversationId: 'cid-fallback-ok',
+      userMessageIds: ['msg-fallback-ok'],
+      title: 'Current requirement',
+      goalText: 'Belongs to the resolved task',
+    });
+    await store.replaceKstarTask('user-a', { ...task, requirementIds: [current.id], currentRequirementId: current.id });
+    await store.replaceKstarRequirement('user-a', current);
+    await store.writeConversationTaskState('user-a', {
+      ...store.createInitialConversationTaskState('user-a', 'cid-fallback-ok'),
+      currentTaskId: task.id,
+      currentRequirementId: current.id,
+      taskComplete: false,
+    });
+
+    await state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-fallback-ok',
+      episodeId: 'ep-fallback-ok',
+      taskId: task.id,
+    });
+
+    expect((await store.readKstarRequirement('user-a', current.id))?.episodeIds).toEqual(['ep-fallback-ok']);
+  });
+
+  it('does not use the current-requirement fallback when attachment opts out, even for a same-task open current requirement', async () => {
+    const { state, store } = await modules();
+    const task = store.createKstarTaskRecord('user-a', { conversationId: 'cid-fallback-optout', title: 'Resolved task' });
+    const current = store.createKstarRequirementRecord('user-a', {
+      taskId: task.id,
+      conversationId: 'cid-fallback-optout',
+      userMessageIds: ['msg-fallback-optout'],
+      title: 'Current requirement',
+      goalText: 'Belongs to the resolved task but must not become a snapshot fallback target',
+    });
+    await store.replaceKstarTask('user-a', { ...task, requirementIds: [current.id], currentRequirementId: current.id });
+    await store.replaceKstarRequirement('user-a', current);
+    await store.writeConversationTaskState('user-a', {
+      ...store.createInitialConversationTaskState('user-a', 'cid-fallback-optout'),
+      currentTaskId: task.id,
+      currentRequirementId: current.id,
+      taskComplete: false,
+    });
+
+    await state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-fallback-optout',
+      episodeId: 'ep-fallback-optout',
+      taskId: task.id,
+    }, { allowCurrentRequirementFallback: false });
+
+    expect((await store.readKstarRequirement('user-a', current.id))?.episodeIds).toEqual([]);
+  });
+
+  it('ignores a closed current requirement instead of throwing the membership error (fallback only targets an open current requirement)', async () => {
+    const { state, store } = await modules();
+    // Task A is the episode's resolved task (input.taskId); the conversation
+    // has since moved to task B whose CURRENT requirement is already closed.
+    // A closed/abandoned current requirement is never a fallback target, so
+    // the membership error must not fire (pre-Fix-4 silent no-attach).
+    const taskA = store.createKstarTaskRecord('user-a', { conversationId: 'cid-closed-current', title: 'Resolved episode task' });
+    const own = store.createKstarRequirementRecord('user-a', {
+      taskId: taskA.id,
+      conversationId: 'cid-closed-current',
+      userMessageIds: ['msg-closed-current-own'],
+      title: 'Owned requirement',
+      goalText: 'Open but unmatched',
+    });
+    const taskB = store.createKstarTaskRecord('user-a', { conversationId: 'cid-closed-current', title: 'Closed current task' });
+    const foreign = store.createKstarRequirementRecord('user-a', {
+      taskId: taskB.id,
+      conversationId: 'cid-closed-current',
+      userMessageIds: ['msg-closed-current-foreign'],
+      title: 'Closed current requirement',
+      goalText: 'Belongs to the current (different) task and is closed',
+    });
+    await store.replaceKstarTask('user-a', { ...taskA, requirementIds: [own.id], currentRequirementId: own.id });
+    await store.replaceKstarRequirement('user-a', own);
+    await store.replaceKstarTask('user-a', { ...taskB, requirementIds: [foreign.id], currentRequirementId: foreign.id });
+    await store.replaceKstarRequirement('user-a', {
+      ...foreign,
+      status: 'closed',
+      closedAt: '2026-09-01T00:00:00.000Z',
+    });
+    await store.writeConversationTaskState('user-a', {
+      ...store.createInitialConversationTaskState('user-a', 'cid-closed-current'),
+      currentTaskId: taskB.id,
+      currentRequirementId: foreign.id,
+      taskComplete: false,
+    });
+
+    await expect(state.attachKstarEpisodeToRequirement('user-a', {
+      conversationId: 'cid-closed-current',
+      episodeId: 'ep-closed-current',
+      taskId: taskA.id,
+    })).resolves.toBeUndefined();
+
+    expect((await store.readKstarRequirement('user-a', foreign.id))?.episodeIds).toEqual([]);
+    expect((await store.readKstarRequirement('user-a', own.id))?.episodeIds).toEqual([]);
+  });
 });

--- a/test/main/features/kstar/run-evidence.test.ts
+++ b/test/main/features/kstar/run-evidence.test.ts
@@ -1,0 +1,1907 @@
+import { createHash } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+let root: string;
+let previousRoot: string | undefined;
+
+beforeEach(() => {
+  vi.resetModules();
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'cogseed-kstar-run-evidence-'));
+  previousRoot = process.env.COGSEED_WORKSPACE_ROOT;
+  process.env.COGSEED_WORKSPACE_ROOT = root;
+});
+
+afterEach(() => {
+  if (previousRoot === undefined) delete process.env.COGSEED_WORKSPACE_ROOT;
+  else process.env.COGSEED_WORKSPACE_ROOT = previousRoot;
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function usageReceiptId(input: {
+  taskRunId: string;
+  projectionId: string;
+  assetId: string;
+  assetVersion: string;
+}): string {
+  const key = JSON.stringify([input.taskRunId, input.projectionId, input.assetId, input.assetVersion]);
+  return `aur-${createHash('sha256').update(key).digest('hex').slice(0, 24)}`;
+}
+
+async function createVersionedAsset(
+  userId: string,
+  assetId: string,
+  statementV1: string,
+  statementV2 = `${statementV1} revised`,
+) {
+  const assets = await import('../../../../src/main/features/recall/asset-service');
+  const createdAt = '2026-09-10T02:00:00.000Z';
+  const v1 = await assets.createSystemAbilityAsset(userId, {
+    schemaVersion: 1,
+    ownerId: userId,
+    id: assetId,
+    candidateId: `candidate-${assetId}`,
+    reviewDecisionId: `rd_${assetId.replace(/-/g, '_')}_create`,
+    type: 'template',
+    title: `Asset ${assetId}`,
+    statement: statementV1,
+    evidenceRefs: [{ kind: 'memory', id: `memory-${assetId}` }],
+    scope: 'product',
+    status: 'active',
+    lifecycleStatus: 'automatically_extracted_unverified',
+    maturity: 'seed',
+    version: '1',
+    createdAt,
+    updatedAt: createdAt,
+  }, 'seed KSTAR run-evidence fixture');
+  const v2 = await assets.updateAbilityAsset(userId, assetId, {
+    statement: statementV2,
+    reason: 'create a newer live version for historical evidence testing',
+    actor: 'user',
+  });
+  return { v1, v2 };
+}
+
+async function seedLinkedRun(input: {
+  userId: string;
+  suffix: string;
+  taskRunId: string;
+  projection: Record<string, unknown>;
+  reuseTurnIds: string[];
+  executionId?: string;
+  reuseTurnIdsTruncated?: boolean;
+}) {
+  const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+  const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+  const recallStore = await import('../../../../src/main/features/recall/store');
+  const conversationId = `conversation-${input.suffix}`;
+  const task = requirementStore.createKstarTaskRecord(input.userId, {
+    conversationId,
+    title: `Task ${input.suffix}`,
+  });
+  const requirement = requirementStore.createKstarRequirementRecord(input.userId, {
+    taskId: task.id,
+    conversationId,
+    userMessageIds: [`message-${input.suffix}`],
+    title: `Requirement ${input.suffix}`,
+    goalText: `Complete ${input.suffix}`,
+  });
+  const projection = {
+    schemaVersion: 2,
+    ownerId: input.userId,
+    taskRunId: task.id,
+    conversationId,
+    purpose: `Evidence for ${input.suffix}`,
+    authorization: 'workspace_policy',
+    sourceRefs: [],
+    omittedRefs: [],
+    status: 'confirmed',
+    createdAt: '2026-09-10T02:10:00.000Z',
+    confirmedAt: '2026-09-10T02:10:00.000Z',
+    ...input.projection,
+  };
+  await recallStore.writeRecallJsonRecord(input.userId, 'projections', String(projection.id), projection);
+  const episode = {
+    schemaVersion: 1 as const,
+    ownerId: input.userId,
+    id: `episode-${input.suffix}`,
+    sessionId: `session-${input.suffix}`,
+    taskRunId: input.taskRunId,
+    reuseTurnIds: input.reuseTurnIds,
+    ...(input.reuseTurnIdsTruncated === true ? { reuseTurnIdsTruncated: true as const } : {}),
+    ...(input.executionId ? { executionId: input.executionId } : {}),
+    projectionId: String(projection.id),
+    k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: [...(projection.assetIds as string[])] },
+    s: { conversationSummary: conversationId },
+    t: { userGoal: `Complete ${input.suffix}`, constraints: [] },
+    a: { toolCalls: [], agentActions: [] },
+    r: { status: 'completed' as const, producedFiles: [] },
+    evidenceRefs: [],
+    createdAt: '2026-09-10T02:11:00.000Z',
+    updatedAt: '2026-09-10T02:11:00.000Z',
+  };
+  await episodeStore.writeKstarEpisode(input.userId, episode);
+  await requirementStore.replaceKstarRequirement(input.userId, {
+    ...requirement,
+    projectionId: String(projection.id),
+    projectionIds: [String(projection.id)],
+    episodeIds: [episode.id],
+  });
+  await requirementStore.replaceKstarTask(input.userId, {
+    ...task,
+    requirementIds: [requirement.id],
+    currentRequirementId: requirement.id,
+  });
+  return { task, requirement, projection, episode };
+}
+
+describe('KSTAR run evidence', () => {
+  it('isolates aggregate-run evidence through logical-task, Episode, Projection, and per-turn receipt references', async () => {
+    const userId = 'user-a';
+    const conversationId = 'conversation-shared';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const reviewService = await import('../../../../src/main/features/kstar/review-service');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    const usage = await import('../../../../src/main/features/recall/asset-usage-receipt');
+
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId,
+      title: 'Two isolated aggregate runs',
+    });
+    const requirementA = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId,
+      userMessageIds: ['message-a'],
+      title: 'Aggregate run A',
+      goalText: 'Complete aggregate run A',
+    });
+    const requirementB = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId,
+      userMessageIds: ['message-b'],
+      title: 'Aggregate run B',
+      goalText: 'Complete aggregate run B',
+    });
+
+    const projectionA = {
+      schemaVersion: 2,
+      ownerId: userId,
+      id: 'projection-run-a',
+      taskRunId: task.id,
+      conversationId,
+      purpose: 'aggregate run A evidence',
+      authorization: 'workspace_policy',
+      assetIds: ['asset-shared'],
+      assetVersions: { 'asset-shared': '1' },
+      sourceRefs: [],
+      omittedRefs: [],
+      status: 'confirmed',
+      createdAt: '2026-09-10T00:00:00.000Z',
+      confirmedAt: '2026-09-10T00:00:00.000Z',
+    };
+    const projectionB = {
+      ...projectionA,
+      id: 'projection-run-b',
+      purpose: 'aggregate run B evidence',
+      createdAt: '2026-09-10T00:01:00.000Z',
+      confirmedAt: '2026-09-10T00:01:00.000Z',
+    };
+    const projectionAAlternate = {
+      ...projectionA,
+      id: 'projection-run-a-alternate',
+      purpose: 'aggregate run A alternate evidence',
+      createdAt: '2026-09-10T00:01:30.000Z',
+      confirmedAt: '2026-09-10T00:01:30.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projectionA.id, projectionA);
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projectionB.id, projectionB);
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projectionAAlternate.id, projectionAAlternate);
+
+    const episodeA = {
+      schemaVersion: 1 as const,
+      ownerId: userId,
+      id: 'episode-run-a',
+      sessionId: 'session-run-a',
+      taskRunId: 'aggregate-run-a',
+      reuseTurnIds: [
+        'turn-a-bound',
+        'turn-a-plain',
+        'turn-forged-injection',
+        'turn-forged-task-source',
+        'turn-forged-task-usage',
+        'turn-forged-projection',
+        'turn-forged-asset',
+        'turn-forged-version',
+        'turn-forged-boundary',
+      ],
+      projectionId: projectionA.id,
+      k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: ['asset-shared'] },
+      s: { conversationSummary: conversationId },
+      t: { userGoal: 'Complete aggregate run A', constraints: [] },
+      a: { toolCalls: [], agentActions: [] },
+      r: { status: 'completed' as const, producedFiles: [] },
+      evidenceRefs: [],
+      createdAt: '2026-09-10T00:02:00.000Z',
+      updatedAt: '2026-09-10T00:02:00.000Z',
+    };
+    const episodeB = {
+      ...episodeA,
+      id: 'episode-run-b',
+      sessionId: 'session-run-b',
+      taskRunId: 'aggregate-run-b',
+      reuseTurnIds: ['turn-b'],
+      projectionId: projectionB.id,
+      t: { userGoal: 'Complete aggregate run B', constraints: [] },
+      createdAt: '2026-09-10T00:03:00.000Z',
+      updatedAt: '2026-09-10T00:03:00.000Z',
+    };
+    const episodeAAlternate = {
+      ...episodeA,
+      id: 'episode-run-a-alternate',
+      sessionId: 'session-run-a-alternate',
+      reuseTurnIds: [],
+      projectionId: projectionAAlternate.id,
+      createdAt: '2026-09-10T00:03:30.000Z',
+      updatedAt: '2026-09-10T00:03:30.000Z',
+    };
+    await episodeStore.writeKstarEpisode(userId, episodeA);
+    await episodeStore.writeKstarEpisode(userId, episodeB);
+    await episodeStore.writeKstarEpisode(userId, episodeAAlternate);
+
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirementA,
+      projectionId: projectionA.id,
+      projectionIds: [projectionA.id, projectionAAlternate.id],
+      episodeIds: [episodeA.id, episodeAAlternate.id],
+    });
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirementB,
+      projectionId: projectionB.id,
+      projectionIds: [projectionB.id],
+      episodeIds: [episodeB.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirementA.id, requirementB.id],
+      currentRequirementId: requirementB.id,
+    });
+
+    const reviewA = reviewService.createInitialKstarReview(episodeA);
+    const reviewB = reviewService.createInitialKstarReview(episodeB);
+    await reviewService.saveKstarReviewRecord(userId, reviewA);
+    await reviewService.saveKstarReviewRecord(userId, reviewB);
+
+    const injectionA = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-a-bound',
+      projectionId: projectionA.id,
+      assetId: 'asset-shared',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'injection-message-a',
+    });
+    const projectionlessA = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-a-plain',
+      assetId: 'asset-authoritative-only',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'dispatched',
+      messageId: 'injection-message-a-plain',
+    });
+    const injectionB = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-b',
+      projectionId: projectionB.id,
+      assetId: 'asset-shared',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'injection-message-b',
+    });
+    const mismatchedProjectionInjection = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-a-bound',
+      projectionId: projectionB.id,
+      assetId: 'asset-shared',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'injection-message-mismatched-projection',
+    });
+    const usageA = await usage.recordAssetUsageReceipt(userId, {
+      taskRunId: 'turn-a-bound',
+      projectionId: projectionA.id,
+      assetId: 'asset-shared',
+      assetVersion: '1',
+      injectionReceiptId: injectionA.id,
+      status: 'usage_unknown',
+      evidenceRefs: [],
+      evidenceKind: 'none',
+      boundary: 'real',
+    });
+    const usageB = await usage.recordAssetUsageReceipt(userId, {
+      taskRunId: 'turn-b',
+      projectionId: projectionB.id,
+      assetId: 'asset-shared',
+      assetVersion: '1',
+      injectionReceiptId: injectionB.id,
+      status: 'usage_unknown',
+      evidenceRefs: [],
+      evidenceKind: 'none',
+      boundary: 'real',
+    });
+
+    // Same aggregate run, different logical Task, same conversation and asset.
+    // Its projection-less receipt must not leak through the shared asset id.
+    const otherTask = requirementStore.createKstarTaskRecord(userId, {
+      conversationId,
+      title: 'Other logical task',
+    });
+    const otherRequirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: otherTask.id,
+      conversationId,
+      userMessageIds: ['message-other'],
+      title: 'Other task run',
+      goalText: 'Complete another task in the same aggregate run',
+    });
+    const otherEpisode = {
+      ...episodeA,
+      id: 'episode-other-task',
+      sessionId: 'session-other-task',
+      reuseTurnIds: ['turn-other-task'],
+      projectionId: undefined,
+      t: { userGoal: 'Other task', constraints: [] },
+      createdAt: '2026-09-10T00:04:00.000Z',
+      updatedAt: '2026-09-10T00:04:00.000Z',
+    };
+    await episodeStore.writeKstarEpisode(userId, otherEpisode);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...otherRequirement,
+      episodeIds: [otherEpisode.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...otherTask,
+      requirementIds: [otherRequirement.id],
+      currentRequirementId: otherRequirement.id,
+    });
+    const otherProjectionless = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-other-task',
+      assetId: 'asset-authoritative-only',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'dispatched',
+      messageId: 'injection-message-other',
+    });
+
+    const relationshipInjections = await Promise.all([
+      ['turn-forged-injection', 'asset-forged-injection', 'message-forged-injection'],
+      ['turn-forged-task-source', 'asset-forged-task', 'message-forged-task'],
+      ['turn-forged-projection', 'asset-forged-projection', 'message-forged-projection'],
+      ['turn-forged-asset', 'asset-forged-asset-source', 'message-forged-asset'],
+      ['turn-forged-version', 'asset-forged-version', 'message-forged-version'],
+      ['turn-forged-boundary', 'asset-forged-boundary', 'message-forged-boundary'],
+    ].map(([taskRunId, assetId, messageId]) => injections.recordInjectionReceipt(userId, {
+      taskRunId,
+      projectionId: projectionA.id,
+      assetId,
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId,
+    })));
+    const usageBase = (injection: typeof relationshipInjections[number]) => ({
+      schemaVersion: 1,
+      ownerId: userId,
+      taskRunId: injection.taskRunId,
+      projectionId: injection.projectionId!,
+      assetId: injection.assetId,
+      assetVersion: injection.assetVersion,
+      injectionReceiptId: injection.id,
+      status: 'usage_unknown',
+      evidenceRefs: [],
+      evidenceKind: 'none',
+      boundary: injection.boundary,
+      createdAt: '2026-09-10T00:05:00.000Z',
+    });
+    const forgedUsage = [
+      { ...usageBase(relationshipInjections[0]), injectionReceiptId: 'injection-unowned' },
+      { ...usageBase(relationshipInjections[1]), taskRunId: 'turn-forged-task-usage' },
+      { ...usageBase(relationshipInjections[2]), projectionId: projectionAAlternate.id },
+      { ...usageBase(relationshipInjections[3]), assetId: 'asset-forged-asset-usage' },
+      { ...usageBase(relationshipInjections[4]), assetVersion: '2' },
+      { ...usageBase(relationshipInjections[5]), boundary: 'test-double' },
+    ].map((record) => {
+      return {
+        ...record,
+        id: usageReceiptId(record),
+      };
+    });
+    expect(new Set([usageA.id, ...forgedUsage.map((record) => record.id)]).size)
+      .toBe(forgedUsage.length + 1);
+    for (const record of forgedUsage) {
+      await recallStore.appendRecallJsonlRecord(userId, 'asset-usage-receipts', 'events', record);
+    }
+
+    const listInjections = vi.spyOn(injections, 'listInjectionReceipts');
+    const listUsage = vi.spyOn(usage, 'listAssetUsageReceipts');
+    listInjections.mockClear();
+    listUsage.mockClear();
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: 'aggregate-run-a',
+    });
+
+    expect(listInjections).toHaveBeenCalledTimes(1);
+    expect(listInjections).toHaveBeenCalledWith(userId);
+    expect(listUsage).toHaveBeenCalledTimes(1);
+    expect(listUsage).toHaveBeenCalledWith(userId);
+    expect(result).toMatchObject({
+      taskId: task.id,
+      taskRunId: 'aggregate-run-a',
+      conversationId,
+      requirementIds: [requirementA.id],
+      projections: [projectionA, projectionAAlternate].sort((left, right) => left.id.localeCompare(right.id)),
+      injectionReceipts: [injectionA, projectionlessA, ...relationshipInjections]
+        .sort((left, right) => left.id.localeCompare(right.id)),
+      usageReceipts: [usageA],
+      episodes: [episodeA, episodeAAlternate].sort((left, right) => left.id.localeCompare(right.id)),
+      reviews: [reviewA],
+      generatedAt: expect.any(String),
+    });
+    expect(result.assets.map(({ assetId, assetVersion }) => ({ assetId, assetVersion }))).toEqual([
+      { assetId: 'asset-authoritative-only', assetVersion: '1' },
+      { assetId: 'asset-forged-asset-source', assetVersion: '1' },
+      { assetId: 'asset-forged-boundary', assetVersion: '1' },
+      { assetId: 'asset-forged-injection', assetVersion: '1' },
+      { assetId: 'asset-forged-projection', assetVersion: '1' },
+      { assetId: 'asset-forged-task', assetVersion: '1' },
+      { assetId: 'asset-forged-version', assetVersion: '1' },
+      { assetId: 'asset-shared', assetVersion: '1' },
+    ]);
+    expect(result.assets.find((asset) => asset.assetId === 'asset-shared')).toMatchObject({
+      injectionReceipts: [injectionA],
+      usageReceipts: [usageA],
+    });
+    expect(result.assets.find((asset) => asset.assetId === 'asset-authoritative-only')).toMatchObject({
+      injectionReceipts: [projectionlessA],
+      usageReceipts: [],
+    });
+    for (const forged of forgedUsage) {
+      expect(result.usageReceipts, forged.id).not.toContainEqual(expect.objectContaining({ id: forged.id }));
+    }
+    expect(Number.isNaN(Date.parse(result.generatedAt))).toBe(false);
+
+    const serialized = JSON.stringify(result);
+    for (const excludedId of [
+      'aggregate-run-b',
+      requirementB.id,
+      projectionB.id,
+      injectionB.id,
+      mismatchedProjectionInjection.id,
+      usageB.id,
+      episodeB.id,
+      reviewB.id,
+      'session-run-b',
+      'turn-b',
+      'injection-message-mismatched-projection',
+      otherTask.id,
+      otherRequirement.id,
+      otherEpisode.id,
+      otherProjectionless.id,
+      'turn-other-task',
+      'injection-message-other',
+      'injection-unowned',
+      'asset-mismatch',
+    ]) {
+      expect(serialized).not.toContain(excludedId);
+    }
+  });
+
+  it('does not read receipt stores when the authoritative reuse turn list is empty', async () => {
+    const userId = 'user-a';
+    const conversationId = 'conversation-empty-receipts';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    const usage = await import('../../../../src/main/features/recall/asset-usage-receipt');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId,
+      title: 'No receipt reads',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId,
+      userMessageIds: ['message-empty-receipts'],
+      title: 'Empty authoritative receipt list',
+      goalText: 'Return evidence without scanning receipt stores',
+    });
+    const episode = {
+      schemaVersion: 1 as const,
+      ownerId: userId,
+      id: 'episode-empty-receipts',
+      sessionId: 'session-empty-receipts',
+      taskRunId: 'aggregate-empty-receipts',
+      reuseTurnIds: [],
+      k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: [] },
+      s: { conversationSummary: conversationId },
+      t: { userGoal: 'Return evidence without scanning receipt stores', constraints: [] },
+      a: { toolCalls: [], agentActions: [] },
+      r: { status: 'completed' as const, producedFiles: [] },
+      evidenceRefs: [],
+      createdAt: '2026-09-10T00:10:00.000Z',
+      updatedAt: '2026-09-10T00:10:00.000Z',
+    };
+    await episodeStore.writeKstarEpisode(userId, episode);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirement,
+      episodeIds: [episode.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+
+    const listInjections = vi.spyOn(injections, 'listInjectionReceipts');
+    const listUsage = vi.spyOn(usage, 'listAssetUsageReceipts');
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: episode.taskRunId,
+    });
+
+    expect(listInjections).not.toHaveBeenCalled();
+    expect(listUsage).not.toHaveBeenCalled();
+    expect(result.injectionReceipts).toEqual([]);
+    expect(result.usageReceipts).toEqual([]);
+  });
+
+  it('treats only a missing linked Projection as absent and surfaces malformed persisted data', async () => {
+    const userId = 'user-a';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId: 'conversation-malformed',
+      title: 'Malformed projection task',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId: task.conversationId,
+      userMessageIds: ['message-malformed'],
+      title: 'Malformed projection requirement',
+      goalText: 'Read the referenced projection',
+    });
+    const episode = {
+      schemaVersion: 1 as const,
+      ownerId: userId,
+      id: 'episode-missing-projection',
+      sessionId: 'session-missing-projection',
+      taskRunId: 'aggregate-malformed',
+      reuseTurnIds: [],
+      projectionId: 'projection-missing',
+      k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: [] },
+      s: {},
+      t: { userGoal: 'Read the referenced projection', constraints: [] },
+      a: { toolCalls: [], agentActions: [] },
+      r: { status: 'completed' as const, producedFiles: [] },
+      evidenceRefs: [],
+      createdAt: '2026-09-10T01:00:00.000Z',
+      updatedAt: '2026-09-10T01:00:00.000Z',
+    };
+    expect(episode.projectionId).toBe('projection-missing');
+    await episodeStore.writeKstarEpisode(userId, episode);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirement,
+      projectionId: 'projection-missing',
+      projectionIds: ['projection-missing'],
+      episodeIds: [episode.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    await expect(readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: episode.taskRunId,
+    })).resolves.toMatchObject({
+      requirementIds: [requirement.id],
+      projections: [],
+      episodes: [episode],
+    });
+
+    await recallStore.writeRecallJsonRecord(userId, 'projections', 'projection-missing', {
+      schemaVersion: 2,
+      ownerId: userId,
+      id: 'projection-missing',
+      taskRunId: task.id,
+      purpose: 'malformed',
+      authorization: 'workspace_policy',
+      status: 'confirmed',
+      createdAt: '2026-09-10T01:00:00.000Z',
+    });
+
+    await expect(readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: episode.taskRunId,
+    })).rejects.toThrow('malformed context projection');
+  });
+
+  it('freezes historical asset versions and keeps owned proof and validation facts separate', async () => {
+    const userId = 'user-assets';
+    const assetId = 'asset-frozen';
+    const { v2 } = await createVersionedAsset(
+      userId,
+      assetId,
+      'Use the approved v1 delivery checklist.',
+      'Use the replacement v2 delivery checklist.',
+    );
+    expect(v2.version).toBe('2');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'frozen',
+      taskRunId: 'aggregate-frozen',
+      executionId: 'execution-frozen',
+      reuseTurnIds: ['turn-frozen'],
+      projection: {
+        id: 'projection-frozen',
+        assetIds: [assetId],
+        assetVersions: { [assetId]: '1' },
+        assetMatches: [
+          { assetId, matchScore: 0.91, matchMethod: 'semantic' },
+          { assetId: 'asset-unowned', matchScore: 0.99, matchMethod: 'semantic' },
+        ],
+      },
+    });
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    const usage = await import('../../../../src/main/features/recall/asset-usage-receipt');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const injection = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-frozen',
+      projectionId: 'projection-frozen',
+      assetId,
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'message-frozen-injection',
+    });
+    const usageReceipt = await usage.recordAssetUsageReceipt(userId, {
+      taskRunId: 'turn-frozen',
+      projectionId: 'projection-frozen',
+      assetId,
+      assetVersion: '1',
+      injectionReceiptId: injection.id,
+      status: 'usage_unknown',
+      evidenceRefs: [],
+      evidenceKind: 'none',
+      boundary: 'real',
+    });
+    const transfer = {
+      schemaVersion: 1,
+      ownerId: userId,
+      id: 'tp-owned-frozen',
+      projectionId: 'projection-frozen',
+      executionId: 'execution-frozen',
+      expectedResultSnapshot: 'Expected delivery result.',
+      assetVersions: [{ assetId, version: '1' }],
+      status: 'succeeded',
+      observedTransfer: 'Asset was available to the run.',
+      createdAt: '2026-09-10T02:12:00.000Z',
+      completedAt: '2026-09-10T02:13:00.000Z',
+    };
+    const aggregateTransfer = {
+      ...transfer,
+      id: 'tp-aggregate-frozen',
+      executionId: linked.episode.taskRunId,
+      createdAt: '2026-09-10T02:13:30.000Z',
+    };
+    const foreignTransfer = {
+      ...transfer,
+      id: 'tp-foreign-execution',
+      executionId: 'execution-foreign',
+      createdAt: '2026-09-10T02:14:00.000Z',
+    };
+    const foreignProjectionTransfer = {
+      ...transfer,
+      id: 'tp-foreign-projection',
+      projectionId: 'projection-foreign',
+      createdAt: '2026-09-10T02:15:00.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'transfer-proofs', transfer.id, transfer);
+    await recallStore.writeRecallJsonRecord(userId, 'transfer-proofs', aggregateTransfer.id, aggregateTransfer);
+    await recallStore.writeRecallJsonRecord(userId, 'transfer-proofs', foreignTransfer.id, foreignTransfer);
+    await recallStore.writeRecallJsonRecord(userId, 'transfer-proofs', foreignProjectionTransfer.id, foreignProjectionTransfer);
+    const effectiveness = {
+      schemaVersion: 1,
+      ownerId: userId,
+      id: 'ep-owned-frozen',
+      transferProofId: transfer.id,
+      outcome: 'worse',
+      status: 'valid',
+      observedResult: 'The outcome regressed.',
+      evidenceRefs: [],
+      createdAt: '2026-09-10T02:16:00.000Z',
+    };
+    const aggregateEffectiveness = {
+      ...effectiveness,
+      id: 'ep-aggregate-frozen',
+      transferProofId: aggregateTransfer.id,
+      createdAt: '2026-09-10T02:16:30.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'effectiveness-proofs', effectiveness.id, effectiveness);
+    await recallStore.writeRecallJsonRecord(
+      userId,
+      'effectiveness-proofs',
+      aggregateEffectiveness.id,
+      aggregateEffectiveness,
+    );
+    await recallStore.writeRecallJsonRecord(userId, 'effectiveness-proofs', 'ep-foreign-frozen', {
+      ...effectiveness,
+      id: 'ep-foreign-frozen',
+      transferProofId: foreignTransfer.id,
+    });
+    const validation = {
+      schemaVersion: 1,
+      ownerId: userId,
+      id: 'val-owned-frozen',
+      assetId,
+      candidateId: `candidate-${assetId}`,
+      taskRunId: transfer.executionId,
+      outcome: 'failure',
+      evidenceRefs: [],
+      createdAt: '2026-09-10T02:17:00.000Z',
+    };
+    const aggregateValidation = {
+      ...validation,
+      id: 'val-aggregate-frozen',
+      taskRunId: aggregateTransfer.executionId,
+      createdAt: '2026-09-10T02:17:30.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'validation-records', validation.id, validation);
+    await recallStore.writeRecallJsonRecord(
+      userId,
+      'validation-records',
+      aggregateValidation.id,
+      aggregateValidation,
+    );
+    await recallStore.writeRecallJsonRecord(userId, 'validation-records', 'val-foreign-execution', {
+      ...validation,
+      id: 'val-foreign-execution',
+      taskRunId: foreignTransfer.executionId,
+    });
+    await recallStore.writeRecallJsonRecord(userId, 'validation-records', 'val-foreign-asset', {
+      ...validation,
+      id: 'val-foreign-asset',
+      assetId: 'asset-unowned',
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-frozen',
+    });
+
+    expect(result.assets).toEqual([{
+      assetId,
+      assetVersion: '1',
+      snapshot: expect.objectContaining({
+        version: '1',
+        statement: 'Use the approved v1 delivery checklist.',
+      }),
+      matches: [{
+        projectionId: 'projection-frozen',
+        matchScore: 0.91,
+        matchMethod: 'semantic',
+      }],
+      injectionReceipts: [injection],
+      usageReceipts: [usageReceipt],
+    }]);
+    expect(result.transferProofs).toEqual([aggregateTransfer, transfer]);
+    expect(result.effectivenessProofs).toEqual([aggregateEffectiveness, effectiveness]);
+    expect(result.validations).toEqual([aggregateValidation, validation]);
+    expect(result.gaps).toEqual(['review_not_recorded']);
+    expect(result.usageReceipts[0]).not.toHaveProperty('successful');
+    expect(result.episodes[0]).not.toHaveProperty('applied');
+    expect(result.reviews).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain('tp-foreign-execution');
+    expect(JSON.stringify(result)).not.toContain('tp-foreign-projection');
+    expect(JSON.stringify(result)).not.toContain('val-foreign-execution');
+    expect(JSON.stringify(result)).not.toContain('val-foreign-asset');
+  });
+
+  it('keeps Projection matches scoped to the asset version each Projection locked', async () => {
+    const userId = 'user-version-matches';
+    const assetId = 'asset-version-matches';
+    await createVersionedAsset(userId, assetId, 'Version one.', 'Version two.');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'version-match-one',
+      taskRunId: 'aggregate-version-matches',
+      reuseTurnIds: [],
+      projection: {
+        id: 'projection-version-one',
+        assetIds: [assetId],
+        assetVersions: { [assetId]: '1' },
+        assetMatches: [{ assetId, matchScore: 0.21, matchMethod: 'semantic' }],
+      },
+    });
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const secondRequirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: linked.task.id,
+      conversationId: linked.task.conversationId,
+      userMessageIds: ['message-version-match-two'],
+      title: 'Version two match',
+      goalText: 'Use version two',
+    });
+    const secondProjection = {
+      ...linked.projection,
+      id: 'projection-version-two',
+      purpose: 'Evidence for version two',
+      assetVersions: { [assetId]: '2' },
+      assetMatches: [{ assetId, matchScore: 0.92, matchMethod: 'semantic' }],
+      createdAt: '2026-09-10T02:12:00.000Z',
+      confirmedAt: '2026-09-10T02:12:00.000Z',
+    };
+    const secondEpisode = {
+      ...linked.episode,
+      id: 'episode-version-match-two',
+      sessionId: 'session-version-match-two',
+      projectionId: secondProjection.id,
+      createdAt: '2026-09-10T02:13:00.000Z',
+      updatedAt: '2026-09-10T02:13:00.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(
+      userId,
+      'projections',
+      secondProjection.id,
+      secondProjection,
+    );
+    await episodeStore.writeKstarEpisode(userId, secondEpisode);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...secondRequirement,
+      projectionId: secondProjection.id,
+      projectionIds: [secondProjection.id],
+      episodeIds: [secondEpisode.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...linked.task,
+      requirementIds: [linked.requirement.id, secondRequirement.id],
+      currentRequirementId: secondRequirement.id,
+    });
+
+    const assets = await import('../../../../src/main/features/recall/asset-service');
+    const listVersions = vi.spyOn(assets, 'listAbilityAssetVersions');
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-version-matches',
+    });
+
+    expect(listVersions).toHaveBeenCalledTimes(1);
+    expect(listVersions).toHaveBeenCalledWith(userId, assetId);
+    expect(result.assets.map(({ assetVersion, matches }) => ({ assetVersion, matches }))).toEqual([
+      {
+        assetVersion: '1',
+        matches: [{
+          projectionId: 'projection-version-one',
+          matchScore: 0.21,
+          matchMethod: 'semantic',
+        }],
+      },
+      {
+        assetVersion: '2',
+        matches: [{
+          projectionId: 'projection-version-two',
+          matchScore: 0.92,
+          matchMethod: 'semantic',
+        }],
+      },
+    ]);
+  });
+
+  it('reports a snapshot gap for a legacy Projection asset without guessing its live version', async () => {
+    const userId = 'user-legacy-unlocked';
+    const assetId = 'asset-legacy-unlocked';
+    await createVersionedAsset(userId, assetId, 'Live content must not be guessed.');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'legacy-unlocked',
+      taskRunId: 'aggregate-legacy-unlocked',
+      reuseTurnIds: [],
+      projection: {
+        id: 'projection-legacy-unlocked',
+        assetIds: [assetId],
+      },
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-legacy-unlocked',
+    });
+
+    expect(result.assets).toEqual([]);
+    expect(result.gaps).toContain('asset_version_snapshot_not_recorded');
+  });
+
+  it('returns a null locked snapshot without guessing an unlocked live asset version', async () => {
+    const userId = 'user-missing-snapshot';
+    await createVersionedAsset(userId, 'asset-missing-snapshot', 'Existing v1 statement.');
+    await createVersionedAsset(userId, 'asset-unlocked-live', 'Never infer this version.');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'missing-snapshot',
+      taskRunId: 'aggregate-missing-snapshot',
+      reuseTurnIds: [],
+      projection: {
+        id: 'projection-missing-snapshot',
+        assetIds: ['asset-missing-snapshot', 'asset-unlocked-live'],
+        assetVersions: { 'asset-missing-snapshot': '99' },
+      },
+    });
+
+    const assets = await import('../../../../src/main/features/recall/asset-service');
+    const listVersions = vi.spyOn(assets, 'listAbilityAssetVersions');
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-missing-snapshot',
+    });
+
+    expect(listVersions).toHaveBeenCalledTimes(1);
+    expect(listVersions).toHaveBeenCalledWith(userId, 'asset-missing-snapshot');
+    expect(result.assets).toEqual([expect.objectContaining({
+      assetId: 'asset-missing-snapshot',
+      assetVersion: '99',
+      snapshot: null,
+    })]);
+    expect(result.gaps).toEqual([
+      'asset_version_snapshot_not_recorded',
+      'review_not_recorded',
+      'effectiveness_not_recorded',
+    ]);
+    // Explicit empty reuseTurnIds means no per-turn receipts were expected, so
+    // absence of receipts must not be reported as injection/usage gaps.
+    expect(result.gaps).not.toContain('injection_not_recorded');
+    expect(result.gaps).not.toContain('usage_not_recorded');
+  });
+
+  it('propagates corrupt asset version history instead of treating it as missing evidence', async () => {
+    const userId = 'user-snapshot-error';
+    const assetId = 'asset-snapshot-error';
+    await createVersionedAsset(userId, assetId, 'Snapshot read errors are not absence.');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'snapshot-error',
+      taskRunId: 'aggregate-snapshot-error',
+      reuseTurnIds: [],
+      projection: {
+        id: 'projection-snapshot-error',
+        assetIds: [assetId],
+        assetVersions: { [assetId]: '1' },
+      },
+    });
+    const assets = await import('../../../../src/main/features/recall/asset-service');
+    const recallPaths = await import('../../../../src/main/features/recall/paths');
+    fs.writeFileSync(
+      recallPaths.recallJsonlPath(userId, 'ability-asset-versions', assetId),
+      '{not valid json\n',
+      'utf8',
+    );
+    const listVersions = vi.spyOn(assets, 'listAbilityAssetVersions');
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+
+    await expect(readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-snapshot-error',
+    })).rejects.toThrow(
+      'recall JSONL ability-asset-versions/asset-snapshot-error line 1: invalid JSON',
+    );
+    expect(listVersions).toHaveBeenCalledTimes(1);
+    expect(listVersions).toHaveBeenCalledWith(userId, assetId);
+  });
+
+  it('does not bind projections or receipts to an aggregate run without an authoritative Episode', async () => {
+    const userId = 'user-unlinked';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId: 'conversation-unlinked',
+      title: 'Unlinked evidence',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId: task.conversationId,
+      userMessageIds: ['message-unlinked'],
+      title: 'Unlinked requirement',
+      goalText: 'Do not infer aggregate ownership',
+    });
+    const projection = {
+      schemaVersion: 2,
+      ownerId: userId,
+      id: 'projection-unlinked',
+      taskRunId: task.id,
+      conversationId: task.conversationId,
+      purpose: 'Confirmed but not linked to the aggregate run',
+      authorization: 'workspace_policy',
+      assetIds: ['asset-unlinked'],
+      assetVersions: { 'asset-unlinked': '1' },
+      sourceRefs: [],
+      omittedRefs: [],
+      status: 'confirmed',
+      createdAt: '2026-09-10T03:00:00.000Z',
+      confirmedAt: '2026-09-10T03:00:00.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projection.id, projection);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirement,
+      projectionId: projection.id,
+      projectionIds: [projection.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+    const injection = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'aggregate-unlinked',
+      projectionId: projection.id,
+      assetId: 'asset-unlinked',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'message-unlinked-injection',
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: 'aggregate-unlinked',
+    });
+
+    expect(result.requirementIds).toEqual([]);
+    expect(result.projections).toEqual([]);
+    expect(result.assets).toEqual([]);
+    expect(result.injectionReceipts).toEqual([]);
+    expect(result.episodes).toEqual([]);
+    expect(result.gaps).toEqual([
+      'task_run_not_linked',
+      'projection_not_recorded',
+      'injection_not_recorded',
+      'usage_not_recorded',
+      'execution_not_recorded',
+      'review_not_recorded',
+      'effectiveness_not_recorded',
+    ]);
+    expect(JSON.stringify(result)).not.toContain(injection.id);
+    expect(result).not.toHaveProperty('successful');
+    expect(result).not.toHaveProperty('applied');
+    expect(result).not.toHaveProperty('better');
+  });
+
+  it('reports missing evaluation evidence without claiming execution is absent when an Episode exists', async () => {
+    const userId = 'user-conservative-gaps';
+    const assetId = 'asset-conservative-gaps';
+    await createVersionedAsset(userId, assetId, 'Use the recorded delivery fact.');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'conservative-gaps',
+      taskRunId: 'aggregate-conservative-gaps',
+      reuseTurnIds: ['turn-conservative-gaps'],
+      projection: {
+        id: 'projection-conservative-gaps',
+        assetIds: [assetId],
+        assetVersions: { [assetId]: '1' },
+      },
+    });
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    const injection = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-conservative-gaps',
+      projectionId: 'projection-conservative-gaps',
+      assetId,
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'message-conservative-gaps',
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-conservative-gaps',
+    });
+
+    expect(result.assets).toEqual([expect.objectContaining({
+      assetId,
+      assetVersion: '1',
+      snapshot: expect.objectContaining({ statement: 'Use the recorded delivery fact.' }),
+      injectionReceipts: [injection],
+      usageReceipts: [],
+    })]);
+    expect(result.transferProofs).toEqual([]);
+    expect(result.effectivenessProofs).toEqual([]);
+    expect(result.validations).toEqual([]);
+    expect(result.reviews).toEqual([]);
+    expect(result.gaps).toEqual([
+      'usage_not_recorded',
+      'review_not_recorded',
+      'effectiveness_not_recorded',
+    ]);
+    expect(result.gaps).not.toContain('execution_not_recorded');
+  });
+
+  it('does not report effectiveness_not_recorded for a terminal unowned Episode when owned Episodes are non-terminal', async () => {
+    const userId = 'user-owned-nonterminal';
+    const conversationId = 'conversation-owned-nonterminal';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId,
+      title: 'Effectiveness scoped to owned Episodes',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId,
+      userMessageIds: ['message-owned-nonterminal'],
+      title: 'Owned non-terminal requirement',
+      goalText: 'Only terminal owned Episodes demand effectiveness evidence',
+    });
+    const ownedProjection = {
+      schemaVersion: 2,
+      ownerId: userId,
+      id: 'projection-owned-cancelled',
+      taskRunId: task.id,
+      conversationId,
+      purpose: 'Owned but cancelled Episode',
+      authorization: 'workspace_policy',
+      assetIds: [],
+      sourceRefs: [],
+      omittedRefs: [],
+      status: 'confirmed',
+      createdAt: '2026-09-10T04:20:00.000Z',
+      confirmedAt: '2026-09-10T04:20:00.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'projections', ownedProjection.id, ownedProjection);
+    const ownedEpisode = {
+      schemaVersion: 1 as const,
+      ownerId: userId,
+      id: 'episode-owned-cancelled',
+      sessionId: 'session-owned-cancelled',
+      taskRunId: 'aggregate-owned-nonterminal',
+      reuseTurnIds: [],
+      projectionId: ownedProjection.id,
+      k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: [] },
+      s: { conversationSummary: conversationId },
+      t: { userGoal: 'Only terminal owned Episodes demand effectiveness evidence', constraints: [] },
+      a: { toolCalls: [], agentActions: [] },
+      r: { status: 'cancelled' as const, producedFiles: [] },
+      evidenceRefs: [],
+      createdAt: '2026-09-10T04:21:00.000Z',
+      updatedAt: '2026-09-10T04:21:00.000Z',
+    };
+    // Terminal Episode matched to the run whose linked Projection record is
+    // missing: it is matched but NOT owned, so it must not trigger the legacy
+    // effectiveness fallback on its own.
+    const unownedTerminalEpisode = {
+      ...ownedEpisode,
+      id: 'episode-unowned-terminal',
+      sessionId: 'session-unowned-terminal',
+      reuseTurnIds: ['turn-unowned-terminal'],
+      projectionId: 'projection-unowned-terminal',
+      r: { status: 'completed' as const, producedFiles: [] },
+      createdAt: '2026-09-10T04:21:30.000Z',
+      updatedAt: '2026-09-10T04:21:30.000Z',
+    };
+    await episodeStore.writeKstarEpisode(userId, ownedEpisode);
+    await episodeStore.writeKstarEpisode(userId, unownedTerminalEpisode);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirement,
+      projectionId: ownedProjection.id,
+      projectionIds: [ownedProjection.id, 'projection-unowned-terminal'],
+      episodeIds: [ownedEpisode.id, unownedTerminalEpisode.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: 'aggregate-owned-nonterminal',
+    });
+
+    // Both Episodes are matched, but only the cancelled one is owned; the
+    // completed Episode's linked Projection is missing so it is not owned.
+    expect(result.episodes).toHaveLength(2);
+    expect(result.projections.map((projection) => projection.id)).toEqual([ownedProjection.id]);
+    expect(result.gaps).not.toContain('effectiveness_not_recorded');
+    expect(result.gaps).toEqual(['review_not_recorded']);
+  });
+
+  it('reports usage_not_recorded when only one of two assets under a shared linked Projection has Usage', async () => {
+    const userId = 'user-per-injection-usage';
+    const conversationId = 'conversation-per-injection-usage';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    const usage = await import('../../../../src/main/features/recall/asset-usage-receipt');
+    await createVersionedAsset(userId, 'asset-per-usage-a', 'Asset A for per-usage coverage.');
+    await createVersionedAsset(userId, 'asset-per-usage-b', 'Asset B for per-usage coverage.');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId,
+      title: 'Per-usage coverage',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId,
+      userMessageIds: ['message-per-usage'],
+      title: 'Per-usage coverage',
+      goalText: 'Cover each owned injection with usage',
+    });
+    const projection = {
+      schemaVersion: 2,
+      ownerId: userId,
+      id: 'projection-per-usage',
+      taskRunId: task.id,
+      conversationId,
+      purpose: 'Two assets under one linked projection',
+      authorization: 'workspace_policy',
+      assetIds: ['asset-per-usage-a', 'asset-per-usage-b'],
+      assetVersions: { 'asset-per-usage-a': '1', 'asset-per-usage-b': '1' },
+      sourceRefs: [],
+      omittedRefs: [],
+      status: 'confirmed',
+      createdAt: '2026-09-10T04:00:00.000Z',
+      confirmedAt: '2026-09-10T04:00:00.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projection.id, projection);
+    const episode = {
+      schemaVersion: 1 as const,
+      ownerId: userId,
+      id: 'episode-per-usage',
+      sessionId: 'session-per-usage',
+      taskRunId: 'aggregate-per-usage',
+      reuseTurnIds: ['turn-per-usage-a', 'turn-per-usage-b'],
+      projectionId: projection.id,
+      k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: projection.assetIds },
+      s: { conversationSummary: conversationId },
+      t: { userGoal: 'Cover each owned injection with usage', constraints: [] },
+      a: { toolCalls: [], agentActions: [] },
+      r: { status: 'completed' as const, producedFiles: [] },
+      evidenceRefs: [],
+      createdAt: '2026-09-10T04:01:00.000Z',
+      updatedAt: '2026-09-10T04:01:00.000Z',
+    };
+    await episodeStore.writeKstarEpisode(userId, episode);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirement,
+      projectionId: projection.id,
+      projectionIds: [projection.id],
+      episodeIds: [episode.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+    const injectionA = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-per-usage-a',
+      projectionId: projection.id,
+      assetId: 'asset-per-usage-a',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'message-per-usage-a',
+    });
+    const injectionB = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-per-usage-b',
+      projectionId: projection.id,
+      assetId: 'asset-per-usage-b',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'message-per-usage-b',
+    });
+    await usage.recordAssetUsageReceipt(userId, {
+      taskRunId: 'turn-per-usage-a',
+      projectionId: projection.id,
+      assetId: 'asset-per-usage-a',
+      assetVersion: '1',
+      injectionReceiptId: injectionA.id,
+      status: 'usage_unknown',
+      evidenceRefs: [],
+      evidenceKind: 'none',
+      boundary: 'real',
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: 'aggregate-per-usage',
+    });
+
+    expect(result.assets.find((asset) => asset.assetId === 'asset-per-usage-a')).toMatchObject({
+      injectionReceipts: [injectionA],
+      usageReceipts: [expect.objectContaining({ injectionReceiptId: injectionA.id })],
+    });
+    expect(result.assets.find((asset) => asset.assetId === 'asset-per-usage-b')).toMatchObject({
+      injectionReceipts: [injectionB],
+      usageReceipts: [],
+    });
+    expect(result.gaps).toContain('usage_not_recorded');
+    expect(result.gaps).not.toContain('injection_not_recorded');
+    expect(result.gaps).not.toContain('execution_not_recorded');
+  });
+
+  it('reports review_not_recorded when only one of two matched Episodes has a review', async () => {
+    const userId = 'user-per-episode-review';
+    const conversationId = 'conversation-per-episode-review';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const reviewService = await import('../../../../src/main/features/kstar/review-service');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId,
+      title: 'Per-episode review',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId,
+      userMessageIds: ['message-per-episode-review'],
+      title: 'Per-episode review',
+      goalText: 'Review each owned episode',
+    });
+    const projectionOne = {
+      schemaVersion: 2,
+      ownerId: userId,
+      id: 'projection-review-one',
+      taskRunId: task.id,
+      conversationId,
+      purpose: 'First owned episode',
+      authorization: 'workspace_policy',
+      assetIds: [],
+      sourceRefs: [],
+      omittedRefs: [],
+      status: 'confirmed',
+      createdAt: '2026-09-10T04:10:00.000Z',
+      confirmedAt: '2026-09-10T04:10:00.000Z',
+    };
+    const projectionTwo = {
+      ...projectionOne,
+      id: 'projection-review-two',
+      purpose: 'Second owned episode',
+      createdAt: '2026-09-10T04:10:30.000Z',
+      confirmedAt: '2026-09-10T04:10:30.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projectionOne.id, projectionOne);
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projectionTwo.id, projectionTwo);
+    const episodeOne = {
+      schemaVersion: 1 as const,
+      ownerId: userId,
+      id: 'episode-review-one',
+      sessionId: 'session-review-one',
+      taskRunId: 'aggregate-per-episode-review',
+      reuseTurnIds: [],
+      projectionId: projectionOne.id,
+      k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: [] },
+      s: { conversationSummary: conversationId },
+      t: { userGoal: 'Review each owned episode', constraints: [] },
+      a: { toolCalls: [], agentActions: [] },
+      r: { status: 'completed' as const, producedFiles: [] },
+      evidenceRefs: [],
+      createdAt: '2026-09-10T04:11:00.000Z',
+      updatedAt: '2026-09-10T04:11:00.000Z',
+    };
+    const episodeTwo = {
+      ...episodeOne,
+      id: 'episode-review-two',
+      sessionId: 'session-review-two',
+      projectionId: projectionTwo.id,
+      createdAt: '2026-09-10T04:11:30.000Z',
+      updatedAt: '2026-09-10T04:11:30.000Z',
+    };
+    await episodeStore.writeKstarEpisode(userId, episodeOne);
+    await episodeStore.writeKstarEpisode(userId, episodeTwo);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirement,
+      projectionId: projectionOne.id,
+      projectionIds: [projectionOne.id, projectionTwo.id],
+      episodeIds: [episodeOne.id, episodeTwo.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+    const reviewOne = reviewService.createInitialKstarReview(episodeOne);
+    await reviewService.saveKstarReviewRecord(userId, reviewOne);
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: 'aggregate-per-episode-review',
+    });
+
+    expect(result.episodes).toHaveLength(2);
+    expect(result.reviews).toHaveLength(1);
+    expect(result.gaps).toContain('review_not_recorded');
+    expect(result.gaps).not.toContain('execution_not_recorded');
+    expect(result.gaps).not.toContain('task_run_not_linked');
+  });
+
+  it('reports reuse_turn_ids_truncated when a matched Episode retained only a receipt-id suffix', async () => {
+    const userId = 'user-reuse-truncated';
+    await createVersionedAsset(userId, 'asset-reuse-truncated', 'Complete ownership is unknown.');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'truncated',
+      taskRunId: 'aggregate-truncated',
+      reuseTurnIds: ['turn-reuse-truncated'],
+      reuseTurnIdsTruncated: true,
+      projection: {
+        id: 'projection-reuse-truncated',
+        assetIds: ['asset-reuse-truncated'],
+        assetVersions: { 'asset-reuse-truncated': '1' },
+      },
+    });
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-reuse-truncated',
+      projectionId: 'projection-reuse-truncated',
+      assetId: 'asset-reuse-truncated',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'message-reuse-truncated',
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-truncated',
+    });
+
+    expect(result.episodes).toHaveLength(1);
+    expect(result.episodes[0].reuseTurnIdsTruncated).toBe(true);
+    expect(result.gaps).toContain('reuse_turn_ids_truncated');
+    expect(result.gaps).not.toContain('execution_not_recorded');
+  });
+
+  it('does not report usage or injection gaps when matched Episodes carry explicit empty reuseTurnIds', async () => {
+    const userId = 'user-empty-reuse-gaps';
+    await createVersionedAsset(userId, 'asset-empty-reuse-gaps', 'No per-turn receipts expected.');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'empty-reuse-gaps',
+      taskRunId: 'aggregate-empty-reuse-gaps',
+      reuseTurnIds: [],
+      projection: {
+        id: 'projection-empty-reuse-gaps',
+        assetIds: ['asset-empty-reuse-gaps'],
+        assetVersions: { 'asset-empty-reuse-gaps': '1' },
+      },
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-empty-reuse-gaps',
+    });
+
+    expect(result.injectionReceipts).toEqual([]);
+    expect(result.usageReceipts).toEqual([]);
+    expect(result.gaps).not.toContain('injection_not_recorded');
+    expect(result.gaps).not.toContain('usage_not_recorded');
+    expect(result.gaps).not.toContain('execution_not_recorded');
+  });
+
+  it('keeps injection_not_recorded aggregate-run scoped across owned Episodes with disjoint authoritative turn lists', async () => {
+    const userId = 'user-run-injection-contract';
+    const conversationId = 'conversation-run-injection-contract';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const reviewService = await import('../../../../src/main/features/kstar/review-service');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    const usage = await import('../../../../src/main/features/recall/asset-usage-receipt');
+    const assetId = 'asset-run-injection-contract';
+    await createVersionedAsset(userId, assetId, 'Run-level injection contract asset.');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId,
+      title: 'Run-level injection contract',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId,
+      userMessageIds: ['message-run-injection-contract'],
+      title: 'Run-level injection requirement',
+      goalText: 'Injection gaps are aggregate-run scoped, not per-Episode',
+    });
+    const projectionA = {
+      schemaVersion: 2,
+      ownerId: userId,
+      id: 'projection-run-contract-a',
+      taskRunId: task.id,
+      conversationId,
+      purpose: 'Episode A projection',
+      authorization: 'workspace_policy',
+      assetIds: [assetId],
+      assetVersions: { [assetId]: '1' },
+      sourceRefs: [],
+      omittedRefs: [],
+      status: 'confirmed',
+      createdAt: '2026-09-10T04:30:00.000Z',
+      confirmedAt: '2026-09-10T04:30:00.000Z',
+    };
+    const projectionB = {
+      ...projectionA,
+      id: 'projection-run-contract-b',
+      purpose: 'Episode B projection',
+      createdAt: '2026-09-10T04:30:30.000Z',
+      confirmedAt: '2026-09-10T04:30:30.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projectionA.id, projectionA);
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projectionB.id, projectionB);
+    const episodeA = {
+      schemaVersion: 1 as const,
+      ownerId: userId,
+      id: 'episode-run-contract-a',
+      sessionId: 'session-run-contract-a',
+      taskRunId: 'aggregate-run-injection-contract',
+      reuseTurnIds: ['turn-run-contract-a'],
+      projectionId: projectionA.id,
+      k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: [assetId] },
+      s: { conversationSummary: conversationId },
+      t: { userGoal: 'Episode A resolves an Injection', constraints: [] },
+      a: { toolCalls: [], agentActions: [] },
+      r: { status: 'completed' as const, producedFiles: [] },
+      evidenceRefs: [],
+      createdAt: '2026-09-10T04:31:00.000Z',
+      updatedAt: '2026-09-10T04:31:00.000Z',
+    };
+    const episodeB = {
+      ...episodeA,
+      id: 'episode-run-contract-b',
+      sessionId: 'session-run-contract-b',
+      reuseTurnIds: ['turn-run-contract-b'],
+      projectionId: projectionB.id,
+      t: { userGoal: 'Episode B resolves zero Injections', constraints: [] },
+      createdAt: '2026-09-10T04:31:30.000Z',
+      updatedAt: '2026-09-10T04:31:30.000Z',
+    };
+    await episodeStore.writeKstarEpisode(userId, episodeA);
+    await episodeStore.writeKstarEpisode(userId, episodeB);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirement,
+      projectionId: projectionA.id,
+      projectionIds: [projectionA.id, projectionB.id],
+      episodeIds: [episodeA.id, episodeB.id],
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+    // Only Episode A gets a review: per-owner review semantics must still flag B.
+    const reviewA = reviewService.createInitialKstarReview(episodeA);
+    await reviewService.saveKstarReviewRecord(userId, reviewA);
+    const injectionA = await injections.recordInjectionReceipt(userId, {
+      taskRunId: 'turn-run-contract-a',
+      projectionId: projectionA.id,
+      assetId,
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'message-run-contract-a',
+    });
+    await usage.recordAssetUsageReceipt(userId, {
+      taskRunId: 'turn-run-contract-a',
+      projectionId: projectionA.id,
+      assetId,
+      assetVersion: '1',
+      injectionReceiptId: injectionA.id,
+      status: 'usage_unknown',
+      evidenceRefs: [],
+      evidenceKind: 'none',
+      boundary: 'real',
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: 'aggregate-run-injection-contract',
+    });
+
+    expect(result.episodes).toHaveLength(2);
+    // Both Episodes carry authoritative non-empty reuseTurnIds, but only A
+    // resolves any Injection.
+    expect(result.injectionReceipts.map((receipt) => receipt.id)).toEqual([injectionA.id]);
+    // Contract: injection_not_recorded is a single aggregate-run signal. A
+    // resolved an Injection for the run, so B's disjoint list resolving zero
+    // Injections must NOT add injection_not_recorded, and with no Injection
+    // there is no injection->usage chain from which to fabricate
+    // usage_not_recorded for B.
+    expect(result.gaps).not.toContain('injection_not_recorded');
+    expect(result.gaps).not.toContain('usage_not_recorded');
+    // Review semantics stay per-owner: A's review must not hide B's missing one.
+    expect(result.gaps).toContain('review_not_recorded');
+    expect(result.gaps).not.toContain('execution_not_recorded');
+  });
+
+  it('caps returned collections and reports truncated plus output_truncated when the cap is exceeded', async () => {
+    const userId = 'user-capped-evidence';
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'capped',
+      taskRunId: 'aggregate-capped',
+      reuseTurnIds: ['turn-capped'],
+      projection: {
+        id: 'projection-capped',
+        assetIds: [],
+      },
+    });
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const createdAt = '2026-09-10T05:00:00.000Z';
+    for (let index = 0; index < 1001; index += 1) {
+      await recallStore.appendRecallJsonlRecord(userId, 'injection-receipts', 'events', {
+        schemaVersion: 1,
+        ownerId: userId,
+        id: `inj-${createHash('sha256').update(`capped-${index}`).digest('hex').slice(0, 24)}`,
+        taskRunId: 'turn-capped',
+        projectionId: 'projection-capped',
+        assetId: 'asset-capped',
+        assetVersion: '1',
+        boundary: 'real',
+        status: 'injected',
+        createdAt,
+      });
+    }
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-capped',
+    });
+
+    expect(result.episodes).toHaveLength(1);
+    expect(result.injectionReceipts).toHaveLength(1000);
+    expect(result.assets).toHaveLength(1);
+    expect(result.truncated).toBe(true);
+    expect(result.gaps).toContain('output_truncated');
+  });
+
+  it('keeps exactly EVIDENCE_COLLECTION_CAP (1000) records untruncated at the inclusive boundary', async () => {
+    const userId = 'user-cap-boundary';
+    const assetId = 'asset-cap-boundary';
+    await createVersionedAsset(userId, assetId, 'Boundary cap asset.');
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'cap-boundary',
+      taskRunId: 'aggregate-cap-boundary',
+      reuseTurnIds: ['turn-cap-boundary'],
+      projection: {
+        id: 'projection-cap-boundary',
+        assetIds: [assetId],
+        assetVersions: { [assetId]: '1' },
+      },
+    });
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const createdAt = '2026-09-10T05:10:00.000Z';
+    for (let index = 0; index < 1000; index += 1) {
+      await recallStore.appendRecallJsonlRecord(userId, 'injection-receipts', 'events', {
+        schemaVersion: 1,
+        ownerId: userId,
+        id: `inj-${createHash('sha256').update(`cap-boundary-${index}`).digest('hex').slice(0, 24)}`,
+        taskRunId: 'turn-cap-boundary',
+        projectionId: 'projection-cap-boundary',
+        assetId,
+        assetVersion: '1',
+        boundary: 'real',
+        status: 'injected',
+        createdAt,
+      });
+    }
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-cap-boundary',
+    });
+
+    // The cap is inclusive: only length > EVIDENCE_COLLECTION_CAP truncates.
+    expect(result.injectionReceipts).toHaveLength(1000);
+    expect(result.truncated).toBe(false);
+    expect(result.gaps).not.toContain('output_truncated');
+  });
+
+  it('still surfaces a genuine gap computed from evidence beyond the collection cap', async () => {
+    const userId = 'user-gap-beyond-cap';
+    const assetId = 'asset-gap-beyond-cap';
+    const conversationId = 'conversation-gap-beyond-cap';
+    const taskRunId = 'aggregate-gap-beyond-cap';
+    const projectionId = 'projection-gap-beyond-cap';
+    await createVersionedAsset(userId, assetId, 'Capping must not hide gaps.');
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const recallStore = await import('../../../../src/main/features/recall/store');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId,
+      title: 'Gap beyond cap',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId,
+      userMessageIds: ['message-gap-beyond-cap'],
+      title: 'Gap beyond cap requirement',
+      goalText: 'Capping must not hide a real gap',
+    });
+    const projection = {
+      schemaVersion: 2,
+      ownerId: userId,
+      id: projectionId,
+      taskRunId: task.id,
+      conversationId,
+      purpose: 'Beyond-cap gap evidence',
+      authorization: 'workspace_policy',
+      assetIds: [assetId],
+      assetVersions: { [assetId]: '1' },
+      sourceRefs: [],
+      omittedRefs: [],
+      status: 'confirmed',
+      createdAt: '2026-09-10T05:20:00.000Z',
+      confirmedAt: '2026-09-10T05:20:00.000Z',
+    };
+    await recallStore.writeRecallJsonRecord(userId, 'projections', projectionId, projection);
+    // Usage receipt ids are keyed to (taskRunId, projectionId, assetId,
+    // assetVersion), so each covered Injection needs its own turn id. An
+    // Episode persists at most 100 canonical reuse turn ids, so spread 1100
+    // per-turn receipts across 11 owned Episodes sharing the linked Projection.
+    const createdAt = '2026-09-10T05:20:00.000Z';
+    const episodeIds: string[] = [];
+    const turnIds: string[] = [];
+    for (let episodeIndex = 0; episodeIndex < 11; episodeIndex += 1) {
+      const episodeId = `episode-gap-beyond-cap-${episodeIndex}`;
+      episodeIds.push(episodeId);
+      const reuseTurnIds: string[] = [];
+      for (let turn = 0; turn < 100; turn += 1) {
+        reuseTurnIds.push(`turn-gap-beyond-cap-${String(episodeIndex * 100 + turn).padStart(4, '0')}`);
+      }
+      turnIds.push(...reuseTurnIds);
+      await episodeStore.writeKstarEpisode(userId, {
+        schemaVersion: 1 as const,
+        ownerId: userId,
+        id: episodeId,
+        sessionId: `session-gap-beyond-cap-${episodeIndex}`,
+        taskRunId,
+        reuseTurnIds,
+        projectionId,
+        k: { memoryRefs: [], contextRefs: [], abilityAssetRefs: [assetId] },
+        s: { conversationSummary: conversationId },
+        t: { userGoal: 'Capping must not hide a real gap', constraints: [] },
+        a: { toolCalls: [], agentActions: [] },
+        r: { status: 'completed' as const, producedFiles: [] },
+        evidenceRefs: [],
+        createdAt,
+        updatedAt: createdAt,
+      });
+    }
+    expect(turnIds).toHaveLength(1100);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...requirement,
+      projectionId,
+      projectionIds: [projectionId],
+      episodeIds,
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+    // One Injection per turn. ids sort by padded turn so the first 1000 after
+    // the id sort are turns 0000..0999 and the remaining 100 are beyond cap.
+    for (const turnId of turnIds) {
+      await recallStore.appendRecallJsonlRecord(userId, 'injection-receipts', 'events', {
+        schemaVersion: 1,
+        ownerId: userId,
+        id: `inj-${turnId}`,
+        taskRunId: turnId,
+        projectionId,
+        assetId,
+        assetVersion: '1',
+        boundary: 'real',
+        status: 'injected',
+        createdAt,
+      });
+    }
+    // Usage for every Injection that survives the cap (turns 0000..0999); the
+    // 100 beyond-cap Injections (turns 1000..1099) are left without Usage, so
+    // any usage_not_recorded gap can only come from beyond-the-cap evidence.
+    for (const turnId of turnIds.slice(0, 1000)) {
+      await recallStore.appendRecallJsonlRecord(userId, 'asset-usage-receipts', 'events', {
+        schemaVersion: 1,
+        ownerId: userId,
+        id: usageReceiptId({
+          taskRunId: turnId,
+          projectionId,
+          assetId,
+          assetVersion: '1',
+        }),
+        taskRunId: turnId,
+        projectionId,
+        assetId,
+        assetVersion: '1',
+        injectionReceiptId: `inj-${turnId}`,
+        status: 'usage_unknown',
+        evidenceRefs: [],
+        evidenceKind: 'none',
+        boundary: 'real',
+        createdAt,
+      });
+    }
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId,
+    });
+
+    expect(result.injectionReceipts).toHaveLength(1000);
+    expect(result.usageReceipts).toHaveLength(1000);
+    expect(result.truncated).toBe(true);
+    expect(result.gaps).toContain('output_truncated');
+    // Every returned (capped) Injection has Usage, so the usage gap is driven
+    // exclusively by Injections dropped by the cap; the gap must still surface.
+    for (const injection of result.injectionReceipts) {
+      expect(result.usageReceipts.some((usage) => usage.injectionReceiptId === injection.id)).toBe(true);
+    }
+    expect(result.gaps).toContain('usage_not_recorded');
+  });
+
+
+  it('propagates a corrupt authoritative Requirement instead of silently skipping it', async () => {
+    const userId = 'user-corrupt-requirement';
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const kstarPaths = await import('../../../../src/main/features/kstar/paths');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId: 'conversation-corrupt-requirement',
+      title: 'Corrupt requirement task',
+    });
+    const requirement = requirementStore.createKstarRequirementRecord(userId, {
+      taskId: task.id,
+      conversationId: task.conversationId,
+      userMessageIds: ['message-corrupt-requirement'],
+      title: 'Corrupt requirement',
+      goalText: 'Must not be skipped',
+    });
+    await requirementStore.replaceKstarRequirement(userId, requirement);
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [requirement.id],
+      currentRequirementId: requirement.id,
+    });
+    fs.writeFileSync(
+      kstarPaths.kstarRequirementPath(userId, requirement.id),
+      '{not valid json\n',
+      'utf8',
+    );
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    await expect(readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: 'aggregate-corrupt-requirement',
+    })).rejects.toThrow(/malformed kstar requirements record: invalid JSON/);
+  });
+});

--- a/test/main/features/kstar/run-evidence.test.ts
+++ b/test/main/features/kstar/run-evidence.test.ts
@@ -138,6 +138,66 @@ async function seedLinkedRun(input: {
 }
 
 describe('KSTAR run evidence', () => {
+  it('rejects a stale Requirement reference that belongs to another Task', async () => {
+    const userId = 'user-cross-task-requirement';
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'foreign-requirement',
+      taskRunId: 'aggregate-foreign-requirement',
+      reuseTurnIds: [],
+      projection: { id: 'projection-foreign-requirement', assetIds: [] },
+    });
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const task = requirementStore.createKstarTaskRecord(userId, {
+      conversationId: 'conversation-requesting-task',
+      title: 'Requesting task',
+    });
+    await requirementStore.replaceKstarTask(userId, {
+      ...task,
+      requirementIds: [linked.requirement.id],
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    await expect(readKstarRunEvidence(userId, {
+      taskId: task.id,
+      taskRunId: 'aggregate-foreign-requirement',
+    })).rejects.toThrow('kstar requirement does not belong to task');
+  });
+
+  it.each([
+    ['taskId', 'kst-foreign-episode-task'],
+    ['requirementId', 'ksreq-foreign-episode-requirement'],
+  ] as const)('rejects an Episode whose persisted %s contradicts its Requirement link', async (field, value) => {
+    const userId = `user-cross-episode-${field}`;
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: `cross-episode-${field}`,
+      taskRunId: `aggregate-cross-episode-${field}`,
+      reuseTurnIds: [],
+      projection: { id: `projection-cross-episode-${field}`, assetIds: [] },
+    });
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const mismatchedEpisode = {
+      ...linked.episode,
+      id: `episode-mismatched-${field}`,
+      [field]: value,
+    };
+    await episodeStore.writeKstarEpisode(userId, mismatchedEpisode);
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...linked.requirement,
+      projectionId: String(linked.projection.id),
+      projectionIds: [String(linked.projection.id)],
+      episodeIds: [mismatchedEpisode.id],
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    await expect(readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: `aggregate-cross-episode-${field}`,
+    })).rejects.toThrow('kstar episode does not belong to requirement');
+  });
+
   it('isolates aggregate-run evidence through logical-task, Episode, Projection, and per-turn receipt references', async () => {
     const userId = 'user-a';
     const conversationId = 'conversation-shared';
@@ -1679,6 +1739,66 @@ describe('KSTAR run evidence', () => {
     expect(result.episodes).toHaveLength(1);
     expect(result.injectionReceipts).toHaveLength(1000);
     expect(result.assets).toHaveLength(1);
+    expect(result.truncated).toBe(true);
+    expect(result.gaps).toContain('output_truncated');
+  });
+
+  it('caps Requirement reference traversal and reports the partial result', async () => {
+    const userId = 'user-requirement-traversal-cap';
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'requirement-traversal-cap',
+      taskRunId: 'aggregate-requirement-traversal-cap',
+      reuseTurnIds: [],
+      projection: { id: 'projection-requirement-traversal-cap', assetIds: [] },
+    });
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    await requirementStore.replaceKstarTask(userId, {
+      ...linked.task,
+      requirementIds: [
+        linked.requirement.id,
+        ...Array.from({ length: 1000 }, (_, index) => `zzreq-traversal-${index}`),
+      ],
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-requirement-traversal-cap',
+    });
+
+    expect(result.requirementIds).toEqual([linked.requirement.id]);
+    expect(result.truncated).toBe(true);
+    expect(result.gaps).toContain('output_truncated');
+  });
+
+  it('caps Episode reference traversal and reports the partial result', async () => {
+    const userId = 'user-episode-traversal-cap';
+    const linked = await seedLinkedRun({
+      userId,
+      suffix: 'episode-traversal-cap',
+      taskRunId: 'aggregate-episode-traversal-cap',
+      reuseTurnIds: [],
+      projection: { id: 'projection-episode-traversal-cap', assetIds: [] },
+    });
+    const requirementStore = await import('../../../../src/main/features/kstar/requirement-store');
+    await requirementStore.replaceKstarRequirement(userId, {
+      ...linked.requirement,
+      projectionId: String(linked.projection.id),
+      projectionIds: [String(linked.projection.id)],
+      episodeIds: [
+        linked.episode.id,
+        ...Array.from({ length: 1000 }, (_, index) => `zzepisode-traversal-${index}`),
+      ],
+    });
+
+    const { readKstarRunEvidence } = await import('../../../../src/main/features/kstar/run-evidence');
+    const result = await readKstarRunEvidence(userId, {
+      taskId: linked.task.id,
+      taskRunId: 'aggregate-episode-traversal-cap',
+    });
+
+    expect(result.episodes).toEqual([expect.objectContaining({ id: linked.episode.id })]);
     expect(result.truncated).toBe(true);
     expect(result.gaps).toContain('output_truncated');
   });

--- a/test/main/features/kstar/secondary-attribution.test.ts
+++ b/test/main/features/kstar/secondary-attribution.test.ts
@@ -128,6 +128,123 @@ describe('KSTAR secondary attribution', () => {
     });
   });
 
+  it('scopes deterministic receipt facts to authoritative reuse turn ids', async () => {
+    const attribution = await import('../../../../src/main/features/kstar/secondary-attribution');
+    const current = episode({
+      taskRunId: 'aggregate-secondary-a',
+      reuseTurnIds: ['turn-secondary-a'],
+    });
+    const detail = attribution.deriveDeterministicAttributionDetails({
+      episode: current,
+      injectionReceipts: [{
+        schemaVersion: 1,
+        ownerId: current.ownerId,
+        id: 'injection-secondary-a',
+        taskRunId: 'turn-secondary-a',
+        projectionId: current.projectionId,
+        assetId: 'asset-a',
+        assetVersion: '1',
+        boundary: 'real',
+        status: 'injected',
+        createdAt: current.createdAt,
+      }],
+      usageReceipts: [{
+        schemaVersion: 1,
+        ownerId: current.ownerId,
+        id: 'usage-secondary-a',
+        taskRunId: 'turn-secondary-a',
+        projectionId: current.projectionId!,
+        assetId: 'asset-a',
+        assetVersion: '1',
+        injectionReceiptId: 'injection-secondary-a',
+        status: 'contradicted',
+        evidenceRefs: current.evidenceRefs,
+        evidenceKind: 'agent_action',
+        boundary: 'real',
+        createdAt: current.createdAt,
+      }],
+    });
+
+    expect(detail?.category).toBe('asset_conflict');
+  });
+
+  it('requires every Usage relationship field to match an owned Injection', async () => {
+    const attribution = await import('../../../../src/main/features/kstar/secondary-attribution');
+    const current = episode({
+      taskRunId: 'aggregate-secondary-relationship',
+      reuseTurnIds: ['turn-secondary-relationship'],
+    });
+    const injection = {
+      schemaVersion: 1 as const,
+      ownerId: current.ownerId,
+      id: 'injection-secondary-relationship',
+      taskRunId: 'turn-secondary-relationship',
+      projectionId: current.projectionId,
+      assetId: 'asset-a',
+      assetVersion: '1',
+      boundary: 'real' as const,
+      status: 'injected' as const,
+      createdAt: current.createdAt,
+    };
+    const usage = {
+      schemaVersion: 1 as const,
+      ownerId: current.ownerId,
+      id: 'usage-secondary-relationship',
+      taskRunId: injection.taskRunId,
+      projectionId: injection.projectionId!,
+      assetId: injection.assetId,
+      assetVersion: injection.assetVersion,
+      injectionReceiptId: injection.id,
+      status: 'contradicted' as const,
+      evidenceRefs: current.evidenceRefs,
+      evidenceKind: 'agent_action' as const,
+      boundary: injection.boundary,
+      createdAt: current.createdAt,
+    };
+
+    expect(attribution.deriveDeterministicAttributionDetails({
+      episode: current,
+      injectionReceipts: [injection],
+      usageReceipts: [usage],
+    })?.category).toBe('asset_conflict');
+
+    for (const override of [
+      { injectionReceiptId: 'injection-other' },
+      { taskRunId: 'turn-other' },
+      { projectionId: 'projection-other' },
+      { assetId: 'asset-other' },
+      { assetVersion: '2' },
+      { boundary: 'degraded' as const },
+    ]) {
+      expect(attribution.deriveDeterministicAttributionDetails({
+        episode: current,
+        injectionReceipts: [injection],
+        usageReceipts: [{ ...usage, ...override }],
+      })?.category, JSON.stringify(override)).not.toBe('asset_conflict');
+    }
+  });
+
+  it('does not fall back to the aggregate run id when an authoritative reuse turn list is present but empty', async () => {
+    const attribution = await import('../../../../src/main/features/kstar/secondary-attribution');
+    const current = episode({ taskRunId: 'aggregate-empty', reuseTurnIds: [] });
+
+    expect(attribution.deriveDeterministicAttributionDetails({
+      episode: current,
+      injectionReceipts: [{
+        schemaVersion: 1,
+        ownerId: current.ownerId,
+        id: 'injection-aggregate-empty',
+        taskRunId: 'aggregate-empty',
+        projectionId: current.projectionId,
+        assetId: 'asset-a',
+        assetVersion: '1',
+        boundary: 'real',
+        status: 'injected',
+        createdAt: current.createdAt,
+      }],
+    })?.category).toBe('injection_failure');
+  });
+
   it('classifies a terminal timeout as execution_error, not environment_failure', async () => {
     const attribution = await import('../../../../src/main/features/kstar/secondary-attribution');
     const current = episode({

--- a/test/main/features/kstar/task-closure.test.ts
+++ b/test/main/features/kstar/task-closure.test.ts
@@ -128,6 +128,294 @@ describe('KSTAR completion evidence merge', () => {
     const review = await reviews.readKstarReview('closure-user', records[0].id as string);
     expect(review?.actualResult).toContain('Report written to disk.');
   });
+
+  it('uses the snapshotted requirement after the current lifecycle switches', async () => {
+    const store = await import('../../../../src/main/features/kstar/requirement-store');
+    const firstTask = store.createKstarTaskRecord('closure-user', { conversationId: 'cid-switched-evidence', title: 'First task' });
+    const firstRequirement = store.createKstarRequirementRecord('closure-user', {
+      taskId: firstTask.id,
+      conversationId: 'cid-switched-evidence',
+      userMessageIds: ['msg-first-evidence'],
+      title: 'First task',
+      goalText: 'Produce the first result',
+    });
+    firstRequirement.completionEvidence = {
+      finalStatus: 'completed',
+      finalText: 'FIRST-RUN-EVIDENCE',
+      producedFiles: ['first.md'],
+      acceptanceEvidence: [],
+    };
+    const secondTask = store.createKstarTaskRecord('closure-user', { conversationId: 'cid-switched-evidence', title: 'Second task' });
+    const secondRequirement = store.createKstarRequirementRecord('closure-user', {
+      taskId: secondTask.id,
+      conversationId: 'cid-switched-evidence',
+      userMessageIds: ['msg-second-evidence'],
+      title: 'Second task',
+      goalText: 'Produce the second result',
+    });
+    secondRequirement.completionEvidence = {
+      finalStatus: 'completed',
+      finalText: 'SECOND-RUN-EVIDENCE',
+      producedFiles: ['second.md'],
+      acceptanceEvidence: [],
+    };
+    await store.replaceKstarTask('closure-user', { ...firstTask, requirementIds: [firstRequirement.id], currentRequirementId: firstRequirement.id });
+    await store.replaceKstarRequirement('closure-user', firstRequirement);
+    await store.replaceKstarTask('closure-user', { ...secondTask, requirementIds: [secondRequirement.id], currentRequirementId: secondRequirement.id });
+    await store.replaceKstarRequirement('closure-user', secondRequirement);
+    await store.writeConversationTaskState('closure-user', {
+      ...store.createInitialConversationTaskState('closure-user', 'cid-switched-evidence'),
+      currentTaskId: secondTask.id,
+      currentRequirementId: secondRequirement.id,
+      taskComplete: false,
+    });
+
+    const closure = await import('../../../../src/main/features/kstar/task-closure');
+    const result = await closure.captureGroupKstarClosure({
+      userId: 'closure-user', runId: 'run-first-snapshot', conversationId: 'cid-switched-evidence', status: 'completed',
+      taskId: firstTask.id,
+      requirementId: firstRequirement.id,
+      startedAtMs: Date.parse('2026-08-05T00:00:00.000Z'), finishedAtMs: Date.parse('2026-08-05T00:01:00.000Z'),
+      messages: [
+        { id: 'msg-first-evidence', from: 'user', text: 'Produce the first result', ts: '2026-08-05T00:00:01.000Z' },
+        { id: 'msg-first-result', from: 'commander', text: 'generic result', ts: '2026-08-05T00:00:30.000Z' },
+      ],
+      inferReview: conservativeInference,
+    });
+
+    expect(result.episode.r).toMatchObject({ finalText: 'FIRST-RUN-EVIDENCE', producedFiles: ['first.md'] });
+    expect(result.episode).toMatchObject({ taskId: firstTask.id, requirementId: firstRequirement.id });
+    const storedFirst = await store.readKstarRequirement('closure-user', firstRequirement.id);
+    const storedSecond = await store.readKstarRequirement('closure-user', secondRequirement.id);
+    expect(storedFirst?.episodeIds).toContain(result.episode.id);
+    expect(storedSecond?.episodeIds).not.toContain(result.episode.id);
+  });
+});
+
+describe('KSTAR degraded new-format closure fallback gating', () => {
+  it('does not merge current-lifecycle evidence or attach when a new-format terminal lost its task/requirement provenance', async () => {
+    const store = await import('../../../../src/main/features/kstar/requirement-store');
+    // The conversation's CURRENT lifecycle is a later task/requirement that
+    // carries completion evidence. The terminal event was new-format
+    // (reuse_turn_ids present) but degraded: task_id and requirement_id were
+    // lost before capture. The closure must NOT reach into the post-run
+    // current lifecycle to enrich or attach the episode.
+    const currentTask = store.createKstarTaskRecord('closure-user', { conversationId: 'cid-degraded-snapshot', title: 'Current task' });
+    const currentRequirement = store.createKstarRequirementRecord('closure-user', {
+      taskId: currentTask.id,
+      conversationId: 'cid-degraded-snapshot',
+      userMessageIds: ['msg-degraded-current'],
+      title: 'Current task',
+      goalText: 'Produce the current result',
+    });
+    currentRequirement.completionEvidence = {
+      finalStatus: 'completed',
+      finalText: 'CURRENT-RUN-EVIDENCE',
+      producedFiles: ['current.md'],
+      acceptanceEvidence: [],
+    };
+    await store.replaceKstarTask('closure-user', { ...currentTask, requirementIds: [currentRequirement.id], currentRequirementId: currentRequirement.id });
+    await store.replaceKstarRequirement('closure-user', currentRequirement);
+    await store.writeConversationTaskState('closure-user', {
+      ...store.createInitialConversationTaskState('closure-user', 'cid-degraded-snapshot'),
+      currentTaskId: currentTask.id,
+      currentRequirementId: currentRequirement.id,
+      taskComplete: false,
+    });
+
+    const closure = await import('../../../../src/main/features/kstar/task-closure');
+    const result = await closure.captureGroupKstarClosure({
+      userId: 'closure-user', runId: 'run-degraded-snapshot', conversationId: 'cid-degraded-snapshot', status: 'completed',
+      reuseTurnIds: [],
+      startedAtMs: Date.parse('2026-08-05T00:00:00.000Z'), finishedAtMs: Date.parse('2026-08-05T00:01:00.000Z'),
+      messages: [
+        { id: 'msg-degraded-user', from: 'user', text: 'Do the current work', ts: '2026-08-05T00:00:01.000Z' },
+        { id: 'msg-degraded-result', from: 'commander', text: 'generic result text', ts: '2026-08-05T00:00:30.000Z' },
+      ],
+      inferReview: conservativeInference,
+    });
+
+    // Episode keeps its message-derived text — the current lifecycle's
+    // completion evidence is never merged in.
+    expect(result.episode.r.finalText).not.toBe('CURRENT-RUN-EVIDENCE');
+    expect(result.episode.r.producedFiles || []).not.toContain('current.md');
+    // And the episode is never attached to the (different) current
+    // requirement: episodeIds stays empty.
+    const stored = await store.readKstarRequirement('closure-user', currentRequirement.id);
+    expect(stored?.episodeIds).toEqual([]);
+  });
+
+  it('never falls back to a later open requirement of the same task when a new-format terminal kept only its task identity', async () => {
+    const store = await import('../../../../src/main/features/kstar/requirement-store');
+    const task = store.createKstarTaskRecord('closure-user', { conversationId: 'cid-degraded-same-task', title: 'Resolved task' });
+    const firstRequirement = store.createKstarRequirementRecord('closure-user', {
+      taskId: task.id,
+      conversationId: 'cid-degraded-same-task',
+      userMessageIds: ['msg-degraded-first'],
+      title: 'Earlier requirement',
+      goalText: 'Produce the first result',
+    });
+    const laterRequirement = store.createKstarRequirementRecord('closure-user', {
+      taskId: task.id,
+      conversationId: 'cid-degraded-same-task',
+      userMessageIds: ['msg-degraded-later'],
+      title: 'Later current requirement',
+      goalText: 'Produce the later result',
+    });
+    laterRequirement.completionEvidence = {
+      finalStatus: 'completed',
+      finalText: 'LATER-RUN-EVIDENCE',
+      producedFiles: ['later.md'],
+      acceptanceEvidence: [],
+    };
+    await store.replaceKstarTask('closure-user', {
+      ...task,
+      requirementIds: [firstRequirement.id, laterRequirement.id],
+      currentRequirementId: laterRequirement.id,
+    });
+    await store.replaceKstarRequirement('closure-user', firstRequirement);
+    await store.replaceKstarRequirement('closure-user', laterRequirement);
+    await store.writeConversationTaskState('closure-user', {
+      ...store.createInitialConversationTaskState('closure-user', 'cid-degraded-same-task'),
+      currentTaskId: task.id,
+      currentRequirementId: laterRequirement.id,
+      taskComplete: false,
+    });
+
+    const closure = await import('../../../../src/main/features/kstar/task-closure');
+    const result = await closure.captureGroupKstarClosure({
+      userId: 'closure-user', runId: 'run-degraded-same-task', conversationId: 'cid-degraded-same-task', status: 'completed',
+      taskId: task.id,
+      reuseTurnIds: [],
+      startedAtMs: Date.parse('2026-08-05T00:00:00.000Z'), finishedAtMs: Date.parse('2026-08-05T00:01:00.000Z'),
+      messages: [
+        { id: 'msg-degraded-same-user', from: 'user', text: 'Do the first work', ts: '2026-08-05T00:00:01.000Z' },
+        { id: 'msg-degraded-same-result', from: 'commander', text: 'generic result text', ts: '2026-08-05T00:00:30.000Z' },
+      ],
+      inferReview: conservativeInference,
+    });
+
+    // Evidence from the LATER current requirement is never merged into the
+    // snapshot episode (identity is task-only).
+    expect(result.episode.r.finalText).not.toBe('LATER-RUN-EVIDENCE');
+    expect(result.episode.r.producedFiles || []).not.toContain('later.md');
+    // Attachment must NOT fall back to the current (same-task) requirement:
+    // both requirements keep empty episodeIds.
+    const storedLater = await store.readKstarRequirement('closure-user', laterRequirement.id);
+    expect(storedLater?.episodeIds).toEqual([]);
+    const storedFirst = await store.readKstarRequirement('closure-user', firstRequirement.id);
+    expect(storedFirst?.episodeIds).toEqual([]);
+  });
+
+  it('still attaches by projection provenance when a new-format terminal kept its task and projection but lost requirement identity', async () => {
+    const store = await import('../../../../src/main/features/kstar/requirement-store');
+    const task = store.createKstarTaskRecord('closure-user', { conversationId: 'cid-degraded-proj-snap', title: 'Resolved task' });
+    const current = store.createKstarRequirementRecord('closure-user', {
+      taskId: task.id,
+      conversationId: 'cid-degraded-proj-snap',
+      userMessageIds: ['msg-degraded-proj-current'],
+      title: 'Current requirement',
+      goalText: 'Stay on the current requirement',
+    });
+    const matched = store.createKstarRequirementRecord('closure-user', {
+      taskId: task.id,
+      conversationId: 'cid-degraded-proj-snap',
+      userMessageIds: ['msg-degraded-proj-matched'],
+      title: 'Matched requirement',
+      goalText: 'Attach by projection provenance',
+    });
+    await store.replaceKstarTask('closure-user', {
+      ...task,
+      requirementIds: [current.id, matched.id],
+      currentRequirementId: current.id,
+    });
+    await store.replaceKstarRequirement('closure-user', current);
+    await store.replaceKstarRequirement('closure-user', { ...matched, projectionId: 'proj-snap-match' });
+    await store.writeConversationTaskState('closure-user', {
+      ...store.createInitialConversationTaskState('closure-user', 'cid-degraded-proj-snap'),
+      currentTaskId: task.id,
+      currentRequirementId: current.id,
+      taskComplete: false,
+    });
+
+    const closure = await import('../../../../src/main/features/kstar/task-closure');
+    await closure.captureGroupKstarClosure({
+      userId: 'closure-user', runId: 'run-degraded-proj-snap', conversationId: 'cid-degraded-proj-snap', status: 'completed',
+      taskId: task.id,
+      projectionId: 'proj-snap-match',
+      reuseTurnIds: [],
+      startedAtMs: Date.parse('2026-08-05T00:00:00.000Z'), finishedAtMs: Date.parse('2026-08-05T00:01:00.000Z'),
+      messages: [
+        { id: 'msg-degraded-proj-user', from: 'user', text: 'Attach by projection provenance', ts: '2026-08-05T00:00:01.000Z' },
+        { id: 'msg-degraded-proj-result', from: 'commander', text: 'generic result text', ts: '2026-08-05T00:00:30.000Z' },
+      ],
+      inferReview: conservativeInference,
+    });
+
+    const storedMatched = await store.readKstarRequirement('closure-user', matched.id);
+    expect(storedMatched?.episodeIds).toContain('kse-run-degraded-proj-snap');
+    const storedCurrent = await store.readKstarRequirement('closure-user', current.id);
+    expect(storedCurrent?.episodeIds).toEqual([]);
+  });
+
+  it('still attaches by projection provenance when a new-format terminal kept ONLY its projection (task/requirement identity lost but the current task owns the projection)', async () => {
+    const store = await import('../../../../src/main/features/kstar/requirement-store');
+    // Snapshot event with ONLY a projection handle: no taskId/requirementId.
+    // The conversation's current task is the SAME task that owns the
+    // projection's requirement, so task resolution via state.currentTaskId
+    // must succeed and the projection provenance match must bind the episode.
+    // The identity-loss skip gate must not swallow this legitimate
+    // provenance-only path (regression: run-evidence could never find the
+    // Episode because requirement.episodeIds stayed empty).
+    const task = store.createKstarTaskRecord('closure-user', { conversationId: 'cid-proj-only-snap', title: 'Owning task' });
+    const owning = store.createKstarRequirementRecord('closure-user', {
+      taskId: task.id,
+      conversationId: 'cid-proj-only-snap',
+      userMessageIds: ['msg-proj-only-user'],
+      title: 'Owning requirement',
+      goalText: 'Produce the owning result',
+    });
+    owning.completionEvidence = {
+      finalStatus: 'completed',
+      finalText: 'OWNING-RUN-EVIDENCE',
+      producedFiles: ['owning.md'],
+      acceptanceEvidence: [],
+    };
+    await store.replaceKstarTask('closure-user', {
+      ...task,
+      requirementIds: [owning.id],
+      currentRequirementId: owning.id,
+    });
+    await store.replaceKstarRequirement('closure-user', { ...owning, projectionId: 'proj-only-snap' });
+    await store.writeConversationTaskState('closure-user', {
+      ...store.createInitialConversationTaskState('closure-user', 'cid-proj-only-snap'),
+      currentTaskId: task.id,
+      currentRequirementId: owning.id,
+      taskComplete: false,
+    });
+
+    const closure = await import('../../../../src/main/features/kstar/task-closure');
+    const result = await closure.captureGroupKstarClosure({
+      userId: 'closure-user', runId: 'run-proj-only-snap', conversationId: 'cid-proj-only-snap', status: 'completed',
+      projectionId: 'proj-only-snap',
+      reuseTurnIds: [],
+      startedAtMs: Date.parse('2026-08-05T00:00:00.000Z'), finishedAtMs: Date.parse('2026-08-05T00:01:00.000Z'),
+      messages: [
+        { id: 'msg-proj-only-user', from: 'user', text: 'Produce the owning result', ts: '2026-08-05T00:00:01.000Z' },
+        { id: 'msg-proj-only-result', from: 'commander', text: 'generic result text', ts: '2026-08-05T00:00:30.000Z' },
+      ],
+      inferReview: conservativeInference,
+    });
+
+    // Provenance-only binding still works: the resolved current task owns the
+    // projection, so the episode is attached to that requirement.
+    const storedOwning = await store.readKstarRequirement('closure-user', owning.id);
+    expect(storedOwning?.episodeIds).toContain(result.episode.id);
+    // Completion-evidence enrichment stays gated (snapshot + no requirementId):
+    // the owning requirement's evidence is never merged into the episode.
+    expect(result.episode.r.finalText).not.toBe('OWNING-RUN-EVIDENCE');
+    expect(result.episode.r.producedFiles || []).not.toContain('owning.md');
+  });
 });
 
 describe('KSTAR task closure', () => {
@@ -962,6 +1250,90 @@ describe('KSTAR group terminal subscriber', () => {
 
     expect(captured).toHaveLength(1);
     expect(captured[0]).toMatchObject({ userId: 'group-user', runId: 'run-group-terminal', conversationId: 'cid-group', status: 'completed' });
+    stop();
+  });
+
+  it('persists terminal reuse turn ids and supplies their per-turn receipts to attribution', async () => {
+    const closure = await import('../../../../src/main/features/kstar/task-closure');
+    const injections = await import('../../../../src/main/features/recall/injection-receipt');
+    const episodeStore = await import('../../../../src/main/features/kstar/episode-store');
+    const injection = await injections.recordInjectionReceipt('group-user', {
+      taskRunId: 'turn-terminal-a',
+      projectionId: 'projection-terminal-a',
+      assetId: 'asset-terminal-a',
+      assetVersion: '1',
+      boundary: 'real',
+      status: 'injected',
+      messageId: 'message-terminal-agent',
+    });
+    let listener: ((event: any) => void) | undefined;
+    let inferenceOptions: any;
+    let captureDone = false;
+    const inferReview = async (_userId: string, episode: any, options: any) => {
+      inferenceOptions = options;
+      return {
+        review: {
+          deltaR: 'unknown' as const,
+          deltaA: 'unknown' as const,
+          outcome: 'unclear' as const,
+          attribution: 'unclear' as const,
+          reason: 'Per-turn receipt attribution was inspected.',
+          confidence: 0,
+          evidenceRefs: episode.evidenceRefs,
+        },
+        reviewState: 'unknown' as const,
+        inferenceMethod: 'deterministic' as const,
+        needsConfirmation: false,
+      };
+    };
+    const stop = closure.startGroupKstarClosure({
+      subscribe: (next: (event: any) => void) => { listener = next; return () => { listener = undefined; }; },
+      readMessages: async () => [
+        { id: 'message-terminal-user', ts: '2026-09-10T00:00:01.000Z', from: 'user', text: 'Use the projected asset.' },
+        {
+          id: 'message-terminal-agent', ts: '2026-09-10T00:00:30.000Z', from: 'agent-a', text: 'The run failed after injection.',
+          recall_citations: [{ asset_id: 'asset-terminal-a', version: '1', projection_id: 'projection-terminal-a' }],
+        },
+      ],
+      capture: async (input) => {
+        try {
+          return await closure.captureGroupKstarClosure({ ...input, inferReview });
+        } finally {
+          captureDone = true;
+        }
+      },
+    });
+
+    listener?.({
+      run_id: 'aggregate-terminal-a',
+      user_id: 'group-user',
+      conversation_id: 'conversation-terminal-a',
+      status: 'failed',
+      started_at_ms: Date.parse('2026-09-10T00:00:00.000Z'),
+      finished_at_ms: Date.parse('2026-09-10T00:01:00.000Z'),
+      projection_id: 'projection-terminal-a',
+      reuse_turn_ids: ['turn-terminal-a'],
+      reuse_turn_ids_truncated: true,
+    });
+    const deadline = Date.now() + 2_000;
+    while (!captureDone && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(captureDone).toBe(true);
+    await expect(episodeStore.readKstarEpisode('group-user', 'kse-aggregate-terminal-a')).resolves.toMatchObject({
+      taskRunId: 'aggregate-terminal-a',
+      reuseTurnIds: ['turn-terminal-a'],
+      reuseTurnIdsTruncated: true,
+    });
+    expect(inferenceOptions?.injectionReceipts).toEqual([expect.objectContaining({ id: injection.id })]);
+    expect(inferenceOptions?.usageReceipts).toEqual([
+      expect.objectContaining({
+        taskRunId: 'turn-terminal-a',
+        projectionId: 'projection-terminal-a',
+        injectionReceiptId: injection.id,
+      }),
+    ]);
     stop();
   });
 

--- a/test/main/features/recall/terminal-proof.test.ts
+++ b/test/main/features/recall/terminal-proof.test.ts
@@ -127,6 +127,36 @@ describe('Recall terminal transfer proof handler', () => {
     expect((await proofs.listTransferProofs('user-a')).some((p) => p.receiptId)).toBe(true);
   });
 
+  it('does not promote from a truncated receipt-id ownership snapshot', async () => {
+    const { asset, projection } = await confirmedProjection('run-truncated-receipts');
+    const { terminalProof, assets } = await modules();
+    const receipts = await import('../../../../src/main/features/p3394/context-reuse-receipt');
+    await receipts.prepareReceipt('user-a', {
+      executionId: 'turn-newest-retained',
+      targetSessionId: 'gconv-cid-truncated',
+      reusedRefs: [asset.id],
+      omittedRefs: [],
+      permissionMode: 'read-only',
+      allowedScopes: ['cognition:projection'],
+      boundary: 'real',
+    }, { sessionId: 'gconv-cid-truncated' });
+
+    await terminalProof.handleRecallTaskTerminal({
+      run_id: 'run-truncated-receipts',
+      user_id: 'user-a',
+      conversation_id: 'cid-truncated',
+      status: 'completed',
+      projection_id: projection.id,
+      reuse_turn_ids: ['newest-retained'],
+      reuse_turn_ids_truncated: true,
+      started_at_ms: 1,
+      finished_at_ms: 2,
+    });
+
+    const unchanged = (await assets.listAbilityAssets('user-a')).find((candidate) => candidate.id === asset.id);
+    expect(unchanged?.maturity).not.toBe('transfer_validated');
+  });
+
   /**
    * 回合收尾会把回执从 prepared 收成终态（bus.ts 的 completeReceipt）。
    * 这条钉住终态回执仍然构成升档证据——否则"让回执真正闭合"这件事本身会

--- a/test/main/ipc/recall.test.ts
+++ b/test/main/ipc/recall.test.ts
@@ -128,6 +128,12 @@ const kstarTraceMock = vi.hoisted(() => ({
 const kstarFailuresMock = vi.hoisted(() => ({
   listKstarFailures: vi.fn(async () => []),
 }));
+const kstarRunEvidenceMock = vi.hoisted(() => ({
+  readKstarRunEvidence: vi.fn(async (_uid: string, input: { taskId: string; taskRunId: string }) => ({
+    ...input,
+    gaps: [],
+  })),
+}));
 const kstarClosureMock = vi.hoisted(() => ({
   confirmKstarReview: vi.fn(async () => ({ episode: {}, review: {} })),
 }));
@@ -202,6 +208,7 @@ vi.mock('../../../src/main/features/recall/teaching-service', () => teachingMock
 vi.mock('../../../src/main/features/recall/context-projection', () => projectionMock);
 vi.mock('../../../src/main/features/kstar/trace', () => kstarTraceMock);
 vi.mock('../../../src/main/features/kstar/failure-service', () => kstarFailuresMock);
+vi.mock('../../../src/main/features/kstar/run-evidence', () => kstarRunEvidenceMock);
 vi.mock('../../../src/main/features/kstar/projection-decision-service', () => projectionDecisionMock);
 vi.mock('../../../src/main/features/kstar/task-closure', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../src/main/features/kstar/task-closure')>()),
@@ -506,6 +513,43 @@ describe('ipc › recall candidate governance', () => {
     await expect(call('kstar.review.read', { episodeId: 'kse-episode-a' }))
       .resolves.toMatchObject({ ok: true, review: { reviewState: 'needs_confirmation' } });
     expect(kstarReviewServiceMock.readKstarReview).toHaveBeenCalledWith(UID, 'kse-episode-a');
+  });
+
+  it('routes KSTAR run evidence reads through the active user boundary', async () => {
+    await expect(call('kstar.runEvidence.read', { taskId: 'task-a', taskRunId: 'run-a' }))
+      .resolves.toMatchObject({
+        ok: true,
+        evidence: { taskId: 'task-a', taskRunId: 'run-a', gaps: [] },
+      });
+    expect(kstarRunEvidenceMock.readKstarRunEvidence).toHaveBeenCalledWith(UID, {
+      taskId: 'task-a',
+      taskRunId: 'run-a',
+    });
+  });
+
+  it('rejects malformed KSTAR run evidence references before the feature call', async () => {
+    const malformed = [
+      {},
+      { taskId: 'task-a' },
+      { taskRunId: 'run-a' },
+      { taskId: 42, taskRunId: 'run-a' },
+      { taskId: 'task-a', taskRunId: 42 },
+      { taskId: '../bad', taskRunId: 'run-a' },
+      { taskId: 'task-a', taskRunId: '../bad' },
+    ];
+
+    for (const payload of malformed) {
+      await expect(call('kstar.runEvidence.read', payload))
+        .resolves.toMatchObject({ ok: false, error: 'invalid kstar run evidence input' });
+    }
+    expect(kstarRunEvidenceMock.readKstarRunEvidence).not.toHaveBeenCalled();
+  });
+
+  it('returns recoverable KSTAR run evidence feature errors', async () => {
+    kstarRunEvidenceMock.readKstarRunEvidence.mockRejectedValueOnce(new Error('evidence unavailable'));
+
+    await expect(call('kstar.runEvidence.read', { taskId: 'task-a', taskRunId: 'run-a' }))
+      .resolves.toMatchObject({ ok: false, error: 'evidence unavailable' });
   });
 
   it('rejects malformed source and capture inputs before feature calls', async () => {

--- a/test/scripts/release-version-consistency.test.ts
+++ b/test/scripts/release-version-consistency.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from 'vitest';
 import YAML from 'yaml';
 
 const repoRoot = resolve(import.meta.dirname, '..', '..');
-const releaseVersion = '0.9.0';
-const releaseDate = '2026-09-07';
+const releaseVersion = '1.0.2';
+const releaseDate = '2026-09-10';
 
 function readJson(relativePath: string): any {
   return JSON.parse(readFileSync(resolve(repoRoot, relativePath), 'utf8'));
@@ -27,7 +27,7 @@ function collectCogSeedVersions(value: unknown, versions = new Set<string>()): S
 }
 
 describe('release version consistency', () => {
-  it('keeps package, publiccode, SBOM, and changelog on 0.9.0', () => {
+  it('keeps package, publiccode, SBOM, and changelog on 1.0.2', () => {
     const packageJson = readJson('package.json');
     const packageLock = readJson('package-lock.json');
     const sbom = readJson('sbom.cdx.json');


### PR DESCRIPTION
## 概述

KSTAR D02/D03 交付：把 **资产选择/注入/实际采用/执行/评价** 的证据收敛为 **run-scoped evidence contract**，通过同一 KSTAR Task/Run 提供稳定、不会串运行的只读结果。

- 基线：`origin/develop @ f99d772ec1f4464d141585246005e6f21613ad99`
- 分支：`codex/kstar-e1-evidence-contract-20260909`
- 无新增依赖、数据库、UI、renderer/preload 契约或 Error Pattern 资产。
- 唯一新增 IPC：`kstar.runEvidence.read`（内部只读、按 active userId 隔离、safeId 校验、输出带截断上限）。

## D02：证据链路（选择 → 注入 → 采用 → 评价）

- Projection（逻辑 Task 确认投影 + 锁定资产版本）、Episode（Group aggregate run）、ContextReuseReceipt / InjectionReceipt / UsageReceipt（per-turn 三类真实 ID）统一关联。
- Usage 只有在「真实注入 + 对应消息存在成功 Host 工具/产物证据」时才落 `applied`，否则保持 `usage_unknown`；六字段关系（injectionReceiptId/taskRunId/projectionId/assetId/assetVersion/boundary）严格校验。
- Review/TransferProof/EffectivenessProof/Validation 与原始事实分离返回，不合成 applied/success/better/effectiveness。
- **无证据时保持 unknown/degraded/gap，不推导成功、采用或效果改善。**

## D03：稳定、不串运行

- 终态在释放 run 前冻结不可变 provenance 快照（aggregate runId、taskId、requirementId、projectionId、精确 turn IDs、起止边界），后台消费只读快照，不再回读可变 current lifecycle。
- 移除终态时间窗 receipt 扫描与 current-lifecycle 回填；崩溃恢复使用稳定 hash 的 aggregate run id，并按持久化 receipt 精确恢复 `gconv`/`gmember` turn（权威空 `[]` 与 legacy unknown 区分）。
- 超过 100 个 reuse turn 时持久化 `reuseTurnIdsTruncated`，terminal-proof 不据此升档，evidence 报 `reuse_turn_ids_truncated` gap。
- run-evidence：逐 Episode/Projection/asset 保守 gaps（review/usage/effectiveness），损坏的权威 Requirement 直读并传播错误；输出集合带 1000 上限与 `truncated`/`output_truncated`。

## 测试

- 新增/扩展 bus-integration、run-evidence、task-closure、requirement-state、terminal-proof、acceptance 正反场景（相邻成功 run 不串入、failed run 不推导 applied、截断不升档、冻结快照隔离后运行、恢复幂等）。
- `npm run typecheck`：通过
- KSTAR/相关专项：482 passed / 4 skipped
- `npm run test:resources`：308 passed
- 全量 JS：10821 passed / 46 skipped；唯一失败为已知 develop 基线 `test/main/features/local_agents/version.test.ts`（detectVersion 探测超时，在纯净 origin/develop 上独立复现，与本分支无关）。

## 说明

- 不含内部会议材料、基线 ZIP、真实个人数据或内部方案文档。
