### PR TITLE
ci: shard the Windows verify gate and allowlist the job graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           fi
           echo "✅ All commit author emails are noreply."
 
-  verify-windows:
+  verify-windows-native:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -68,11 +68,43 @@ jobs:
       - run: npm run lint
       - name: P3394 Windows compatibility gate
         run: npm run test:p3394:windows
-      - run: node scripts/run-tests.mjs run --maxWorkers=1
       - run: npm run test:resources
       - run: npm run test:platform-native
       - name: P3394 gateway protocol smoke
         run: node p3394-gateway/test/smoke.cjs
+
+  # Full JS suite split into four serial shards on separate runners. Each shard
+  # keeps --maxWorkers=1 (Windows process/timing stability) while the shards
+  # themselves run in parallel.
+  verify-windows-shard:
+    name: verify-windows-shard-${{ matrix.shard }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci --prefer-offline
+      - run: node scripts/run-tests.mjs run --maxWorkers=1 --shard=${{ matrix.shard }}/4
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
       - run: npm run build:win
       # Known Windows packaged-STT gap: the smoke does not produce its marker
       # on the hosted runner yet. Keep it visible with the app's captured
@@ -88,3 +120,21 @@ jobs:
           path: dist/CogSeed-*-win-x64.exe
           if-no-files-found: error
           retention-days: 14
+
+  # Aggregate keeps the release-gate job name stable while failing closed if
+  # any Windows lane fails. `if: always()` is required so a failed dependency
+  # produces an explicit failure instead of a skipped job.
+  verify-windows:
+    needs: [verify-windows-native, verify-windows-shard, build-windows]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every Windows lane
+        run: |
+          set -euo pipefail
+          echo "native=${{ needs.verify-windows-native.result }}"
+          echo "shards=${{ needs.verify-windows-shard.result }}"
+          echo "build=${{ needs.build-windows.result }}"
+          test "${{ needs.verify-windows-native.result }}" = "success"
+          test "${{ needs.verify-windows-shard.result }}" = "success"
+          test "${{ needs.build-windows.result }}" = "success"

--- a/scripts/verify-release-gates.mjs
+++ b/scripts/verify-release-gates.mjs
@@ -4,8 +4,27 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const WORKFLOW_JOBS = Object.freeze({
-  'ci.yml': Object.freeze(['verify', 'verify-windows']),
-  'compliance.yml': Object.freeze(['compliance']),
+  'ci.yml': Object.freeze({
+    required: Object.freeze(['verify', 'verify-windows']),
+    // The Windows lane fans out into four serial shards, one native/browser
+    // lane, and a parallel build lane; `verify-windows` is the aggregate that
+    // fails closed if any of them fails. Allow exactly this job graph and
+    // nothing else.
+    allowed: Object.freeze([
+      'verify',
+      'verify-windows',
+      'verify-windows-shard-1',
+      'verify-windows-shard-2',
+      'verify-windows-shard-3',
+      'verify-windows-shard-4',
+      'verify-windows-native',
+      'build-windows',
+    ]),
+  }),
+  'compliance.yml': Object.freeze({
+    required: Object.freeze(['compliance']),
+    allowed: Object.freeze(['compliance']),
+  }),
 });
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const MAX_PAGES = 100;
@@ -137,7 +156,7 @@ function verifyRunSuccess(run, workflowName) {
   }
 }
 
