### PR TITLE
test: widen Windows shell and CI test budgets

### DIFF
--- a/test/main/model/local-tools.test.ts
+++ b/test/main/model/local-tools.test.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 
 const TEST_NODE = process.env.COGSEED_TEST_NODE || process.execPath;
 const SHELL_SUCCESS_TIMEOUT_MS = process.platform === 'win32' && process.env.CI
-  ? 60_000
+  ? 100_000
   : process.platform === 'win32'
     ? 15_000
     : 5_000;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,8 +33,8 @@ export default defineConfig({
     // CI 全套件并发负载下 30s 会偶发误伤（本地通过、CI 超时）；给足余量。
     // Windows runner 上真实 shell/进程用例在满载时会超过 60s，CI 统一放宽
     // 到 120s；本地保持 60s，避免掩盖真正的挂死。
-    testTimeout: process.env.CI ? 120_000 : 60_000,
-    hookTimeout: process.env.CI ? 120_000 : 60_000,
+    testTimeout: process.env.CI ? 150_000 : 60_000,
+    hookTimeout: process.env.CI ? 150_000 : 60_000,
     // CI 单机满载时 worker 会持续刷 console 日志（electron-log、agent-runner
     // 等），Vitest 在 worker 收尾关闭 rpc 时会撞上 "Closing rpc while
     // onUserConsoleLog was pending" 的未处理错误，让全绿套件退出码变 1。


### PR DESCRIPTION
## Root cause

The cicd `verify-windows` run failed only at:

```
local-tools › bash permission gate > delegates to core-agent bash after legacy revoke maps to workspace_approval
AssertionError: expected true to be falsy   (res.isError)
```

`SHELL_SUCCESS_TIMEOUT_MS` was 60s on Windows CI. On the loaded runner the real shell delegation exceeded that, so the tool returned an error before the test could assert success. (Earlier it failed as a Vitest 60s timeout instead.)

## Fix

- Windows CI shell tool budget: 60s → 100s
- CI Vitest `testTimeout` / `hookTimeout`: 120s → 150s so the tool budget remains inside the test budget

## Verification

- `npm run typecheck` / `npm run lint` passed
- `test/main/model/local-tools.test.ts`: 64 passed (macOS)