### PR TITLE
ci: retry flaky hosted-runner tests twice

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,11 @@ export default defineConfig({
     // 到 120s；本地保持 60s，避免掩盖真正的挂死。
     testTimeout: process.env.CI ? 150_000 : 60_000,
     hookTimeout: process.env.CI ? 150_000 : 60_000,
+    // Windows hosted runners intermittently hang one timing-sensitive test
+    // (different file each run) while the same test passes immediately on a
+    // retry. Allow two CI retries so a one-off runner stall does not fail the
+    // release gate; deterministic failures still fail after both retries.
+    retry: process.env.CI ? 2 : 0,
     // CI 单机满载时 worker 会持续刷 console 日志（electron-log、agent-runner
     // 等），Vitest 在 worker 收尾关闭 rpc 时会撞上 "Closing rpc while
     // onUserConsoleLog was pending" 的未处理错误，让全绿套件退出码变 1。


### PR DESCRIPTION
## Problem

The Windows `verify` runs keep failing on a different timing-sensitive test each attempt (most recently `messaging.test.ts › dispatches synthetic envelopes immediately, bypassing the merger`, `Test timed out in 150000ms`). Each of those tests passes on a subsequent run.

## Fix

Set Vitest `retry: 2` on CI (0 locally). Deterministic failures still fail after both retries; one-off hosted-runner stalls no longer fail the release gate.

## Verification

- `npm run typecheck` / `npm run lint` passed
- `test/scripts/verify-packaged-stt-win.test.ts`: 10 passed