-function verifyJobs(jobs, requiredNames, workflowName, attempt) {
+function verifyJobs(jobs, requiredNames, allowedNames, workflowName, attempt) {
   const counts = new Map();
   for (const job of jobs) {
     const row = objectFrom(job, `${workflowName} job`);
@@ -151,9 +170,11 @@ function verifyJobs(jobs, requiredNames, workflowName, attempt) {
   for (const name of requiredNames) {
     const count = counts.get(name) ?? 0;
     if (count === 0) throw new Error(`Missing required ${workflowName} job: ${name}`);
-    if (count > 1) throw new Error(`Duplicate required ${workflowName} job: ${name}`);
   }
-  const extras = [...counts.keys()].filter((name) => !requiredNames.includes(name));
+  for (const [name, count] of counts) {
+    if (count > 1) throw new Error(`Duplicate ${workflowName} job: ${name}`);
+  }
+  const extras = [...counts.keys()].filter((name) => !allowedNames.includes(name));
   if (extras.length > 0) throw new Error(`Unexpected ${workflowName} jobs: ${extras.join(', ')}`);
   for (const job of jobs) {
     if (job.status !== 'completed' || job.conclusion !== 'success') {
@@ -181,7 +202,7 @@ export async function verifyReleaseGates({ env = process.env, fetchImpl = global
   }
 
   const workflows = {};
-  for (const [workflowName, requiredJobs] of Object.entries(WORKFLOW_JOBS)) {
+  for (const [workflowName, jobSpec] of Object.entries(WORKFLOW_JOBS)) {
     const runs = await api.getAll(`/actions/workflows/${workflowName}/runs`, 'workflow_runs', {
       branch: 'cicd',
       event: 'push',
@@ -190,7 +211,7 @@ export async function verifyReleaseGates({ env = process.env, fetchImpl = global
     const run = latestRun(runs, workflowName, peeledSha);
     verifyRunSuccess(run, workflowName);
     const jobs = await api.getAll(`/actions/runs/${run.id}/attempts/${run.run_attempt}/jobs`, 'jobs');
-    verifyJobs(jobs, requiredJobs, workflowName, run.run_attempt);
+    verifyJobs(jobs, jobSpec.required, jobSpec.allowed, workflowName, run.run_attempt);
     workflows[workflowName] = { runId: run.id, attempt: run.run_attempt };
   }
   return { peeledSha, workflows };

--- a/test/scripts/release-workflow-contract.test.ts
+++ b/test/scripts/release-workflow-contract.test.ts
@@ -34,24 +34,43 @@ describe('release workflow contract', () => {
     });
   });
 
-  it('keeps the CI job names exact and makes the Windows gate complete', () => {
+  it('keeps the CI job names exact and fans the Windows gate out into shards', () => {
     const workflow = load('ci.yml');
-    expect(Object.keys(workflow.jobs).sort()).toEqual(['verify', 'verify-windows']);
-    const windowsJob = workflow.jobs['verify-windows'];
-    const windows = commands(windowsJob);
+    expect(Object.keys(workflow.jobs).sort()).toEqual([
+      'build-windows',
+      'verify',
+      'verify-windows',
+      'verify-windows-native',
+      'verify-windows-shard',
+    ]);
+
+    const native = workflow.jobs['verify-windows-native'];
     for (const expected of [
+      'npm run typecheck',
       'npm run lint',
-      'node scripts/run-tests.mjs run --maxWorkers=1',
+      'npm run test:p3394:windows',
       'npm run test:resources',
       'npm run test:platform-native',
-      'npm run test:p3394:windows',
       'node p3394-gateway/test/smoke.cjs',
-      'npm run build:win',
-    ]) expect(windows).toContain(expected);
-    const p3394Index = steps(windowsJob).findIndex((step) => step.run === 'npm run test:p3394:windows');
-    const fullJsIndex = steps(windowsJob).findIndex((step) => step.run === 'node scripts/run-tests.mjs run --maxWorkers=1');
-    expect(p3394Index).toBeGreaterThanOrEqual(0);
-    expect(p3394Index).toBeLessThan(fullJsIndex);
+    ]) expect(commands(native)).toContain(expected);
+
+    const shard = workflow.jobs['verify-windows-shard'];
+    expect(shard.name).toBe('verify-windows-shard-${{ matrix.shard }}');
+    expect(shard.strategy).toMatchObject({ 'fail-fast': false, matrix: { shard: [1, 2, 3, 4] } });
+    expect(commands(shard)).toContain('node scripts/run-tests.mjs run --maxWorkers=1 --shard=${{ matrix.shard }}/4');
+
+    const build = workflow.jobs['build-windows'];
+    expect(commands(build)).toContain('npm run build:win');
+    const upload = steps(build).find((step) => step.uses === 'actions/upload-artifact@v4');
+    expect(upload?.with?.path).toContain('dist/CogSeed-*-win-x64.exe');
+
+    const aggregate = workflow.jobs['verify-windows'];
+    expect(aggregate.needs).toEqual(['verify-windows-native', 'verify-windows-shard', 'build-windows']);
+    expect(aggregate.if).toBe('always()');
+    const aggregateRun = commands(aggregate);
+    for (const need of ['verify-windows-native', 'verify-windows-shard', 'build-windows']) {
+      expect(aggregateRun).toContain(`needs.${need}.result`);
+    }
   });
 
   it('pins the Windows P3394 lane to the platform-native regression suites', () => {

--- a/test/scripts/verify-packaged-stt-win.test.ts
+++ b/test/scripts/verify-packaged-stt-win.test.ts
@@ -26,7 +26,7 @@ describe('Windows packaged STT smoke', () => {
   it('runs the packaged fake-microphone verifier immediately after the Windows build', () => {
     const scriptPath = path.resolve('scripts/verify-packaged-stt-win.cjs');
     const workflow = parse(fs.readFileSync(path.resolve('.github/workflows/ci.yml'), 'utf8'), { version: '1.2' });
-    const steps = workflow.jobs['verify-windows'].steps as Array<{ run?: string }>;
+    const steps = workflow.jobs['build-windows'].steps as Array<{ run?: string }>;
     const buildIndex = steps.findIndex((step) => step.run === 'npm run build:win');
     const smokeIndex = steps.findIndex((step) => step.run === 'npm run verify:package:stt:win');
 

--- a/test/scripts/verify-release-gates.test.ts
+++ b/test/scripts/verify-release-gates.test.ts
@@ -222,6 +222,30 @@ describe('release gate verification', () => {
     ] } })).rejects.toThrow(/duplicate.*compliance/i);
   });
 
+  it('accepts the sharded Windows job graph and rejects unknown extra jobs', async () => {
+    const shardedCiJobs = [
+      { name: 'verify', status: 'completed', conclusion: 'success', run_attempt: 1 },
+      { name: 'verify-windows', status: 'completed', conclusion: 'success', run_attempt: 1 },
+      { name: 'verify-windows-native', status: 'completed', conclusion: 'success', run_attempt: 1 },
+      { name: 'build-windows', status: 'completed', conclusion: 'success', run_attempt: 1 },
+      ...[1, 2, 3, 4].map((shard) => ({
+        name: `verify-windows-shard-${shard}`,
+        status: 'completed',
+        conclusion: 'success',
+        run_attempt: 1,
+      })),
+    ];
+    await expect(run({ jobs: { '20/attempts/1': shardedCiJobs } })).resolves.toMatchObject({ peeledSha: SHA });
+    await expect(run({
+      jobs: {
+        '20/attempts/1': [
+          ...shardedCiJobs,
+          { name: 'verify-windows-extra', status: 'completed', conclusion: 'success', run_attempt: 1 },
+        ],
+      },
+    })).rejects.toThrow(/Unexpected ci\.yml jobs: verify-windows-extra/i);
+  });
+
   it('rejects missing or non-positive run_attempt values', async () => {
     await expect(run({ jobs: { '21/attempts/1': [
       { name: 'compliance', status: 'completed', conclusion: 'success' },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
     // 到 120s；本地保持 60s，避免掩盖真正的挂死。
     testTimeout: process.env.CI ? 150_000 : 60_000,
     hookTimeout: process.env.CI ? 150_000 : 60_000,
+    // Hosted runners intermittently stall one timing-sensitive test; allow two
+    // CI retries so a one-off stall does not fail the release gate.
+    retry: process.env.CI ? 2 : 0,
     // CI 单机满载时 worker 会持续刷 console 日志（electron-log、agent-runner
     // 等），Vitest 在 worker 收尾关闭 rpc 时会撞上 "Closing rpc while
     // onUserConsoleLog was pending" 的未处理错误，让全绿套件退出码变 1。


### PR DESCRIPTION
## Why

`verify-windows` takes 39-46 min because the full JS suite runs serially on one runner. This implements the Windows CI acceleration design and keeps the release-gate contract intact.

## Job graph

- `verify-windows-native` — typecheck, lint, P3394 Windows gate, resources, platform-native, gateway smoke
- `verify-windows-shard-1..4` — matrix, `--maxWorkers=1 --shard=N/4`, fail-fast off
- `build-windows` — `npm run build:win` + informational packaged STT smoke + artifact upload
- `verify-windows` — `if: always()` aggregate that fails closed on any lane

## Gate contract

`scripts/verify-release-gates.mjs` now carries required + allowlist job names (exact match, no prefix matching) and rejects duplicates and unknown jobs. `test/scripts/verify-release-gates.test.ts` covers the sharded graph and the unknown-job rejection; `release-workflow-contract.test.ts` covers the new job wiring.

## Verification

- `npm run typecheck` / `npm run lint` passed
- gate + contract suites: 31 passed
- real shard smoke: `run-tests.mjs run --maxWorkers=1 --shard=1/4` → 242 files / 2759 tests passed in ~2.5 min (macOS, 1 worker)

## Notes

- Also carries the CI retry policy (Vitest retry 2 on CI), superseding #236/#237.
- GitHub-hosted Windows minutes are free for this public repo; four shards cost wall-clock only.