### PR TITLE
fix(windows): close updater and packaged smoke gaps

### DIFF
--- a/src/main/features/updater/client.ts
+++ b/src/main/features/updater/client.ts
@@ -55,7 +55,7 @@ import type {
 const log = createLogger('updater');
 
 const LATEST_CHECK_TIMEOUT_MS = 15_000;
-const DOWNLOAD_EXTENSIONS_ALLOWED = new Set(['.dmg', '.zip']);
+const DOWNLOAD_EXTENSIONS_ALLOWED = new Set(['.dmg', '.exe', '.zip']);
 
 /**
  * Headers for the updates endpoints. The updates contract
@@ -103,6 +103,10 @@ function currentAppVersion(): string {
 }
 
 export { currentAppVersion };
+
+function isPackagedReminderPlatformUnsupported(): boolean {
+  return electronApp?.isPackaged === true && process.platform !== 'darwin';
+}
 
 function _asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -171,6 +175,12 @@ export async function checkForUpdates(
 ): Promise<CheckResult> {
   const now = opts.now ?? Date.now();
   const current = currentAppVersion();
+  if (isPackagedReminderPlatformUnsupported()) {
+    const state = readUpdaterState(userId);
+    state.last_check_at = now;
+    writeUpdaterState(userId, { ...state, latest_info: undefined });
+    return { checked: true, has_update: false, reminded: false, current_version: current };
+  }
   try {
     const info = await _fetchLatest();
     const state = readUpdaterState(userId);
@@ -226,7 +236,7 @@ export function installerFilenameFromUrl(url: string): string {
       if (DOWNLOAD_EXTENSIONS_ALLOWED.has(ext)) return base;
     }
   } catch { /* fall through to the fallback name */ }
-  const ext = url.toLowerCase().match(/\.(dmg|zip)(\?|$)/)?.[1] || 'dmg';
+  const ext = url.toLowerCase().match(/\.(dmg|exe|zip)(\?|$)/)?.[1] || 'dmg';
   return `CogSeed-${process.platform}-${process.arch}.${ext}`;
 }
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -464,6 +464,14 @@ const cogseedApi = {
 };
 contextBridge.exposeInMainWorld('cogseed', cogseedApi);
 
+function runAfterDomReady(callback) {
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', callback, { once: true });
+    return;
+  }
+  callback();
+}
+
 // Windows final-package microphone smoke. This runs only when the packaged
 // verifier supplies the private renderer argument. It intentionally exercises
 // the same contextBridge invoke/stream functions as the UI and records only
