### PR TITLE
test: stabilize Windows CI assertions

### DIFF
--- a/p3394-gateway/test/smoke.cjs
+++ b/p3394-gateway/test/smoke.cjs
@@ -790,12 +790,21 @@ async function main() {
     await new Promise((resolve) => ocPersistGw.once('close', resolve));
   }
   if (process.platform === 'win32') {
+    // The abort-unavailable fallback restarts the managed server, so the PID
+    // files now hold both generations: 2 servers + 2 descendants. Windows can
+    // also take a moment to reap a taskkill tree after the gateway closes, so
+    // allow a bounded settle window before treating a surviving PID as a leak.
     const ocTreePids = [ocPidFile, ocDescendantPidFile]
       .flatMap((file) => fs.readFileSync(file, 'utf8').split('\n').filter(Boolean).map(Number));
-    const survivors = ocTreePids.filter((pid) => {
-      try { process.kill(pid, 0); return true; } catch { return false; }
-    });
-    check('opencode 常驻：gateway close 前 server 进程树已全部退出', ocTreePids.length === 2 && survivors.length === 0);
+    const alive = new Set(ocTreePids);
+    const settleDeadline = Date.now() + 5_000;
+    while (alive.size > 0 && Date.now() < settleDeadline) {
+      for (const pid of alive) {
+        try { process.kill(pid, 0); } catch { alive.delete(pid); }
+      }
+      if (alive.size > 0) await sleep(100);
+    }
+    check('opencode 常驻：gateway close 后 server 进程树在宽限期内全部退出', ocTreePids.length === 4 && alive.size === 0);
   }
 
   // shutdown deadline 必须在 runtime.close() 之前生效；第二次 shutdown


### PR DESCRIPTION
## Windows gate failures

The cicd `verify-windows` gate surfaced two flaky/failing test paths on the promotion run:

1. `p3394-gateway/test/smoke.cjs` — the abort-unavailable fallback restarts the managed OpenCode server, so the PID files hold two server generations plus two descendants. The Windows-only assertion still expected `ocTreePids.length === 2`.
2. `test/main/features/cogseed_backend/runtime-controller.test.ts` — `eventually()` only retried 50 x 5 ms (~250 ms), below Windows CI scheduler latency for background runtime delivery.

## Fix

- Expect all four recorded PIDs after the restart fallback and allow a bounded 5 s taskkill settle window.
- Keep the fast path in `eventually()` but allow a bounded 5 s deadline.

## Verification

- `node --check p3394-gateway/test/smoke.cjs` + `node p3394-gateway/test/smoke.cjs` → `ALL PASS` (macOS)
- `runtime-controller.test.ts` + `kstar-v4-chain.test.ts` → 66 passed (macOS)
- Windows-only paths are exercised by the cicd `verify-windows` gate.