@@ -476,7 +484,7 @@ const _isPackagedSttSmoke = process.platform === 'win32'
   && String(process.env.COGSEED_PACKAGED_STT_SMOKE_WAV || '').trim().length > 0
   && process.argv.includes('--cogseed-packaged-stt-smoke');
 if (_isPackagedSttSmoke) {
-  window.addEventListener('DOMContentLoaded', () => {
+  runAfterDomReady(() => {
     const metrics = {
       audioTrackLive: false,
       sampleCount: 0,
@@ -595,7 +603,7 @@ if (_isPackagedSttSmoke) {
     void run().catch((error) => {
       console.error('[packaged-stt-smoke] failed to record result', error);
     });
-  }, { once: true });
+  });
 }
 
 // Final-package launch smoke. The main process adds this private renderer
@@ -603,7 +611,7 @@ if (_isPackagedSttSmoke) {
 // A successful ping proves the preload bridge and main IPC handler both ran;
 // DOMContentLoaded proves the packaged renderer was read and initialized.
 if (process.argv.includes('--cogseed-packaged-launch-smoke')) {
-  window.addEventListener('DOMContentLoaded', () => {
+  runAfterDomReady(() => {
     ipcRenderer.invoke('cogseed.ping')
       .then((ping) => ipcRenderer.invoke('cogseed.packagedLaunchSmokeReady', {
         preloadLoaded: true,
@@ -613,5 +621,5 @@ if (process.argv.includes('--cogseed-packaged-launch-smoke')) {
       .catch((error) => {
         console.error('[packaged-launch-smoke] preload/renderer readiness failed', error);
       });
-  }, { once: true });
+  });
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1037,7 +1037,7 @@
       </section>
             </div>
 
-            <!-- 触点 → 入口卡跳转到设置 > 消息平台 -->
+            <!-- 触点：连接页内直接承载原消息平台/触点工作台。 -->
             <div class="connections-tab-pane" id="connections-pane-touchpoints" data-connections-pane="touchpoints" hidden>
               <!-- 触点（飞书等）整体迁入：原设置 messaging pane 的内容原样搬移。 -->
               <div class="touchpoint-settings-shell" aria-live="polite">
@@ -1062,7 +1062,7 @@
               </div>
             </div>
 
-            <!-- 模型与额度 → 入口卡跳转到设置 > Model Providers -->
+            <!-- 模型与额度：连接页内入口，不再回跳设置配置页。 -->
             <div class="connections-tab-pane" id="connections-pane-models" data-connections-pane="models" hidden>
               <div class="cognition-subentry-list">
                 <button type="button" class="cognition-entry-card" data-connections-subentry="models">

--- a/src/renderer/modules/connections.js
+++ b/src/renderer/modules/connections.js
@@ -5,7 +5,7 @@
 //   - MCP与工具 tab  ← connectors 网格（connectors.js 按原 ID 渲染）
 //   - 数据源 tab     ← #panel-contexts（资料库）
 //   - 触点 tab       ← messaging/touchpoint（自设置迁入）
-//   - 模型与额度 tab ← 入口卡（暂保留，跳转设置 Model Providers）
+//   - 模型与额度 tab ← 入口卡（连接页内承载，不回跳设置页）
 // Tab switching + per-tab lazy priming + entry-card wiring live here.
 
 function _connectionsEl(id) {
@@ -42,7 +42,9 @@ function initConnections() {
 
   // Restore the last-visible tab across view re-entries (preserves the user's
   // position while inside the panel; defaults to the first tab on first open).
-  const lastTab = _connectionsLastTab || document.querySelector('.connections-tab.is-active')?.dataset.connectionsTab || tabs[0].dataset.connectionsTab;
+  const requestedTab = window.__connectionsPendingTab || '';
+  window.__connectionsPendingTab = '';
+  const lastTab = requestedTab || _connectionsLastTab || document.querySelector('.connections-tab.is-active')?.dataset.connectionsTab || tabs[0].dataset.connectionsTab;
   _renderConnectionsPageHeader();
   activateConnectionsTab(lastTab);
 }
@@ -54,30 +56,17 @@ let _connectionsSkillsPrimed = false;
 
 function _connectionsOpenTarget(target) {
   if (target === 'touchpoints') {
-    _connectionsOpenConfiguration('gateways');
+    activateConnectionsTab('touchpoints');
     return;
   }
-  if (target === 'models' && typeof setView === 'function') {
-    _connectionsOpenConfiguration('models');
-  }
-}
-
-function _connectionsOpenConfiguration(anchor) {
-  if (typeof setView === 'function') {
-    setView('settings', undefined, { settingsTab: 'configuration', settingsAnchor: anchor });
-  }
-  if (typeof window.activateSettingsTab === 'function') {
-    window.activateSettingsTab('configuration', { anchor });
+  if (target === 'models') {
+    activateConnectionsTab('models');
   }
 }
 
 function activateConnectionsTab(name) {
   const tabs = Array.from(document.querySelectorAll('.connections-tab'));
   if (!tabs.length) return;
-  if (name === 'touchpoints') {
-    _connectionsOpenTarget(name);
-    return;
-  }
   const existing = tabs.find((btn) => btn.dataset.connectionsTab === name);
   const target = existing ? name : tabs[0].dataset.connectionsTab;
   _connectionsLastTab = target;
@@ -156,7 +145,26 @@ function activateConnectionsTab(name) {
     Promise.resolve(loadAgents(false)).catch(() => {});
   }
 
-  // 数据源 tab 内嵌资料库；触点已归入设置—配置。
+  // 触点 tab 内嵌原设置触点工作台；需要 settings bundle 里的
+  // messaging/touchpoint modules，但不再跳转到 Settings › Configuration。
+  if (target === 'touchpoints') {
+    const loader = typeof loadRendererFeature === 'function' ? loadRendererFeature : window.loadRendererFeature;
+    Promise.resolve(typeof loader === 'function' ? loader('settings') : undefined)
+      .then(() => {
+        if (typeof window.initTouchpointSettings === 'function') return window.initTouchpointSettings();
+        if (typeof initTouchpointSettings === 'function') return initTouchpointSettings();
+        return undefined;
+      })
+      .catch((err) => {
+        if (typeof createLogger === 'function') {
+          createLogger('connections').warn('touchpoints load failed', {
+            error: (err && err.message) || String(err),
+          });
+        }
+      });
+  }
+
+  // 数据源 tab 内嵌资料库。
   if (target === 'sources') {
     // 资料库（contexts）是懒加载模块：从「连接」视图进入时 boot 只初始化
     // tab 壳，不会加载 contexts.js。这里先加载模块再渲染，否则面板永远

--- a/src/renderer/modules/run-center.js
+++ b/src/renderer/modules/run-center.js
@@ -207,6 +207,14 @@
     });
     return true;
   }
+  function openConnectionsTab(tab) {
+    const target = String(tab || '').trim();
+    if (target) rootWindow.__connectionsPendingTab = target;
+    rootWindow.setView?.('connections');
+    if (target && typeof rootWindow.activateConnectionsTab === 'function') {
+      rootWindow.activateConnectionsTab(target);
+    }
+  }
   function restoreFocus(snapshot, fallbackSelector = '') {
     if (!snapshot) return false;
     const target = panel();
@@ -1710,13 +1718,11 @@
       if (button.dataset.runCenterRefresh !== undefined) { refresh(); return; }
       if (button.dataset.runCenterCreateOpen !== undefined) { openCreate('create'); return; }
       if (button.dataset.runCenterConfigureModel !== undefined) {
-        rootWindow.setView?.('settings', undefined, { settingsTab: 'configuration', settingsAnchor: 'models' });
-        rootWindow.activateSettingsTab?.('configuration', { anchor: 'models' });
+        openConnectionsTab('models');
         return;
       }
       if (button.dataset.runCenterAgentSettings !== undefined) {
-        rootWindow.setView?.('settings', undefined, { settingsTab: 'configuration', settingsAnchor: 'agents' });
-        rootWindow.activateSettingsTab?.('configuration', { anchor: 'agents' });
+        openConnectionsTab('agents');
         return;
       }
       if (button.dataset.runCenterSettingsAnchor) {

--- a/test/main/features/updater/client.test.ts
+++ b/test/main/features/updater/client.test.ts
@@ -38,6 +38,16 @@ function stubFetch(impl: (input: string | URL | Request, init?: RequestInit) => 
 const DMG_BODY = 'fake-dmg-bytes-0123456789';
 const DMG_SHA = crypto.createHash('sha256').update(DMG_BODY).digest('hex');
 
+async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  }
+}
+
 function infoFixture(overrides: Record<string, unknown> = {}) {
   return {
     latest_version: '0.0.6',
@@ -57,6 +67,7 @@ async function resetState() {
 
 describe('checkForUpdates', () => {
   beforeEach(() => {
+    electronMock.app.isPackaged = false;
     electronMock.app.getVersion.mockReturnValue('0.0.5');
     process.env.COGSEED_API_BASE_URL = API_BASE;
     void resetState();
@@ -99,6 +110,22 @@ describe('checkForUpdates', () => {
     // Other metadata rides along unchanged.
     expect(headers['CogSeed-App-Version']).toBe('0.0.5');
     expect(headers['CogSeed-Arch']).toBe(process.arch);
+  });
+
+  it('skips packaged Windows latest checks instead of surfacing updates/latest 400', async () => {
+    electronMock.app.isPackaged = true;
+    const fetchMock = stubFetch(async () => new Response('bad platform', { status: 400 }));
+
+    const result = await withPlatform('win32', () => updater.checkForUpdates(UID, { manual: true, now: 1_000 }));
+
+    expect(result).toMatchObject({
+      checked: true,
+      has_update: false,
+      reminded: false,
+      current_version: '0.0.5',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(readUpdaterState(UID).latest_info).toBeUndefined();
   });
 
   it('throttles automatic reminders to once per day, same version', async () => {
@@ -255,9 +282,11 @@ describe('downloadUpdate', () => {
   it('derives safe filenames and falls back on traversal attempts', () => {
     expect(updater.installerFilenameFromUrl('https://dl.example.com/CogSeed-0.0.6-mac-arm64.dmg'))
       .toBe('CogSeed-0.0.6-mac-arm64.dmg');
+    expect(updater.installerFilenameFromUrl('https://dl.example.com/CogSeed-0.9.0-win-x64.exe'))
+      .toBe('CogSeed-0.9.0-win-x64.exe');
     const evil = updater.installerFilenameFromUrl('https://dl.example.com/CogSeed%2F..%2F..%2Fetc%2Fpasswd');
     expect(evil).not.toContain('..');
     expect(evil).not.toContain('/');
-    expect(evil.endsWith('.dmg') || evil.endsWith('.zip')).toBe(true);
+    expect(evil.endsWith('.dmg') || evil.endsWith('.zip') || evil.endsWith('.exe')).toBe(true);
   });
 });

--- a/test/main/preload.test.ts
+++ b/test/main/preload.test.ts
@@ -506,6 +506,42 @@ describe('preload bridge', () => {
     );
   });
 
+  it('starts the packaged STT smoke when the renderer is already ready', async () => {
+    const preload = loadPreload(null, {
+      argv: ['--cogseed-packaged-stt-smoke'],
+      env: {
+        COGSEED_PACKAGED_STT_SMOKE_FILE: 'C:\\smoke\\result.json',
+        COGSEED_PACKAGED_STT_SMOKE_WAV: 'C:\\smoke\\fake.wav',
+      },
+      navigator: { mediaDevices: { getUserMedia: vi.fn(async () => { throw new Error('no microphone'); }) } },
+      platform: 'win32',
+      resourcesPath: 'C:\\repo\\dist\\win-unpacked\\resources',
+    });
+
+    await vi.waitFor(() => {
+      expect(preload.ipcRenderer.invoke).toHaveBeenCalledWith(
+        'cogseed.packagedSttSmokeReady',
+        expect.objectContaining({ failureCount: 1 }),
+      );
+    });
+  });
+
+  it('starts the packaged launch smoke when the renderer is already ready', async () => {
+    const preload = loadPreload(null, {
+      argv: ['--cogseed-packaged-launch-smoke'],
+    });
+
+    await vi.waitFor(() => {
+      expect(preload.ipcRenderer.invoke).toHaveBeenCalledWith(
+        'cogseed.packagedLaunchSmokeReady',
+        expect.objectContaining({
+          preloadLoaded: true,
+          rendererReadyState: 'complete',
+        }),
+      );
+    });
+  });
+
   it('drives the packaged STT smoke through media capture and the canonical bridge', async () => {
     let processor: { onaudioprocess: null | ((event: unknown) => void) } | null = null;
     const track = { readyState: 'live', stop: vi.fn() };

--- a/test/renderer/connections-navigation.test.ts
+++ b/test/renderer/connections-navigation.test.ts
@@ -27,6 +27,7 @@ class FakeClassList {
 class FakeElement {
   classList: FakeClassList;
   hidden: boolean;
+  listeners = new Map<string, Array<() => void>>();
 
   constructor(
     public dataset: Record<string, string>,
@@ -36,32 +37,71 @@ class FakeElement {
     this.classList = new FakeClassList(classes);
     this.hidden = hidden;
   }
+
+  addEventListener(type: string, handler: () => void) {
+    const list = this.listeners.get(type) || [];
+    list.push(handler);
+    this.listeners.set(type, list);
+  }
+
+  click() {
+    for (const handler of this.listeners.get('click') || []) handler();
+  }
 }
 
 function loadConnectionsModule() {
   const tabs = [
     new FakeElement({ connectionsTab: 'agents' }, ['connections-tab']),
     new FakeElement({ connectionsTab: 'mcp' }, ['connections-tab', 'is-active']),
+    new FakeElement({ connectionsTab: 'touchpoints' }, ['connections-tab']),
+    new FakeElement({ connectionsTab: 'models' }, ['connections-tab']),
   ];
   const panes = [
     new FakeElement({ connectionsPane: 'agents' }, ['connections-tab-pane'], true),
     new FakeElement({ connectionsPane: 'mcp' }, ['connections-tab-pane']),
+    new FakeElement({ connectionsPane: 'touchpoints' }, ['connections-tab-pane'], true),
+    new FakeElement({ connectionsPane: 'models' }, ['connections-tab-pane'], true),
+  ];
+  const cards = [
+    new FakeElement({ connectionsSubentry: 'models' }),
   ];
   const setView = vi.fn();
   const loadAgents = vi.fn();
+  const loadRendererFeature = vi.fn(async () => undefined);
+  const initTouchpointSettings = vi.fn();
   const document = {
+    getElementById() {
+      return null;
+    },
+    querySelector(selector: string) {
+      if (selector === '.connections-tab.is-active') {
+        return tabs.find((tab) => tab.classList.contains('is-active')) || null;
+      }
+      return null;
+    },
     querySelectorAll(selector: string) {
       if (selector === '.connections-tab') return tabs;
       if (selector === '.connections-tab-pane') return panes;
+      if (selector === '[data-connections-subentry]') return cards;
       return [];
     },
   };
-  const context: any = { document, loadAgents, Promise, setView, window: {} };
+  const context: any = {
+    document,
+    initTouchpointSettings,
+    loadAgents,
+    loadRendererFeature,
+    Promise,
+    setView,
+    window: { addEventListener: vi.fn() },
+  };
   context.window.window = context.window;
+  context.window.loadRendererFeature = loadRendererFeature;
+  context.window.initTouchpointSettings = initTouchpointSettings;
   vm.createContext(context);
   const source = fs.readFileSync(path.join(root, 'src/renderer/modules/connections.js'), 'utf8');
   vm.runInContext(source, context, { filename: 'connections.js' });
-  return { loadAgents, panes, setView, tabs, window: context.window };
+  return { cards, initTouchpointSettings, loadAgents, loadRendererFeature, panes, setView, tabs, window: context.window };
 }
 
 describe('connections navigation', () => {
@@ -83,5 +123,29 @@ describe('connections navigation', () => {
     window.activateConnectionsTab('agents');
 
     expect(loadAgents).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps the Touchpoints tab inside Connections and loads its settings bundle', async () => {
+    const { initTouchpointSettings, loadRendererFeature, panes, setView, tabs, window } = loadConnectionsModule();
+
+    window.activateConnectionsTab('touchpoints');
+    await Promise.resolve();
+
+    expect(setView).not.toHaveBeenCalled();
+    expect(tabs[2].classList.contains('is-active')).toBe(true);
+    expect(panes[2].hidden).toBe(false);
+    expect(loadRendererFeature).toHaveBeenCalledWith('settings');
+    expect(initTouchpointSettings).toHaveBeenCalled();
+  });
+
+  it('opens Models & Quota inside Connections instead of bouncing to Settings configuration', () => {
+    const { cards, panes, setView, tabs, window } = loadConnectionsModule();
+
+    window.initConnections();
+    cards[0].click();
+
+    expect(setView).not.toHaveBeenCalled();
+    expect(tabs[3].classList.contains('is-active')).toBe(true);
+    expect(panes[3].hidden).toBe(false);
   });
 });

--- a/test/renderer/run-center.test.ts
+++ b/test/renderer/run-center.test.ts
@@ -123,6 +123,8 @@ describe('Run Center renderer contract', () => {
     expect(source).toContain("document.addEventListener('keydown'");
     expect(source).toContain('data-run-center-settings-anchor="worktrees"');
     expect(source).toContain('data-run-center-settings-anchor="diagnostics"');
+    expect(source).not.toContain("settingsAnchor: 'models'");
+    expect(source).not.toContain("settingsAnchor: 'agents'");
     expect(source).toContain('data-run-center-source-filter');
     expect(source).toContain('req-run-center-');
     expect(source).not.toContain('cogseed_agent.task.');
@@ -1032,7 +1034,7 @@ describe('Run Center renderer contract', () => {
           },
         },
         addEventListener: vi.fn(), setTimeout, clearTimeout, confirm: vi.fn(() => true),
-        setView: vi.fn(), activateSettingsTab: vi.fn(), uiToast: vi.fn(),
+        setView: vi.fn(), activateSettingsTab: vi.fn(), activateConnectionsTab: vi.fn(), uiToast: vi.fn(),
         uiIconHtml: (name: string) => `<i>${name}</i>`,
       },
       document: Object.assign(documentState, { getElementById: () => panel, addEventListener: (type: string, listener: (event: any) => void) => documentListeners.set(type, listener) }),
@@ -1129,9 +1131,9 @@ describe('Run Center renderer contract', () => {
     expect(context.window.setView).toHaveBeenCalledTimes(viewCallsBeforeUnavailableAgentTask);
     expect(context.window.uiToast).toHaveBeenLastCalledWith('run_center.task_unavailable', { variant: 'warning' });
     click({ runCenterAgentSettings: '' });
-    expect(context.window.setView).toHaveBeenLastCalledWith('settings', undefined, {
-      settingsTab: 'configuration', settingsAnchor: 'agents',
-    });
+    expect(context.window.setView).toHaveBeenLastCalledWith('connections');
+    expect(context.window.activateSettingsTab).not.toHaveBeenCalledWith('configuration', { anchor: 'agents' });
+    expect(context.window.activateConnectionsTab).toHaveBeenLastCalledWith('agents');
 
     expect(html).toContain('data-run-center-tools-toggle');
     expect(html).toContain('aria-haspopup="menu" aria-controls="run-center-tools-menu" aria-expanded="false"');
@@ -1479,10 +1481,9 @@ describe('Run Center renderer contract', () => {
     expect(failedSummary).toContain('class="btn ui-button ui-button--primary ui-button--sm');
     expect(failedSummary).not.toContain('data-run-center-action="retry"');
     click({ runCenterConfigureModel: '' });
-    expect(context.window.setView).toHaveBeenLastCalledWith('settings', undefined, {
-      settingsTab: 'configuration', settingsAnchor: 'models',
-    });
-    expect(context.window.activateSettingsTab).toHaveBeenLastCalledWith('configuration', { anchor: 'models' });
+    expect(context.window.setView).toHaveBeenLastCalledWith('connections');
+    expect(context.window.activateSettingsTab).not.toHaveBeenCalledWith('configuration', { anchor: 'models' });
+    expect(context.window.activateConnectionsTab).toHaveBeenLastCalledWith('models');
 
     task.errorCode = 'model_preflight';
     click({ runCenterRefresh: '' });


### PR DESCRIPTION
## Summary
- Close the Windows updater gap by skipping unsupported packaged Windows/Linux `/updates/latest` v1 checks while keeping Squirrel auto-update disabled off macOS.
- Keep Connections and Run Center model/agent/touchpoint routes inside the Connections surface instead of bouncing through Settings > Configuration.
- Start packaged STT and launch smoke checks even when preload runs after the renderer is already `interactive`/`complete`.

## Test Plan
- [x] RED: `npx vitest run test/main/preload.test.ts` failed for already-ready packaged STT/launch smoke before the preload ready-state fix.
- [x] `npx vitest run test/main/preload.test.ts`
- [x] `npx vitest run test/main/features/updater/client.test.ts test/main/features/updater/auto.test.ts test/renderer/connections-navigation.test.ts test/renderer/settings-tabs.test.ts test/renderer/run-center-settings.test.ts test/renderer/run-center.test.ts`
- [x] `npx vitest run test/main/preload.test.ts test/main/features/updater/client.test.ts test/main/features/updater/auto.test.ts test/renderer/connections-navigation.test.ts test/renderer/settings-tabs.test.ts test/renderer/run-center-settings.test.ts test/renderer/run-center.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`

## Notes
- Base: `origin/develop` at `d0d50ff4276e938bba88b97357a4826b4ec21f40`.
- This PR intentionally does not change version metadata or create release artifacts.