### PR TITLE
fix：过程时间线两处修复、上下文窗口与统计口径、过程 UI 与界面整理

### DIFF
--- a/p3394-gateway/gateway.cjs
+++ b/p3394-gateway/gateway.cjs
@@ -1497,6 +1497,26 @@ class CodexAppServerRuntime {
     await this.start();
     let threadId = this.threads.get(sessionId);
     if (!threadId) {
+      // G-27 持久化补齐（2026-09-11）：thread 映射此前只在内存——网关重启后
+      // 同一 P3394 会话静默 thread/start 换新原生会话，用户侧表现为"切走再
+      // 切回，智能体新建会话并重发内容"（实测同会话双 rollout）。对齐 sscli
+      // 路径的 cli-session.json：重启后先读盘 thread/resume 恢复原 thread；
+      // resume 被拒（rollout 已删/被孤儿 app-server 占用 writer）才清绑定按
+      // 全新会话处理，下一轮写回新 id。
+      const persisted = readCliSession(sessionId);
+      if (persisted && persisted.sessionId) {
+        try {
+          await this._request('thread/resume', { threadId: persisted.sessionId });
+          threadId = persisted.sessionId;
+          this.threads.set(sessionId, threadId);
+        } catch (resumeError) {
+          console.warn('[p3394-gateway] codex thread/resume rejected, starting fresh: '
+            + (resumeError && resumeError.message ? resumeError.message : String(resumeError)));
+          clearCliSession(sessionId);
+        }
+      }
+    }
+    if (!threadId) {
       // CogSeed 扩展（统一执行入口）：单轮模型 → thread/start 的 model 参数
       // （与 CogSeed 直连 backend 同一传法）；单轮强度 → config 的
       // model_reasoning_effort（CogSeed 统一档位 low/high 与 codex 值集 1:1）。
@@ -1529,6 +1549,7 @@ class CodexAppServerRuntime {
       threadId = result && result.thread && result.thread.id;
       if (!threadId) throw new Error('p3394_codex_thread_start_failed');
       this.threads.set(sessionId, threadId);
+      writeCliSession(sessionId, threadId);
     }
     // 可取消键与其余 runtime 一致：task_id 优先（cancel 控制帧按 task_id
     // 匹配），无 task_id 回退 message_id。

--- a/p3394-gateway/test/codex-thread-persistence.cjs
+++ b/p3394-gateway/test/codex-thread-persistence.cjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * CodexAppServerRuntime 会话持久化回归测试（2026-09-11 修复）：
+ * 网关重启（threads 内存清空）后，同一 P3394 会话必须 thread/resume 续接
+ * 原 thread，而不是 thread/start 换新原生会话。
+ *
+ * 三个断言：
+ *  1. 首次 deliver（无盘绑定）→ thread/start，成功后 cli-session.json 落盘；
+ *  2. 新实例（模拟网关重启）→ thread/resume 用盘上 id，不再 thread/start；
+ *  3. resume 被拒（rollout 已删等）→ 清盘回退 thread/start，并写回新 id。
+ *
+ * 运行：node test/codex-thread-persistence.cjs
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const vm = require('vm');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'gateway.cjs'), 'utf8');
+
+// 从 gateway.cjs 提取依赖函数与类源码（与 smoke.cjs 的 vm 提取法同风格）。
+function extract(name, kind = 'function') {
+  const marker = kind === 'class' ? `class ${name} ` : `function ${name}(`;
+  const start = src.indexOf(marker);
+  if (start < 0) throw new Error('extract failed: ' + name);
+  let depth = 0, i = src.indexOf('{', start);
+  for (let j = i; j < src.length; j++) {
+    if (src[j] === '{') depth++;
+    else if (src[j] === '}') { depth--; if (depth === 0) { return src.slice(start, j + 1); } }
+  }
+  throw new Error('unbalanced: ' + name);
+}
+
+const GATEWAY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'p3394-codex-persist-'));
+const sandbox = {
+  fs, path,
+  console: { warn() {}, error() {}, log() {} },
+  process: { env: { P3394_GATEWAY_HOME: GATEWAY_HOME } },
+  setTimeout: () => 0, clearTimeout() {},
+};
+// readCliSession/writeCliSession/clearCliSession/sessionDir 引用模块级
+// GATEWAY_HOME 常量——把提取的函数与该常量一起求值进同一沙箱。
+vm.runInNewContext(
+  `const GATEWAY_HOME = ${JSON.stringify(GATEWAY_HOME)};`
+  + `const AGENT_ID = 'codex';`
+  + extract('sessionDir')
+  + extract('cliSessionFile')
+  + extract('readCliSession')
+  + extract('writeCliSession')
+  + extract('clearCliSession')
+  + extract('CodexAppServerRuntime', 'class')
+  + `
+    globalThis.__factory = {
+      sessionDir, readCliSession, writeCliSession, clearCliSession,
+      makeRuntime: () => {
+        const r = new CodexAppServerRuntime();
+        r.start = async () => {}; // 不 spawn 真进程
+        return r;
+      },
+    };
+  `,
+  sandbox,
+);
+const { makeRuntime, sessionDir, readCliSession } = sandbox.__factory;
+
+// _request stub：记录调用序列，按 script 返回结果。
+function stubRequests(runtime, script) {
+  const calls = [];
+  runtime._request = async (method, params) => {
+    calls.push({ method, params });
+    const step = script.find((s) => s.method === method && !s.used) || script.find((s) => s.method === method);
+    if (!step) throw new Error('unexpected method: ' + method);
+    if (step.reject) throw new Error(step.reject);
+    return typeof step.result === 'function' ? step.result(params) : step.result;
+  };
+  return calls;
+}
+// deliver 的 promise 由 pending 的 turn 完成结算——stub 手动 resolve。
+function settleTurn(runtime) {
+  for (const [, entry] of runtime.pending) entry.resolve({});
+}
+
+(async () => {
+  const SESSION = 'ses-regression-1';
+  let failed = 0;
+  const check = (name, cond, detail) => {
+    console.log((cond ? '  ✓ ' : '  ✗ ') + name + (cond ? '' : '  ← ' + String(detail)));
+    if (!cond) failed++;
+  };
+
+  // ── 1. 首次 deliver：thread/start + 落盘 ──
+  {
+    const rt = makeRuntime();
+    const calls = stubRequests(rt, [
+      { method: 'thread/start', result: { thread: { id: 'thread-AAA' } } },
+      { method: 'turn/start', result: {} },
+    ]);
+    const p = rt.deliver(SESSION, 'msg-1', 'hello', {}, () => {}, () => {});
+    settleTurn(rt); await p.catch(() => {});
+    check('首次 deliver 走 thread/start', calls.some((c) => c.method === 'thread/start'));
+    const saved = readCliSession(SESSION);
+    check('threadId 落盘 cli-session.json', !!saved && saved.sessionId === 'thread-AAA', JSON.stringify(saved));
+  }
+
+  // ── 2. 网关重启（新实例）：thread/resume 续接，不再 start ──
+  {
+    const rt = makeRuntime(); // 内存 threads 为空 = 重启后
+    const calls = stubRequests(rt, [
+      { method: 'thread/resume', result: { thread: { id: 'thread-AAA' } } },
+      { method: 'turn/start', result: {} },
+    ]);
+    const p = rt.deliver(SESSION, 'msg-2', 'again', {}, () => {}, () => {});
+    settleTurn(rt); await p.catch(() => {});
+    const resume = calls.find((c) => c.method === 'thread/resume');
+    check('重启后走 thread/resume', !!resume);
+    check('resume 用盘上的原 threadId', resume && resume.params.threadId === 'thread-AAA', JSON.stringify(resume && resume.params));
+    check('未再 thread/start', !calls.some((c) => c.method === 'thread/start'));
+    check('turn 用续接的 threadId', calls.find((c) => c.method === 'turn/start' && c.params.threadId === 'thread-AAA') != null);
+  }
+
+  // ── 3. resume 被拒：清盘回退 start，写回新 id ──
+  {
+    const rt = makeRuntime();
+    const calls = stubRequests(rt, [
+      { method: 'thread/resume', reject: 'no rollout found for thread id thread-AAA' },
+      { method: 'thread/start', result: { thread: { id: 'thread-BBB' } } },
+      { method: 'turn/start', result: {} },
+    ]);
+    const p = rt.deliver(SESSION, 'msg-3', 'third', {}, () => {}, () => {});
+    settleTurn(rt); await p.catch(() => {});
+    check('resume 被拒后回退 thread/start', calls.some((c) => c.method === 'thread/start'));
+    const saved = readCliSession(SESSION);
+    check('盘上更新为新 threadId', !!saved && saved.sessionId === 'thread-BBB', JSON.stringify(saved));
+  }
+
+  console.log(failed ? `\nFAIL: ${failed} 项断言未过` : '\nPASS: codex thread 持久化回归全过');
+  fs.rmSync(GATEWAY_HOME, { recursive: true, force: true });
+  process.exit(failed ? 1 : 0);
+})();

--- a/src/core-agent/src/agent/runner.ts
+++ b/src/core-agent/src/agent/runner.ts
@@ -866,6 +866,10 @@ export class AgentRunner {
     let toolLoops = 0;
     let compactionCount = 0;
     let lastUsage: import("../shared/types.js").Usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, totalTokens: 0 };
+    // 最后一次模型调用的 usage（覆盖式，非累加）——"当前上下文占用"的唯一
+    // 正确口径。lastUsage 是整轮累加（每步重发的历史被求和一次），只适合
+    // 消耗/计费口径；窗口占用必须读这个（2026-09-11 统计口径修复）。
+    let lastCallUsage: import("../shared/types.js").Usage | undefined;
     const toolNamesSet = new Set<string>();
     const skillsLoadedSet = new Set<string>();
     let transientToolErrors = 0;
@@ -1081,6 +1085,7 @@ export class AgentRunner {
         // under-reported cache activity (cost/hit-rate blind spot). mergeUsage
         // sums input/output/cacheRead/cacheWrite/total consistently.
         lastUsage = mergeUsage(lastUsage, result.usage);
+        lastCallUsage = result.usage;
 
         if (result.stopReason === "max_tokens") {
           const maxOutputTokens = this.config.models.catalog[streamModel]?.maxOutputTokens
@@ -1148,6 +1153,7 @@ export class AgentRunner {
               provider: provider.id,
               stopReason: result.stopReason,
               usage: lastUsage,
+              ...(lastCallUsage ? { lastCallUsage } : {}),
               toolLoops,
               compactionCount,
               timings: finalizedRunTimings(startTime, timings),
@@ -1222,6 +1228,7 @@ export class AgentRunner {
               provider: provider.id,
               stopReason: summary.stopReason,
               usage: lastUsage,
+              ...(lastCallUsage ? { lastCallUsage } : {}),
               toolLoops,
               compactionCount,
               timings: finalizedRunTimings(startTime, timings),
@@ -1302,6 +1309,7 @@ export class AgentRunner {
               provider: provider.id,
               stopReason: result.stopReason,
               usage: lastUsage,
+              ...(lastCallUsage ? { lastCallUsage } : {}),
               toolLoops,
               compactionCount,
               timings: finalizedRunTimings(startTime, timings),
@@ -1620,6 +1628,7 @@ export class AgentRunner {
               provider: provider.id,
               stopReason: "end_turn",
               usage: lastUsage,
+              ...(lastCallUsage ? { lastCallUsage } : {}),
               toolLoops,
               compactionCount,
               timings: finalizedRunTimings(startTime, timings),
@@ -1790,7 +1799,7 @@ export class AgentRunner {
             kind: "timeout",
             message: "Run aborted",
             code: "ABORT_ERR",
-          }, lastUsage, toolLoops, compactionCount, true, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
+          }, lastUsage, lastCallUsage, toolLoops, compactionCount, true, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
           yield { type: "done", result: e };
           return;
         }
@@ -1800,7 +1809,7 @@ export class AgentRunner {
             kind: "auth",
             message: err.message,
             code: errorCodeForMeta(err) || "AUTH_ERROR",
-          }, lastUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
+          }, lastUsage, lastCallUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
           yield { type: "done", result: e };
           return;
         }
@@ -1824,7 +1833,7 @@ export class AgentRunner {
               kind: "context_overflow",
               message: err.message,
               code: errorCodeForMeta(err) || "CONTEXT_OVERFLOW",
-            }, lastUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
+            }, lastUsage, lastCallUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
             yield { type: "done", result: e };
             return;
           }
@@ -1895,7 +1904,7 @@ export class AgentRunner {
               kind: "context_overflow",
               message: err.message,
               code: errorCodeForMeta(err) || "CONTEXT_OVERFLOW",
-            }, lastUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
+            }, lastUsage, lastCallUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
             yield { type: "done", result: e };
             return;
           }
@@ -1917,7 +1926,7 @@ export class AgentRunner {
           kind: retryKind === "rate_limit" ? "rate_limit" : (retryKind === "timeout" ? "timeout" : "provider_error"),
           message: formatError(err),
           code: errorCodeForMeta(err),
-        }, lastUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
+        }, lastUsage, lastCallUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
         yield { type: "done", result: e };
         return;
       }
@@ -1926,7 +1935,7 @@ export class AgentRunner {
     const exhausted = this.errorResult(startTime, modelId, provider.id, {
       kind: "provider_error",
       message: "Max retries exceeded",
-    }, lastUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
+    }, lastUsage, lastCallUsage, toolLoops, compactionCount, false, [...toolNamesSet], [...skillsLoadedSet], transientToolErrors, permanentToolErrors, finalizedRunTimings(startTime, timings));
     yield { type: "done", result: exhausted };
   }
 
@@ -2563,6 +2572,7 @@ export class AgentRunner {
     provider: string,
     error: AgentRunMeta["error"],
     usage?: Partial<AgentRunMeta["usage"]>,
+    lastCallUsage?: AgentRunMeta["lastCallUsage"],
     toolLoops = 0,
     compactionCount = 0,
     aborted = false,
@@ -2587,6 +2597,7 @@ export class AgentRunner {
           cacheWriteTokens: usage?.cacheWriteTokens ?? 0,
           totalTokens: usage?.totalTokens ?? 0,
         },
+        ...(lastCallUsage ? { lastCallUsage } : {}),
         toolLoops,
         compactionCount,
         timings,

--- a/src/core-agent/src/agent/types.ts
+++ b/src/core-agent/src/agent/types.ts
@@ -99,6 +99,12 @@ export type AgentRunMeta = {
   stopReason: StopReason;
   /** Accumulated token usage. */
   usage: Usage;
+  /** Prompt-side usage of the FINAL model call only. Unlike `usage` (the
+   *  whole-run accumulation, where re-sent history is summed once per tool
+   *  round), this is the true current context occupancy — consumers that
+   *  show "how full is the window" must use this, not `usage`. Absent on
+   *  runs that never made a model call. */
+  lastCallUsage?: Usage;
   /** Number of tool-use loop iterations. */
   toolLoops: number;
   /** Number of compaction cycles. */

--- a/src/main/features/chat_events/project-upstream.ts
+++ b/src/main/features/chat_events/project-upstream.ts
@@ -118,7 +118,7 @@ function summarizeArgs(args: unknown): string | undefined {
 }
 
 /** usage 载荷的键名在上游（result.meta.usage）随 provider 而异，宽松取。 */
-function usagePayloadFrom(data: Record<string, unknown>): {
+function pickUsageFields(data: Record<string, unknown>): {
   inputTokens?: number;
   outputTokens?: number;
   cacheReadTokens?: number;
@@ -145,6 +145,31 @@ function usagePayloadFrom(data: Record<string, unknown>): {
     // pi-ai 驼峰 / DeepSeek 下划线 / Anthropic 命名。
     ...(cacheRead !== undefined ? { cacheReadTokens: cacheRead } : {}),
     ...(cacheWrite !== undefined ? { cacheWriteTokens: cacheWrite } : {}),
+  };
+}
+
+/** usage 载荷（2026-09-11 双口径）：顶层字段=整轮累加（消耗口径，Token 段
+ *  继续用）；`lastCallUsage`=最后一次调用的 prompt 侧用量（当前上下文占用
+ *  的权威口径——累加值把每步重发的历史求和，绝不能当窗口占用展示）。 */
+function usagePayloadFrom(data: Record<string, unknown>): {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  lastCallUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+} {
+  const nestedRaw = data.lastCallUsage;
+  const nested = nestedRaw && typeof nestedRaw === 'object' && !Array.isArray(nestedRaw)
+    ? pickUsageFields(nestedRaw as Record<string, unknown>)
+    : null;
+  return {
+    ...pickUsageFields(data),
+    ...(nested && Object.keys(nested).length ? { lastCallUsage: nested } : {}),
   };
 }
 

--- a/src/main/features/chat_events/schema.ts
+++ b/src/main/features/chat_events/schema.ts
@@ -77,13 +77,23 @@ const textPayloadSchema = z.object({
 });
 
 const usagePayloadSchema = z.object({
-  /** 输入/输出 token 数（口径沿用 #84 对话内统计）。 */
+  /** 输入/输出 token 数（口径沿用 #84 对话内统计）。
+   *  注意：这是**整轮累加**（每步工具循环的调用求和）——消耗口径。 */
   inputTokens: z.number().nonnegative().optional(),
   outputTokens: z.number().nonnegative().optional(),
   /** 缓存读/写 token 数（2026-09-08 补：面板用量行与页脚 meta 口径
    *  一致——投影器 usagePayloadFrom 已带上，schema 此前会静默剥掉）。 */
   cacheReadTokens: z.number().nonnegative().optional(),
   cacheWriteTokens: z.number().nonnegative().optional(),
+  /** 最后一次调用的 prompt 侧用量（2026-09-11 补）：**当前上下文占用**的
+   *  权威口径——上方累加字段把每步重发的历史求和，绝不能当窗口占用展示。
+   *  schema 必须登记，否则 zod 静默剥离（2026-09-08 cacheRead 同类教训）。 */
+  lastCallUsage: z.object({
+    inputTokens: z.number().nonnegative().optional(),
+    outputTokens: z.number().nonnegative().optional(),
+    cacheReadTokens: z.number().nonnegative().optional(),
+    cacheWriteTokens: z.number().nonnegative().optional(),
+  }).optional(),
   /** 按用户默认单价估算的费用（非账单金额）。 */
   estimatedCost: z.number().nonnegative().optional(),
   /** 上下文窗口占用比（0-1），接近 1 触发压缩提示（矩阵 #10）。 */

--- a/src/main/features/chat_events/types.ts
+++ b/src/main/features/chat_events/types.ts
@@ -73,6 +73,14 @@ export type UsagePayload = {
    *  不可见。schema 仍为事实源，此处保持同步）。 */
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
+  /** 最后一次调用的 prompt 侧用量（2026-09-11）：当前上下文占用的权威
+   *  口径；上方字段为整轮累加（消耗口径）。与 schema 保持同步。 */
+  lastCallUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
   estimatedCost?: number;
   contextWindowRatio?: number;
 };

--- a/src/main/features/cogseed_backend/lifecycle.ts
+++ b/src/main/features/cogseed_backend/lifecycle.ts
@@ -39,6 +39,17 @@ export function isCogSeedTaskActiveStatus(status: CogSeedTaskStatus): boolean {
   return status === 'created' || status === 'queued' || status === 'running' || status === 'waiting_user';
 }
 
+/**
+ * 执行中（executing）＝真的有活在跑。区别于 isCogSeedTaskActiveStatus 的
+ * 运营口径"还挂着"：`waiting_user` 表示任务已停止执行、正在等用户回话
+ * （状态机 TRANSITIONS 里它只在用户再说话时回到 queued），算进运行态会让
+ * 会话被判定为"正在回复"——发送按钮卡在停止态、后续消息被错排队
+ * （2026-09-11 实机事故）。运行中心/看板的活跃计数仍用上面那个宽口径。
+ */
+export function isCogSeedTaskExecutingStatus(status: CogSeedTaskStatus): boolean {
+  return status === 'created' || status === 'queued' || status === 'running';
+}
+
 export async function archiveCogSeedTask(userId: string, taskId: string): Promise<CogSeedTaskRecord> {
   assertCogSeedUserId(userId);
   assertCogSeedTaskId(taskId);

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -679,48 +679,73 @@ type ProcessItem =
 /**
  * conv-core 存储补差合并：老格式 processItems + chat_events 新条目合成单条
  * 过程轨迹，总量守住 MAX_PROCESS_ITEMS_PER_TURN（消息过程上限是既有不变量，
- * 见 bus-integration 饱和测试）。预算分配：turn 终态条目最优先（收束态总耗时
- * 的唯一来源），工具 chatItem 次之（保持到达序），reasoning 垫底（与老格式
- * progress 文本语义重复，超额先丢）。老格式已打满上限时新条目全弃——历史
- * 重建回退老路径，行为与收编前完全一致。
+ * 见 bus-integration 饱和测试）。
+ *
+ * 顺序契约（2026-09-11 真机二次事故）：条目顺序即时间线，合并结果的相对顺序
+ * 必须与到达序一致——渲染层一见 chatItem 就整体走事件重放（不再看老格式），
+ * 顺序错了历史里就成了「中途思考全堆到末尾」。取舍只决定丢谁，绝不改变保留
+ * 项的前后关系（19:38 消息：收集器 33 段思考本已与工具交错，落盘变成末尾
+ * 14 段——正是超额路径按"非 reasoning 在前"重排 + 截断所致）。
+ *
+ * 超额预算分配：
+ *   1. 老格式思考 progress（_thinking 内存态标记）与 chat_events reasoning 是
+ *      同一次思考的重复存储——超额时先从后往前丢这些重复项换预算。真机
+ *      19:38：155+164 超 19 条，丢 19 条重复思考后 136+164=300 恰好落回预算
+ *      内，零丢失且时间线完整（对齐"丢谁不丢序"）。
+ *   2. 仍超额才按优先级选保留集合：turn 终态（收束态总耗时的唯一来源）>
+ *      非 reasoning（工具/正文/usage）> reasoning；选中后仍按原序输出。
+ * 老格式已打满上限、且没有重复思考可丢时新条目全弃——历史重建回退老路径，
+ * 行为与收编前完全一致。
  */
 export function mergeProcessTrail(
   processItems: ProcessItem[],
   chatEntries: readonly PersistedChatEntry[],
 ): Array<ProcessItem | PersistedChatEntry> {
-  const budget = MAX_PROCESS_ITEMS_PER_TURN - processItems.length;
-  if (budget <= 0) return [...processItems];
+  const budget = MAX_PROCESS_ITEMS_PER_TURN;
+  // 老格式自身已打满上限：新条目全弃——历史重建回退老路径，行为与收编前一致。
+  if (processItems.length >= budget) return [...processItems];
   const turnEntries = chatEntries.filter((e) => e.type === "turn");
   const nonTurn = chatEntries.filter((e) => e.type !== "turn");
   const isReasoning = (e: PersistedChatEntry) =>
     e.type === "chatItem" && (e.item as { kind?: string }).kind === "reasoning";
-  const ordered = [
-    ...nonTurn.filter((e) => !isReasoning(e)),
-    ...nonTurn.filter(isReasoning),
-    ...turnEntries,
-  ];
-  // 上限内尽量保全：**保持原序**（2026-09-11 修复——reasoning 与工具的
-  // 交错位置是时间线语义：此前无条件用优先级序拼接，把整轮思考全部推到
-  // 过程区末尾，中途思考在历史重放里不可见。优先级序只用于超限时的取舍，
-  // 不得改变正常路径的顺序）。终态保到最后一档。
-  if (nonTurn.length + turnEntries.length <= budget) {
-    return [...processItems, ...nonTurn, ...turnEntries];
+  const isThinkingLegacy = (e: ProcessItem | PersistedChatEntry) =>
+    e.type === "progress" && (e as { _thinking?: boolean })._thinking === true;
+  const total = (legacy: readonly unknown[]) =>
+    legacy.length + nonTurn.length + turnEntries.length;
+
+  // 只在「新条目确有 reasoning」时才把老格式思考当重复——收集器没产出
+  // reasoning 的回合（老投影/异常轮次）里老格式思考是唯一来源，必须留。
+  let head: ProcessItem[] = processItems;
+  if (nonTurn.some(isReasoning) && processItems.some(isThinkingLegacy) && total(processItems) > budget) {
+    const kept = [...processItems];
+    for (
+      let i = kept.length - 1;
+      i >= 0 && total(kept) > budget;
+      i -= 1
+    ) {
+      if (isThinkingLegacy(kept[i])) kept.splice(i, 1);
+    }
+    head = kept;
   }
-  const keepTurn = Math.min(turnEntries.length, Math.max(1, budget));
-  // 预算共享（PR209 评审 M7）：非 reasoning 与 reasoning 两组共用
-  // budget - keepTurn 的总额度——此前两组各 slice 同一 keepRest，合并
-  // 总长可达 2×keepRest 突破 300 上限（实测可到 401），与函数头注释
-  // 「守住 MAX_PROCESS_ITEMS_PER_TURN」矛盾。优先级序：非 reasoning
-  // （工具/正文/usage）先取，剩余额度给 reasoning。
-  const restBudget = Math.max(0, budget - keepTurn);
-  const nonReasoning = nonTurn.filter((e) => !isReasoning(e));
-  const reasoning = nonTurn.filter(isReasoning);
-  const keptNonReasoning = nonReasoning.slice(0, restBudget);
-  const keptReasoning = reasoning.slice(0, Math.max(0, restBudget - keptNonReasoning.length));
+  // 预算内：原序直出（终态条目本就是时间线最后一条，无需搬家）。上限内
+  // 保持原序是硬要求——reasoning 与工具的交错位置就是时间线语义。
+  if (total(head) <= budget) {
+    return [...head, ...nonTurn, ...turnEntries];
+  }
+  // 仍超额：先选保留集合（优先级），再按原序拼接（保留项相对位置不变）。
+  const restBudget = Math.max(0, budget - head.length);
+  const keepTurn = Math.min(turnEntries.length, Math.max(1, restBudget));
+  const take = Math.max(0, restBudget - keepTurn);
+  const keepIdx = new Set<number>();
+  for (let i = 0; i < nonTurn.length && keepIdx.size < take; i += 1) {
+    if (!isReasoning(nonTurn[i])) keepIdx.add(i);
+  }
+  for (let i = 0; i < nonTurn.length && keepIdx.size < take; i += 1) {
+    if (isReasoning(nonTurn[i])) keepIdx.add(i);
+  }
   return [
-    ...processItems,
-    ...keptNonReasoning,
-    ...keptReasoning,
+    ...head,
+    ...nonTurn.filter((_, i) => keepIdx.has(i)),
     ...turnEntries.slice(0, keepTurn),
   ];
 }

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -6704,6 +6704,15 @@ async function runActorTurnBody(
         usageOut.cacheReadTokens = usageIn.cacheReadTokens;
       if (typeof usageIn?.cacheWriteTokens === "number")
         usageOut.cacheWriteTokens = usageIn.cacheWriteTokens;
+      // lastCallUsage（2026-09-11）：占用口径，嵌套对象原样透传（白名单在
+      // client.ts 的 safeUsageForLog 一侧完成）。
+      if (
+        usageIn?.lastCallUsage && typeof usageIn.lastCallUsage === "object"
+      ) {
+        usageOut.lastCallUsage = usageIn.lastCallUsage as NonNullable<
+          GroupMessageMetrics["usage"]
+        >["lastCallUsage"];
+      }
       const toolCalls = Number(agentRunTimingData.tool_calls);
       replyMetrics = {
         startedAt,

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -5467,7 +5467,6 @@ async function runActorTurnBody(
       // 是外部协作的主目标，优先于话题隔离；sessionForGoal 的 goal 通道与
       // runP3394GatewayTurn 的 goal 参数保留——将来 KStar 需求粒度变粗
       // （真正的长话题）或出现显式"新话题"用户动作时，可恢复注入。
-      let gatewayTurnGoal: string | undefined;
       const cliOut = sharedFormBlock
         ? { text: sharedFormBlock, produced: [] as string[] }
         : isP3394Gateway
@@ -5496,7 +5495,8 @@ async function runActorTurnBody(
               ? { reasoningEffort: item.execConfig.effort }
               : {}),
             ...(item.execConfig?.model ? { model: item.execConfig.model } : {}),
-            ...(gatewayTurnGoal ? { goal: gatewayTurnGoal } : {}),
+            // goal 槽位宿主侧不注入（会话连续性优先，见上方注释）；网关
+            // runP3394GatewayTurn 的 goal 参数通道保留，恢复注入时加回这里。
             // T1 引用信封化：本轮 quote/@ 的引用快照进信封 metadata 槽位
             //（正文文本已含 <referenced-messages> 可读版，双通道冗余供给）。
             ...(item.references && item.references.length

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -5428,18 +5428,16 @@ async function runActorTurnBody(
       // （如 project_dir）未满足时不派发，返回表单块由 runTerminal 提升为
       // <agent-input-form> 询问用户。
       const sharedFormBlock = await _maybeBuildCliInputForm(uid, cid, cliAgent);
-      // G-28 话题隔离：当前会话有开放的 KStar 需求（= 系统判定的当前话题）
-      // 时以需求 id 作 goal——sessionForGoal 按 (会话, 对端, goal) 分 P3394
-      // 会话，话题（需求）切换自动开新会话，旧话题记忆不互相污染；无开放
-      // 需求（闲聊）时 goal 缺省，保持原有稳定会话，连续性不受影响。
+      // G-28 话题隔离（2026-09-11 停用自动注入）：此前把"当前开放的 KStar
+      // 需求 id"作为 goal 传入信封，sessionForGoal 按 (会话,对端,goal) 分
+      // P3394 会话。但 KStar 的需求粒度是"每条实质提问一个新需求"——同一
+      // 会话连问两个问题 goal 就变，G-28 退化为"每问必开新会话"，外部智能
+      // 体对几分钟前的上下文全部失忆（实测同会话三连问产生三个 P3394 会
+      // 话、三个 codex 原生 thread）。会话连续性（同会话+同对端=同一会话）
+      // 是外部协作的主目标，优先于话题隔离；sessionForGoal 的 goal 通道与
+      // runP3394GatewayTurn 的 goal 参数保留——将来 KStar 需求粒度变粗
+      // （真正的长话题）或出现显式"新话题"用户动作时，可恢复注入。
       let gatewayTurnGoal: string | undefined;
-      try {
-        const { readKstarTaskLifecycle } = await import("../kstar/lifecycle-adapter");
-        const lifecycle = await readKstarTaskLifecycle(uid, cid);
-        if (lifecycle.requirement && lifecycle.requirement.status === "open") {
-          gatewayTurnGoal = "req:" + lifecycle.requirement.id;
-        }
-      } catch { /* KStar 不可用时退回默认稳定会话 */ }
       const cliOut = sharedFormBlock
         ? { text: sharedFormBlock, produced: [] as string[] }
         : isP3394Gateway

--- a/src/main/features/group_chat/bus.ts
+++ b/src/main/features/group_chat/bus.ts
@@ -699,8 +699,13 @@ export function mergeProcessTrail(
     ...nonTurn.filter(isReasoning),
     ...turnEntries,
   ];
-  // 上限内尽量保全：先按优先序截断非终态条目，终态保到最后一档。
-  if (ordered.length <= budget) return [...processItems, ...ordered];
+  // 上限内尽量保全：**保持原序**（2026-09-11 修复——reasoning 与工具的
+  // 交错位置是时间线语义：此前无条件用优先级序拼接，把整轮思考全部推到
+  // 过程区末尾，中途思考在历史重放里不可见。优先级序只用于超限时的取舍，
+  // 不得改变正常路径的顺序）。终态保到最后一档。
+  if (nonTurn.length + turnEntries.length <= budget) {
+    return [...processItems, ...nonTurn, ...turnEntries];
+  }
   const keepTurn = Math.min(turnEntries.length, Math.max(1, budget));
   // 预算共享（PR209 评审 M7）：非 reasoning 与 reasoning 两组共用
   // budget - keepTurn 的总额度——此前两组各 slice 同一 keepRest，合并

--- a/src/main/features/group_chat/index.ts
+++ b/src/main/features/group_chat/index.ts
@@ -181,11 +181,15 @@ export async function runtimeStatus(
     let backendTurns: Array<{ actor: string; turn_id: string; started_at_ms: number }> = [];
     try {
       const { listCogSeedTasks } = await import('../cogseed_backend/task-store');
+      const { isCogSeedTaskExecutingStatus } = await import('../cogseed_backend/lifecycle');
       const tasks = await listCogSeedTasks(userId);
+      // 只认「执行中」（created/queued/running）。此前按"非终态"黑名单过滤，
+      // 把 `waiting_user`（已停止、等用户回话）也算作活跃，导致会话
+      // processing 恒为 true：发送按钮卡在停止态、后续消息被排队
+      // （2026-09-11 claude spawn 失败后实机复现）。
       const active = (Array.isArray(tasks) ? tasks : []).filter((t) => (
         t && t.conversationId === cid
-        && t.status !== 'completed' && t.status !== 'failed'
-        && t.status !== 'cancelled' && t.status !== 'recoverable'
+        && isCogSeedTaskExecutingStatus(t.status)
       ));
       backendActive = active.length > 0;
       backendAgents = Array.from(new Set(

--- a/src/main/features/group_chat/visibility.ts
+++ b/src/main/features/group_chat/visibility.ts
@@ -97,6 +97,14 @@ export interface GroupMessageMetrics {
     outputTokens?: number;
     cacheReadTokens?: number;
     cacheWriteTokens?: number;
+    /** 最后一次调用的 prompt 侧用量（2026-09-11）：当前上下文占用的权威
+     *  口径；上方字段为整轮累加（消耗口径，每步重发的历史被求和）。 */
+    lastCallUsage?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    };
     /** CLI 自报成本（美元，claude 的 total_cost_usd 等）。比单价表估算准，
      *  渲染层优先消费；缺省时回退价格表估算。 */
     costUsd?: number;

--- a/src/main/model/core-agent/client.ts
+++ b/src/main/model/core-agent/client.ts
@@ -295,6 +295,14 @@ type SafeUsage = {
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
   totalTokens?: number;
+  /** 最后一次调用的 prompt 侧用量（2026-09-11）：当前上下文占用的权威
+   *  口径；上方字段为整轮累加（消耗口径）。 */
+  lastCallUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
 };
 
 export type LiveRunTimingPhase = 'provider' | 'tool' | 'compaction' | 'retry_wait' | 'other';
@@ -463,6 +471,20 @@ function safeUsageForLog(usage: unknown): SafeUsage | undefined {
   if (cacheReadTokens !== undefined) out.cacheReadTokens = cacheReadTokens;
   if (cacheWriteTokens !== undefined) out.cacheWriteTokens = cacheWriteTokens;
   if (totalTokens !== undefined) out.totalTokens = totalTokens;
+  const nestedRaw = u.lastCallUsage;
+  if (nestedRaw && typeof nestedRaw === 'object' && !Array.isArray(nestedRaw)) {
+    const n = nestedRaw as Record<string, unknown>;
+    const nested: NonNullable<SafeUsage['lastCallUsage']> = {};
+    const ni = finiteNumber(n.inputTokens);
+    const no = finiteNumber(n.outputTokens);
+    const ncr = finiteNumber(n.cacheReadTokens);
+    const ncw = finiteNumber(n.cacheWriteTokens);
+    if (ni !== undefined) nested.inputTokens = ni;
+    if (no !== undefined) nested.outputTokens = no;
+    if (ncr !== undefined) nested.cacheReadTokens = ncr;
+    if (ncw !== undefined) nested.cacheWriteTokens = ncw;
+    if (Object.keys(nested).length) out.lastCallUsage = nested;
+  }
   return Object.keys(out).length ? out : undefined;
 }
 
@@ -707,7 +729,13 @@ export function recordModelRawEventForLog(stats: ModelRunLogDiagnostics, ev: unk
       noteElapsedOnce(stats, 'doneRawEventMs', nowMs);
       const result = e.result as { meta?: Record<string, unknown> } | undefined;
       const meta = result?.meta || {};
-      stats.usage = safeUsageForLog(meta.usage) || stats.usage;
+      // meta.lastCallUsage（2026-09-11）平级挂在 meta 上，先并入 usage 再
+      // 走白名单过滤，否则占用口径字段会在这一站被剥掉。
+      stats.usage = safeUsageForLog(
+        meta.lastCallUsage
+          ? { ...(meta.usage && typeof meta.usage === 'object' ? meta.usage : {}), lastCallUsage: meta.lastCallUsage }
+          : meta.usage,
+      ) || stats.usage;
       stats.providerDurationMs = finiteNumber(meta.durationMs) ?? stats.providerDurationMs;
       stats.provider = typeof meta.provider === 'string' ? meta.provider : stats.provider;
       stats.model = typeof meta.model === 'string' ? meta.model : stats.model;

--- a/src/main/model/core-agent/event-mapper.ts
+++ b/src/main/model/core-agent/event-mapper.ts
@@ -607,7 +607,18 @@ export async function* mapCoreAgentEvents(
         if (result.meta.usage) {
           yield {
             type: 'event',
-            event: { stream: 'usage', data: result.meta.usage as unknown as Record<string, unknown> },
+            event: {
+              stream: 'usage',
+              // lastCallUsage（2026-09-11）：最后一次调用的 prompt 侧用量——
+              // "当前上下文占用"的权威口径。上方的累加 usage（每步重发历史
+              // 求和）只服务消耗/计费口径。
+              data: {
+                ...(result.meta.usage as unknown as Record<string, unknown>),
+                ...(result.meta.lastCallUsage
+                  ? { lastCallUsage: result.meta.lastCallUsage as unknown as Record<string, unknown> }
+                  : {}),
+              },
+            },
           };
         }
         if (result.meta.error) {

--- a/src/main/model/public_model_catalog.ts
+++ b/src/main/model/public_model_catalog.ts
@@ -65,11 +65,15 @@ export const PUBLIC_PROVIDER_MODELS: Readonly<Record<string, readonly ProviderMo
     { id: 'MiniMax-M2.7', name: 'MiniMax 2.7' },
   ],
   deepseek: [
-    { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
-    { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
-    // 窗口与视觉口径来源：产品确认（2026-08-27），deepseek-v4-pro/flash 文本版
-    // 无权威数字故不标 —— 目录只收确凿数据，不猜。
+    { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', contextWindow: 1_048_576 },
+    { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', contextWindow: 1_048_576 },
+    // 窗口口径 2026-09-11 更新（产品负责人确认）：V4 文本系列与此前已确认
+    // 1M 的 v4-flash-vision-exp 共用 1M 窗口——原先"文本版无权威数字故不标"
+    // 的保守口径作废；v4.1 是 V4 的迭代版本（用户实际配置的 id 形态
+    // `deepseek/deepseek-v4.1-flash`），同族同窗口，一并登记。
     { id: 'deepseek-v4-flash-vision-exp', name: 'DeepSeek V4 Flash Vision (exp)', contextWindow: 1_048_576, vision: true },
+    { id: 'deepseek-v4.1-pro', name: 'DeepSeek V4.1 Pro', contextWindow: 1_048_576 },
+    { id: 'deepseek-v4.1-flash', name: 'DeepSeek V4.1 Flash', contextWindow: 1_048_576 },
   ],
   doubao: [
     { id: 'doubao-seed-2-0-pro-260215', name: 'Doubao Seed 2.0 Pro' },

--- a/src/renderer/chat-stream.css
+++ b/src/renderer/chat-stream.css
@@ -23,7 +23,16 @@
   flex-direction: column;
   gap: 1px;
   min-width: 0;
+  /* 行收缩贴合内容（2026-09-11）：默认 stretch 把每行拉到面板全宽，
+     hover 背景远长于截断后的行内容、尾部大片空白。flex-start 下子项
+     按内容宽收缩（width:fit-content 实测不生效——与行内 % max-width
+     循环解析，Chromium 按 available 取值仍得全宽）。 */
+  align-items: flex-start;
 }
+/* 展开态（diff/输出/思考全文）回到全宽：块级展开区需要整行宽可读。 */
+.cs-row.cs-open { align-self: stretch; }
+/* 正文段时间线段保持全宽：markdown 段落的排版基线与消息正文一致。 */
+.cs-text { width: 100%; }
 
 /* ── 计时/收起徽章：挂在消息头 cogseed 名字右侧，点击开合下方时间线 ── */
 .cs-badge {
@@ -71,9 +80,8 @@
 
 /* ── 动作行：外层管 hover/点击（块级），内层 cs-row-line 一行内联摘要 ── */
 .cs-row {
-  /* 行宽贴合内容（2026-09-11：此前块级占满消息宽，hover 背景远长于截断
-     后的行内容，尾部大片空白）。长行（命令截断/展开区）仍受容器宽约束。 */
-  width: fit-content;
+  /* 行宽由父级 align-items:flex-start 收缩到内容（见 .cs-flow-body 注释）；
+     max-width 兜底长命令/展开区不超面板。 */
   max-width: 100%;
   padding: 3px 6px;
   border-radius: var(--radius-1);
@@ -82,10 +90,15 @@
 }
 .cs-row:hover { background: var(--color-stream-hover); }
 .cs-row-line {
-  display: flex;
+  /* inline-flex（2026-09-11）：块级 div 的 auto 宽恒等于可用宽，把外层
+     任何收缩（fit-content/min-content）都顶回面板全宽——hover 背景因此
+     远长于行内容。改 inline-flex 后宽度=内容，配合 .cs-flow-body 的
+     flex-start 实现整行贴合内容。 */
+  display: inline-flex;
   align-items: center;
   gap: 7px;
   min-width: 0;
+  max-width: 100%;
 }
 
 .cs-ico { display: inline-flex; flex: none; color: var(--color-stream-chip-2); }

--- a/src/renderer/chat-stream.css
+++ b/src/renderer/chat-stream.css
@@ -95,7 +95,7 @@
      远长于行内容。改 inline-flex 后宽度=内容，配合 .cs-flow-body 的
      flex-start 实现整行贴合内容。 */
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 7px;
   min-width: 0;
   max-width: 100%;
@@ -131,16 +131,16 @@
   font-size: var(--font-size-2);
 }
 .cs-target {
-  /* 不再 flex:1 撑满——那会把耗时推到行最右（交互设计 2026-09-08：工具行
-     耗时应紧跟目标文本，与思考行「· 持续了 Xs」同位同样式）。行宽仍由
-     max-width 截断保护。 */
   flex: 0 1 auto; min-width: 0;
-  /* 命令/查询类目标显式截断：超长部分直接隐去（对齐 CLI 行宽省略） */
-  max-width: 68%;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  /* 完整显示（2026-09-11 需求变更）：不再 68% 截断+单行省略——命令全文
+     换行展示，行/背景贴合全部文字，无尾部空白；超容器宽自然折行。 */
+  max-width: 100%;
+  white-space: pre-wrap;
+  word-break: break-all;
   color: var(--color-stream-target);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--font-size-2);
+  line-height: 1.5;
 }
 
 /* 行内 diff 统计与展开的 diff 正文 */

--- a/src/renderer/chat-stream.css
+++ b/src/renderer/chat-stream.css
@@ -180,9 +180,22 @@
   font-size: var(--font-size-1); white-space: pre-wrap; word-break: break-all;
 }
 
-/* ── 思考行： brain 图标 + 思考 + 时长；点开看原文 ── */
+/* ── 思考行： brain 图标 + 思考 + 时长 + 常显单行预览；点开看全文 ── */
 .cs-row-think .cs-think-dur { color: var(--color-stream-dim); }
-/* 思考展开块（.cs-think-full）已移除（2026-09-11）：思考行只保留单行摘要。 */
+/* 思考全文（点击行展开，2026-09-11 方案 C）：纯文本块——无边框、无底色、
+   无圆角，不算卡片。缩进对齐时间线正文。 */
+.cs-think-full {
+  display: none;
+  margin: 2px 0 2px 22px;
+  color: var(--color-stream-think);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: var(--font-size-2);
+  line-height: 1.55;
+}
+.cs-row.cs-open .cs-think-full { display: block; }
+/* 展开态隐藏行内预览，避免与全文重复显示。 */
+.cs-row.cs-open .cs-think-live { display: none; }
 
 /* ── 时间线正文段（边说边执行的文字，交回前的时间线内呈现） ── */
 /* 实时 markdown 渲染后段内是块级 <p>/<ul>（各带自身 margin）——
@@ -267,6 +280,7 @@
     background: transparent;
     border-left-color: var(--color-stream-dark-line-2);
   }
+  .cs-think-full { color: var(--color-stream-chip); }
   .cs-interaction-detail { background: var(--color-stream-dark-deep); }
   .cs-card.cs-interaction { background: var(--color-stream-dark-card); }
   .cs-btn { background: var(--color-stream-dark-hover); }

--- a/src/renderer/chat-stream.css
+++ b/src/renderer/chat-stream.css
@@ -71,6 +71,10 @@
 
 /* ── 动作行：外层管 hover/点击（块级），内层 cs-row-line 一行内联摘要 ── */
 .cs-row {
+  /* 行宽贴合内容（2026-09-11：此前块级占满消息宽，hover 背景远长于截断
+     后的行内容，尾部大片空白）。长行（命令截断/展开区）仍受容器宽约束。 */
+  width: fit-content;
+  max-width: 100%;
   padding: 3px 6px;
   border-radius: var(--radius-1);
   cursor: pointer;

--- a/src/renderer/chat-stream.css
+++ b/src/renderer/chat-stream.css
@@ -65,8 +65,6 @@
 .cs-badge-tools:not(:empty)::before { content: '·'; padding: 0 4px 0 2px; opacity: .55; }
 /* 思考行运行中实时显示最新思考文本（截断一行；收行后仍只显时长）。 */
 .cs-think-live { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; opacity: .72; }
-/* 工具行权威耗时（payload.timing；无 timing 不渲染——不编造）。 */
-.cs-dur { flex: none; font-variant-numeric: tabular-nums; opacity: .72; }
 .cs-flow.failed .cs-badge { color: var(--color-stream-fail); }
 .cs-flow.failed .cs-badge:hover { color: var(--color-stream-fail-3); }
 .cs-badge-stop {

--- a/src/renderer/chat-stream.css
+++ b/src/renderer/chat-stream.css
@@ -132,11 +132,13 @@
 }
 .cs-target {
   flex: 0 1 auto; min-width: 0;
-  /* 完整显示（2026-09-11 需求变更）：不再 68% 截断+单行省略——命令全文
-     换行展示，行/背景贴合全部文字，无尾部空白；超容器宽自然折行。 */
+  /* 单行紧凑（2026-09-11 需求变更，覆盖上一版的换行完整显示）：强制单行，
+     一行放不下直接硬截断（text-overflow: clip，不出现省略号），超出的
+     部分不换行不提示。宽度由 flex 收缩到行内可用空间。 */
   max-width: 100%;
-  white-space: pre-wrap;
-  word-break: break-all;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
   color: var(--color-stream-target);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--font-size-2);
@@ -180,18 +182,7 @@
 
 /* ── 思考行： brain 图标 + 思考 + 时长；点开看原文 ── */
 .cs-row-think .cs-think-dur { color: var(--color-stream-dim); }
-.cs-think-full {
-  display: none;
-  margin: 2px 0 2px 22px;
-  padding: 2px 0 2px 10px;
-  border-left: 2px solid var(--color-stream-guide-2);
-  color: var(--color-stream-think);
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-size: var(--font-size-2);
-  line-height: 1.55;
-}
-.cs-row.cs-open .cs-think-full { display: block; }
+/* 思考展开块（.cs-think-full）已移除（2026-09-11）：思考行只保留单行摘要。 */
 
 /* ── 时间线正文段（边说边执行的文字，交回前的时间线内呈现） ── */
 /* 实时 markdown 渲染后段内是块级 <p>/<ul>（各带自身 margin）——
@@ -270,7 +261,6 @@
   .cs-text { color: var(--text, var(--color-stream-fallback)); }
   .cs-usage-row { color: var(--color-stream-chip); }
   .cs-loading { color: var(--color-stream-chip); }
-  .cs-think-full { color: var(--color-stream-chip); border-left-color: var(--color-stream-dark-line); }
   /* 输出块与浅色模式同构：无底色卡，竖线引导（浅色 2026-09-08 21:10
      改法同步——此前暗色仍残留 rgba(0,0,0,.28) 深底卡）。 */
   .cs-row-out pre {

--- a/src/renderer/modules/chat-stream.js
+++ b/src/renderer/modules/chat-stream.js
@@ -142,7 +142,11 @@ function _csFirstArg(args, keys) {
 }
 
 function _csFmtDur(ms) {
-  const total = Math.max(0, Math.floor((Number(ms) || 0) / 1000));
+  // 亚秒级显示毫秒（2026-09-11：本地 CLI 工具普遍几十毫秒完成，整秒
+  // 取整把真实耗时吞成"0 秒"，看起来像计时坏了——真机两轮误报）。
+  const v = Math.max(0, Number(ms) || 0);
+  if (v < 1000) return `${Math.round(v)}ms`;
+  const total = Math.floor(v / 1000);
   if (total < 60) return `${total} 秒`;
   return `${Math.floor(total / 60)} 分 ${total % 60} 秒`;
 }
@@ -544,19 +548,13 @@ function _csRenderToolRow(row, payload, status) {
   const failed = status === 'failed';
   const target = _csTargetHtml(style.targetKind, args, argsSummary);
   const hover = [p.toolName, argsSummary].filter(Boolean).join(' ');
-  // 工具耗时：主进程权威 timing（存储补差后实时/历史同源）；历史重放是瞬时
-  // 到达，墙钟差恒为 0——没有 payload.timing 就不显示（不编造）。
-  let dur = '';
-  if (p.timing && typeof p.timing.startedAtMs === 'number'
-    && typeof p.timing.completedAtMs === 'number') {
-    dur = `<span class="cs-dur">${_csFmtDur(Math.max(0, p.timing.completedAtMs - p.timing.startedAtMs))}</span>`;
-  }
+  // 工具耗时不再显示（2026-09-11 需求变更）：本地 CLI 工具普遍毫秒级完成，
+  // 数字信息量低还占行宽；timing 数据仍随条目保留，需要时悬停/调试可查。
   // 行 = 一行内联摘要（cs-row-line）+ 块级展开区（错误/输出，点行开合）。
   const line = [
     `<span class="cs-ico${failed ? ' failed' : ''}">${_csIco(style.icon)}</span>`,
     `<span class="cs-verb${failed ? ' failed' : ''}${style.raw ? ' raw' : ''}">${_csEscapeHtml(style.verb)}</span>`,
     target,
-    dur,
   ];
   const blocks = [];
   if (p.error) blocks.push(`<div class="cs-row-error">${_csEscapeHtml(p.error)}</div>`);

--- a/src/renderer/modules/chat-stream.js
+++ b/src/renderer/modules/chat-stream.js
@@ -946,11 +946,11 @@ window.chatStreamHandleEvent = function chatStreamHandleEvent(cid, anchor, chatE
         const rDelta = String((payload && payload.delta) || '');
         const rFull = String((payload && payload.text) || '');
         if (status === 'inProgress') {
-          // 思考实时流式（交互设计 2026-09-09 需求）：增量逐段落入思考行，
-          // 行自动展开——进行中就能看到推理进度，不等完成态折叠块。
+          // 思考实时流式：增量逐段落入思考行。默认折叠（2026-09-11 需求
+          // 变更：交互过程不再自动展开全文）——行内 cs-think-live 保留单行
+          // 实时预览，用户点击行才展开 cs-think-full 全文。
           if (rDelta) {
-            const row = _csAppendReasoning(body, rDelta);
-            row.classList.add('cs-open');
+            _csAppendReasoning(body, rDelta);
           }
           return;
         }

--- a/src/renderer/modules/chat-stream.js
+++ b/src/renderer/modules/chat-stream.js
@@ -651,21 +651,24 @@ function _csThinkDurText(row) {
 // 「上一锚点→下一锚点」窗口写回 csT0/csDur——见该处的推导注释。
 
 function _csRenderThinkRow(row) {
-  const running = row.dataset.csClosed !== '1';
+  // 单行预览常显（2026-09-11 方案 C）：不管运行中还是已收行，都显示思考
+  // 内容的一行预览（最后一个非空行，尾部截断）——收行后内容不再消失。
   let live = '';
-  if (running && row.dataset.csFull) {
+  if (row.dataset.csFull) {
     const tl = String(row.dataset.csFull).split('\n').filter(Boolean).pop() || '';
     if (tl) live = `<span class="cs-think-live">${_csEscapeHtml(tl.slice(-90))}</span>`;
   }
-  // 2026-09-11 需求变更：思考的展开全文块（cs-think-full 卡片）彻底移除——
-  // 只保留单行摘要（图标 + 思考 + 时长 + 运行中单行预览）。
+  // 点击行展开全文：纯文本块，无边框/底色/圆角（不算卡片）。
+  const full = row.dataset.csFull
+    ? `<div class="cs-think-full">${_csEscapeHtml(row.dataset.csFull)}</div>` : '';
   row.innerHTML = `
     <div class="cs-row-line">
       <span class="cs-ico">${_csIco('brain-circuit')}</span>
       <span class="cs-verb">思考</span>
       <span class="cs-row-dim cs-think-dur">${_csThinkDurText(row)}</span>
       ${live}
-    </div>`;
+    </div>
+    ${full}`;
 }
 
 /** 文字段实时 markdown 渲染（交互设计 2026-09-08：流式期间 # ** 等符号裸露）。
@@ -702,7 +705,8 @@ function _csAppendReasoning(body, text) {
     row = document.createElement('div');
     row.className = 'cs-row cs-row-think';
     row.dataset.csT0 = String(Date.now());
-    // 思考行不再可点击展开（2026-09-11：展开块移除，纯单行摘要）。
+    // 点击行展开/收起全文（方案 C：纯文本块，无卡片样式）。
+    row.addEventListener('click', () => row.classList.toggle('cs-open'));
     body.appendChild(row);
   }
   if (text) row.dataset.csFull = (row.dataset.csFull || '') + text;

--- a/src/renderer/modules/chat-stream.js
+++ b/src/renderer/modules/chat-stream.js
@@ -657,16 +657,15 @@ function _csRenderThinkRow(row) {
     const tl = String(row.dataset.csFull).split('\n').filter(Boolean).pop() || '';
     if (tl) live = `<span class="cs-think-live">${_csEscapeHtml(tl.slice(-90))}</span>`;
   }
-  const full = row.dataset.csFull
-    ? `<div class="cs-think-full">${_csEscapeHtml(row.dataset.csFull)}</div>` : '';
+  // 2026-09-11 需求变更：思考的展开全文块（cs-think-full 卡片）彻底移除——
+  // 只保留单行摘要（图标 + 思考 + 时长 + 运行中单行预览）。
   row.innerHTML = `
     <div class="cs-row-line">
       <span class="cs-ico">${_csIco('brain-circuit')}</span>
       <span class="cs-verb">思考</span>
       <span class="cs-row-dim cs-think-dur">${_csThinkDurText(row)}</span>
       ${live}
-    </div>
-    ${full}`;
+    </div>`;
 }
 
 /** 文字段实时 markdown 渲染（交互设计 2026-09-08：流式期间 # ** 等符号裸露）。
@@ -703,7 +702,7 @@ function _csAppendReasoning(body, text) {
     row = document.createElement('div');
     row.className = 'cs-row cs-row-think';
     row.dataset.csT0 = String(Date.now());
-    row.addEventListener('click', () => row.classList.toggle('cs-open'));
+    // 思考行不再可点击展开（2026-09-11：展开块移除，纯单行摘要）。
     body.appendChild(row);
   }
   if (text) row.dataset.csFull = (row.dataset.csFull || '') + text;

--- a/src/renderer/modules/conversation-metrics.js
+++ b/src/renderer/modules/conversation-metrics.js
@@ -167,6 +167,7 @@ function foldSessionMetrics(metricsList, opts = {}) {
   let reportedCostUsd = 0;   // CLI/网关自报成本合计（美元）
   let reportedCostTurns = 0;
   let lastUsage = null;
+  let lastCtxUsage = null;   // 占用口径（lastCallUsage 优先，缺失回退 lastUsage）
   let lastUsageModel = null; // 自报模型 id——ctx 分母按它解析（CLI 回合不再错用全局模型窗口）
   for (const m of list) {
     if (num(m.toolCalls) > 0) steps += num(m.toolCalls);
@@ -192,6 +193,13 @@ function foldSessionMetrics(metricsList, opts = {}) {
     if (num(u.inputTokens) + num(u.outputTokens) > 0) {
       lastUsage = u;
       lastUsageModel = typeof m.model === 'string' && m.model ? m.model : null;
+      // 占用口径（2026-09-11）：优先最后一次调用的 prompt 侧用量
+      // （usage.lastCallUsage）——上方累加 usage 把每步工具循环重发的历史
+      // 求和，直接当窗口占用会虚高数倍（真机：单轮 33 步显示 566K，实际
+      // 最后一步 prompt 仅数十 K）。缺失时回退累加值（CLI 回合等旧数据）。
+      lastCtxUsage = (u.lastCallUsage && typeof u.lastCallUsage === 'object')
+        ? u.lastCallUsage
+        : u;
     }
   }
   // 命中率分母 = billedInput = input+cacheRead+cacheWrite（与 DSH billedInputTokens 口径一致，§101）
@@ -210,8 +218,9 @@ function foldSessionMetrics(metricsList, opts = {}) {
   const ctxWindow = (typeof windowFromModel === 'number' && windowFromModel > 0)
     ? windowFromModel
     : num(opts.contextWindow);
-  const ctxUsed = lastUsage
-    ? num(lastUsage.inputTokens) + num(lastUsage.cacheReadTokens) + num(lastUsage.cacheWriteTokens)
+  const ctxUsage = lastCtxUsage || lastUsage;
+  const ctxUsed = ctxUsage
+    ? num(ctxUsage.inputTokens) + num(ctxUsage.cacheReadTokens) + num(ctxUsage.cacheWriteTokens)
     : 0;
   const ctx = lastUsage && ctxWindow > 0
     ? { used: ctxUsed, window: ctxWindow }

--- a/src/renderer/modules/conversation-metrics.js
+++ b/src/renderer/modules/conversation-metrics.js
@@ -86,7 +86,10 @@ function cacheHitPercentText(cacheReadTokens, inputTokens, cacheWriteTokens = 0)
 
 function messageMetricsLine(metrics) {
   if (!metrics || typeof metrics !== 'object') return null;
-  const { startedAt, firstTokenAt, completedAt, usage } = metrics;
+  const { startedAt, firstTokenAt, completedAt } = metrics;
+  // CLI 回合统计已下线（bus 剥 usage）：metrics 只带时间戳是常态而非异常。
+  // 宿主对象归一化后，inputTokens 等字段全部经 num() 安全取值。
+  const usage = metrics.usage || {};
   const hasUsage = usage && (num(usage.inputTokens) + num(usage.outputTokens)
     + num(usage.cacheReadTokens) + num(usage.cacheWriteTokens)) > 0;
   if (typeof startedAt !== 'number' || typeof completedAt !== 'number') return null;

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -10557,19 +10557,14 @@ async function _resolveMarketplaceInstallRequest(card, req, cid, msgId, decision
 function _renderPersistedProcess(msgDiv, items, { expanded = false } = {}) {
   const bubble = msgDiv.querySelector('.chat-bubble');
   if (!bubble) return;
-  const details = document.createElement('details');
+  // 2026-09-11 需求变更：过程轨迹不再用 details 折叠卡容器包裹，改普通
+  // div 平铺纯文本行（与流式路径同形态）。expanded 参数保留签名兼容但
+  // 平铺恒显，无折叠语义。
+  void expanded;
+  const details = document.createElement('div');
   details.className = 'stream-process';
-  if (expanded) details.open = true;
-  details.innerHTML = `
-    <summary class="stream-process-summary">
-      <span class="stream-process-caret" aria-hidden="true">${_uiIconHtml('chevron-right', 'ui-icon stream-process-caret-icon')}</span>
-      <span class="stream-process-label">${escapeHtml(t('chat.process_info'))}</span>
-      <span class="stream-process-runtime" hidden></span>
-    </summary>
-    <div class="stream-process-body"></div>
-  `;
+  details.innerHTML = '<div class="stream-process-body"></div>';
   const body = details.querySelector('.stream-process-body');
-  _setProcessSummaryRuntime(details, _processSummaryRuntimeFromItems(items));
   for (const item of items) {
     let text = '';
     const itemEvent = item && item.type === 'event'
@@ -13894,14 +13889,9 @@ function _createStreamingAssistantMessage(container, opts = {}) {
       <span class="chat-msg-time">${formatTime(new Date().toISOString())}</span>
     </div>
     <div class="chat-bubble">
-      <details class="stream-process" data-role="process-container" style="display:none">
-        <summary class="stream-process-summary">
-          <span class="stream-process-caret" aria-hidden="true">${_uiIconHtml('chevron-right', 'ui-icon stream-process-caret-icon')}</span>
-          <span class="stream-process-label">${escapeHtml(t('chat.process_info'))}</span>
-          <span class="stream-process-runtime" hidden></span>
-        </summary>
+      <div class="stream-process" data-role="process-container" style="display:none">
         <div class="stream-process-body" data-role="process"></div>
-      </details>
+      </div>
       <div class="stream-activity" data-role="activity" style="display:none">
         <span class="stream-activity-pulse" aria-hidden="true"></span>
         <span class="stream-activity-text" data-role="activity-text"></span>
@@ -14456,31 +14446,16 @@ function _streamingSetFinal(msg, text, { archive = false } = {}) {
   // line (e.g. the model answered in one shot with no reasoning / tool
   // calls), keep the initial display:none so we don't render an empty
   // "process info" bubble.
-  // **Exception**: when the final body is just an empty/abort stub
-  // (i.e. the "(stopped)" placeholder for a turn that never produced
-  // real text), the process trail IS the user-visible output — keep
-  // it expanded; otherwise the user perceives it as "the process I
-  // just watched stream is gone after finalize", which gets worse on
-  // refresh.
+  // 2026-09-11 需求变更：过程轨迹已平铺（无折叠卡），finalize 只按"有无
+  // 过程行"控制显隐——空回合（中断桩）与正常回合同形态恒显，无展开态可谈。
   const details = msg.querySelector('.stream-process');
   if (details) {
     const body = details.querySelector('.stream-process-body');
     const hasProcess = !!body && body.children.length > 0;
-    const bodyText = String(display || '').trim();
-    // Match both possible forms — jsonl history can carry either depending
-    // on the UI language at the time of write (i18n key `model.aborted` →
-    // '(stopped)' in en, '（已中断）' in zh).
-    const isAbortStub = bodyText === '（已中断）' || bodyText === '(stopped)' || bodyText === '';
-    if (hasProcess && isAbortStub) {
-      details.open = true;
+    if (hasProcess) {
       details.style.display = '';
-    } else if (hasProcess) {
-      details.removeAttribute('open');
-      details.style.display = '';
-    } else {
-      details.removeAttribute('open');
-      // else: keep display:none (the initial value set by _createStreamingAssistantMessage).
     }
+    // else: keep display:none (the initial value set by _createStreamingAssistantMessage).
   }
 }
 

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -7842,11 +7842,22 @@ async function _loadOlderConversationHistory(cid, before) {
         .map(_groupMsgToLegacy)
         .sort((a, b) => _msTs(a && a.time) - _msTs(b && b.time));
       const fragment = document.createDocumentFragment();
-      messages.forEach((msg) => appendChatMessage(msg, false, {
-        cid,
-        container: fragment,
-        historyHydration: true,
-      }));
+      // 与 loadConversationHistory 主路径同款隔离：单条坏消息只丢自己。
+      messages.forEach((msg) => {
+        try {
+          appendChatMessage(msg, false, {
+            cid,
+            container: fragment,
+            historyHydration: true,
+          });
+        } catch (err) {
+          _convLog.warn('older history message render failed, skipping', {
+            cid,
+            msg_id: msg && msg._msg_id,
+            error: err && err.message,
+          });
+        }
+      });
       // Keep the auto-load sentinel as the first child. Every successively
       // older page lands immediately after it and before the already-mounted
       // transcript, preserving chronological order across repeated loads.
@@ -8316,15 +8327,32 @@ async function loadConversationHistory(cid, opts = {}) {
       // tree scans. Live messages and recovery paths still use the guarded
       // incremental insertion path below.
       const historyFragment = document.createDocumentFragment();
-      history.forEach((msg) => appendChatMessage(msg, false, {
-        cid,
-        // Only stamp authoritative source indexes returned by an anchored
-        // history read. A normal latest-page row has no global index; using
-        // its local 0..9 offset would let a later search falsely match it.
-        msgIndex: Number.isSafeInteger(msg?._history_index) ? msg._history_index : undefined,
-        container: historyFragment,
-        historyHydration: true,
-      }));
+      // 单条消息渲染失败只丢该条并记日志——一条坏消息不能把整个会话
+      // 炸成"加载失败"（2026-09-11 codex 会话 usage 缺失事故的教训）。
+      let renderFailures = 0;
+      history.forEach((msg) => {
+        try {
+          appendChatMessage(msg, false, {
+            cid,
+            // Only stamp authoritative source indexes returned by an anchored
+            // history read. A normal latest-page row has no global index; using
+            // its local 0..9 offset would let a later search falsely match it.
+            msgIndex: Number.isSafeInteger(msg?._history_index) ? msg._history_index : undefined,
+            container: historyFragment,
+            historyHydration: true,
+          });
+        } catch (err) {
+          renderFailures += 1;
+          _convLog.warn('history message render failed, skipping', {
+            cid,
+            msg_id: msg && msg._msg_id,
+            error: err && err.message,
+          });
+        }
+      });
+      if (renderFailures > 0) {
+        _convLog.warn('history render skipped broken messages', { cid, count: renderFailures });
+      }
       container.appendChild(historyFragment);
     }
     // 历史重载汇合点（空/非空分支都经过）：fragment 离屏装载期间

--- a/src/renderer/modules/conversation.js
+++ b/src/renderer/modules/conversation.js
@@ -9272,7 +9272,8 @@ function _refreshSessionStats() {
     segs.push({ k: t('chat.stats.speedK'), v: f.ttftAvgText });
   }
   if (f.cacheHitText) segs.push({ k: t('chat.stats.cacheK'), v: f.cacheHitText });
-  if (f.ctxText) segs.push({ k: t('chat.stats.ctxK'), v: f.ctxText, hot: f.ctxHot });
+  // 上下文段独立加框突出（2026-09-11 需求）：总窗口 + 占用量一眼可辨。
+  if (f.ctxText) segs.push({ k: t('chat.stats.ctxK'), v: f.ctxText, hot: f.ctxHot, cls: 'ctx' });
   segs.push({
     k: t('chat.stats.tokK'),
     v: f.cacheReadText
@@ -9284,7 +9285,7 @@ function _refreshSessionStats() {
   box.hidden = false;
   segs.forEach((s) => {
     const seg = document.createElement('span');
-    seg.className = s.hot ? 'seg seg-hot' : 'seg';
+    seg.className = ['seg', s.hot ? 'seg-hot' : '', s.cls ? `seg-${s.cls}` : ''].filter(Boolean).join(' ');
     if (s.k) {
       const k = document.createElement('span');
       k.className = 'k';

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -10353,13 +10353,17 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-self: flex-end;
   align-items: stretch;
 }
-/* 编辑卡片外框（2026-09-11 设计稿）：中性浅灰、四角同半径、淡边淡影。
-   覆盖用户气泡的绿调背景/绿边与右下 4px 切角——非编辑态消息不受影响。
-   .user 一并入选择器：否则同特异性的绿调气泡规则（后写）会赢。 */
+/* 编辑卡片外框（2026-09-11 设计稿）：中性浅灰、淡边淡影，非编辑态消息不受影响。
+   作用面（特异性实测）：主会话面板里 `#panel-conversation .chat-message.user >
+   .chat-bubble`（含 id）对颜色/边框/圆角/阴影一律胜出——本规则在那里只吃下
+   padding，外观由面板自己的「quiet Work Buddy」气泡规则给出（同为中性浅灰
+   无阴影，与设计稿一致，故无需 !important 硬拼）；嵌入式聊天面（无该 id 规则）
+   才由本规则的 background/border/box-shadow 生效。
+   圆角不在此声明：各面沿用自己气泡的圆角（主面板 20px；嵌入式保留用户气泡的
+   右下切角），避免为局部卡片改写全局气泡观感。 */
 .chat-message.user.is-message-editing .chat-bubble {
   background: #f5f6f7;
   border: 1px solid rgba(15, 23, 42, 0.06);
-  border-radius: 18px;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.05);
   padding: 14px;
 }
@@ -10398,8 +10402,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   gap: 10px;
 }
 .chat-message.is-message-editing .chat-message-edit-actions .btn {
-  /* 设计稿按钮：取消白底灰边、主按钮品牌绿、圆角 10（仅编辑卡片内）。 */
-  border-radius: 10px;
+  /* 设计稿按钮：取消白底灰边、主按钮品牌绿，尺寸放大到 8px 18px 内边距。
+     圆角不在此声明——沿用 .btn 自身的 8px（设计令牌 --radius-2 口径），
+     与全局按钮观感一致，也避免再引入一个超刻度圆角字面量。 */
   padding: 8px 18px;
 }
 

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -4898,14 +4898,15 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .dashboard .db-alert[data-level="error"] .db-alert-icon { background: var(--db-bad); }
 .dashboard .db-alert[data-level="error"] .db-alert-icon::before { content: "!"; }
 
-/* Table — compact, numeric columns right-aligned. */
+/* Table — compact, numeric columns right-aligned.
+   2026-09-11 需求变更：去掉卡片封装（border/radius/background）——表格以
+   原生形态展示，在父容器中水平居中（内容自然宽，两侧留白对称）。 */
 .dashboard .db-table-wrap {
   overflow-x: auto;
-  border: 1px solid var(--db-border);
-  border-radius: var(--db-radius);
-  background: var(--db-surface);
+  display: flex;
+  justify-content: center;
 }
-.dashboard .db-table { width: 100%; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
+.dashboard .db-table { width: auto; max-width: 100%; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
 .dashboard .db-table th,
 .dashboard .db-table td { padding: 7px 10px; border-bottom: 1px solid rgba(20, 71, 55, 0.08); text-align: left; }
 .dashboard .db-table tr:last-child td { border-bottom: none; }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -4910,7 +4910,8 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .dashboard .db-table { width: 100%; max-width: 900px; margin: 0 auto; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
 .dashboard .db-table th,
 .dashboard .db-table td { padding: 7px 10px; border-bottom: 1px solid rgba(20, 71, 55, 0.08); text-align: left; }
-.dashboard .db-table tr:last-child td { border-bottom: none; }
+/* 末行保留底线（2026-09-11）：卡片封装移除后，原来的 none 会让表格底部
+   缺一条线、视觉未闭合。 */
 .dashboard .db-table th { background: var(--db-surface-soft); font-weight: 600; color: var(--text); }
 .dashboard .db-table tbody tr:nth-child(even) td { background: rgba(248, 250, 252, 0.55); }
 .dashboard .db-table th[data-numeric="1"],
@@ -11411,8 +11412,12 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   overflow: hidden;
 }
 
-/* 其它易撑破气泡的块级内容（表格、长 URL/图片）也约束到气泡宽度以内。 */
-.chat-bubble .markdown-body table { display: block; max-width: 100%; overflow-x: auto; }
+/* 其它易撑破气泡的块级内容（表格、长 URL/图片）也约束到气泡宽度以内。
+   dashboard 表格（.db-table）豁免：它由自己的规则管（限宽 900 + 居中，
+   且外层 .db-table-wrap 已有横向滚动兜底）——不能豁免的话本条
+   max-width:100%（特异性 0,2,1）会压过 .dashboard .db-table（0,2,0），
+   900 上限与居中静默失效（真机踩坑 2026-09-11）。 */
+.chat-bubble .markdown-body table:not(.db-table) { display: block; max-width: 100%; overflow-x: auto; }
 .chat-bubble .markdown-body img   { max-width: 100%; }
 .chat-bubble .markdown-body .chat-md-img { width: 100%; height: 100%; }
 

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -10343,11 +10343,14 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 .chat-message.is-message-editing {
-  /* 编辑态居中对齐 AI 内容列（交互设计 2026-09-08 布局统一）：用户消息编辑时
-     原右对齐换居中，宽度与 AI 区块一致。 */
+  /* 2026-09-11 需求变更：编辑卡片右对齐。09-08 原设计为居中对齐 AI 内容
+     列，但用户消息自身的 margin-right:10%（右缘对齐 AI 块）仍然生效，
+     center + margin 叠加把卡片压到中部偏左、右侧留大片空白。
+     改 flex-end 后右缘回到与普通用户消息一致的列位（AI 块右缘）。
+     仅作用于编辑态——is-message-editing 随编辑开始/取消对称增删。 */
   width: min(80%, 760px);
   max-width: min(80%, 760px);
-  align-self: center;
+  align-self: flex-end;
   align-items: stretch;
 }
 .chat-message-edit-composer {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -4899,14 +4899,13 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .dashboard .db-alert[data-level="error"] .db-alert-icon::before { content: "!"; }
 
 /* Table — compact, numeric columns right-aligned.
-   2026-09-11 需求变更：去掉卡片封装（border/radius/background）——表格以
-   原生形态展示，在父容器中水平居中（内容自然宽，两侧留白对称）。 */
+   2026-09-11 需求变更：去掉卡片封装（border/radius/background）后表格
+   铺满容器左右边界（width:100%，列按内容比例均匀铺开）——占满即居中；
+   窄屏由 wrap 的横向滚动兜底。 */
 .dashboard .db-table-wrap {
   overflow-x: auto;
-  display: flex;
-  justify-content: center;
 }
-.dashboard .db-table { width: auto; max-width: 100%; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
+.dashboard .db-table { width: 100%; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
 .dashboard .db-table th,
 .dashboard .db-table td { padding: 7px 10px; border-bottom: 1px solid rgba(20, 71, 55, 0.08); text-align: left; }
 .dashboard .db-table tr:last-child td { border-bottom: none; }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -4631,7 +4631,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
    注意：气泡层的 .chat-bubble .markdown-body table 规则（特异性更高）不得
    再声明 max-width——否则会静默压过这里（真机踩坑两次）。 */
 .markdown-body table { border-collapse: collapse; width: 100%; max-width: 900px; margin: 0.7em auto; font-size: 12.5px; }
-.markdown-body th, .markdown-body td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; }
+.markdown-body th, .markdown-body td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; overflow-wrap: anywhere; }
 .markdown-body th { background: var(--bg); font-weight: 600; }
 
 /* ─── Chart bar ─── */
@@ -11417,12 +11417,13 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   overflow: hidden;
 }
 
-/* 其它易撑破气泡的块级内容（表格、长 URL/图片）也约束到气泡宽度以内。
-   dashboard 表格（.db-table）豁免滚动容器化：布局由 .dashboard/.markdown-body
-   的表格规则统一管（限宽 900 + 居中）。这里不再声明 max-width——本规则
-   特异性更高，声明了会静默压过基础规则（真机踩坑 2026-09-11）。
-   display:block 仅作为极窄屏的横向滚动兜底。 */
-.chat-bubble .markdown-body table:not(.db-table) { display: block; overflow-x: auto; }
+/* 表格不再 display:block（2026-09-11 根因修复，踩坑两次的元凶）：
+   block 化的 table 元素盒与内部列网格脱节——元素被 width:100% 撑满而
+   网格仍按内容宽排布，右侧留下大片"空壳"空白（真机：元素 852px、最后
+   一格只到 590px，视觉表格"没铺满"且限定宽度规则全部失效）。
+   改为原生表格布局后 width/max-width/居中全部正常生效。
+   防撑破改由单元格断行承担（见 th/td 的 overflow-wrap）——超长 URL
+   等无空格内容可在格内换行，不再需要横向滚动容器。 */
 .chat-bubble .markdown-body img   { max-width: 100%; }
 .chat-bubble .markdown-body .chat-md-img { width: 100%; height: 100%; }
 

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -11260,46 +11260,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   font-variant-numeric: tabular-nums;
 }
 
+/* 2026-09-11 需求变更：过程轨迹不再是 details 折叠卡——普通透明容器，
+   行直接平铺为纯文本（行样式见 .stream-process-line），无竖线/summary。 */
 .stream-process {
   margin-bottom: 8px;
-  border-left: 2px solid #cbd5e1;
-  padding-left: 10px;
 }
-.stream-process:not([open]) { margin-bottom: 0; }
-.stream-process-summary {
-  cursor: pointer;
-  list-style: none;
-  font-size: 12px;
-  color: #475569;
-  padding: 2px 0;
-  user-select: none;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.stream-process-summary::-webkit-details-marker { display: none; }
-/* Same caret family as the tree nodes (chevron-right → rotate 90° when expanded). */
-.stream-process-caret {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  font-size: 13px;
-  line-height: 1;
-  color: #475569;
-  transition: transform 0.15s;
-}
-.stream-process[open] .stream-process-summary .stream-process-caret {
-  transform: rotate(90deg);
-}
-.stream-process-label { font-weight: 600; }
-.stream-process-runtime {
-  color: #64748b;
-  font-weight: 500;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-.stream-process-runtime[hidden] { display: none; }
 
 .stream-process-body {
   max-height: 300px;
@@ -11325,11 +11290,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   white-space: pre-wrap;
   word-break: break-all;
 }
-/* Four-tier hierarchy. The constraint: every content line must be
-   visually LIGHTER than the section header (`.stream-process-summary`,
-   slate-600 #475569 + 600) — content is supporting detail, the header
-   is the label. An earlier pass had bound/tool lines at slate-900 + 600
-   which inverted the hierarchy (content darker than its own label).
+/* Four-tier hierarchy. The constraint: every content line stays
+   subordinate to the message body — content is supporting detail
+   (2026-09-11 起无 summary 头，层级基准即正文文本).
    Tiers:
      1. Core    — milestones / tool calls / plans / file edits;
                   slate-500 + 500 weight. Distinguishable at a glance
@@ -11393,13 +11356,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   /* Appears below process section with a subtle divider when process is open */
 }
 /* Divider between the process trail and the final body — only when the
-   process section is actually visible. The placeholder bubble starts with
-   `.stream-process` carrying both `[open]` and inline `display:none` (so it
-   expands automatically the first time a process event arrives), and we
-   must NOT paint the dashed border above the body while the process row
-   is still hidden — otherwise the bubble shows a stray top divider above
-   the streaming text with nothing above it to separate from. */
-.stream-process[open]:not([style*="display:none"]) + .stream-final:not([style*="display:none"]) {
+   process section is actually visible. 2026-09-11 起容器是普通 div（无
+   [open] 折叠态），以行内 display 样式判断可见性。 */
+.stream-process:not([style*="display:none"]) + .stream-final:not([style*="display:none"]) {
   margin-top: 8px;
   padding-top: 10px;
   border-top: 1px dashed var(--border);

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -10736,6 +10736,16 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 .chat-session-stats[hidden] { display: none; }
 .chat-session-stats .seg-hot .v { color: var(--danger); }
+/* 上下文段独立加框（2026-09-11 需求）：模型窗口总大小 + 当前占用单独成框
+   突出显示；占用达到告警阈值（seg-hot）时边框同步转警示色。
+   本规则置于 .seg 基础规则之后以同特异性后写覆盖。 */
+.chat-session-stats .seg-ctx {
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 1px 9px;
+  margin: 0 5px;
+}
+.chat-session-stats .seg-ctx.seg-hot { border-color: var(--danger); }
 
 @media (hover: none), (pointer: coarse) {
   #panel-conversation .chat-message .chat-bubble-actions {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -4625,7 +4625,12 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .markdown-body em { font-style: italic; }
 .markdown-body a { color: var(--primary); text-decoration: none; }
 .markdown-body a:hover { text-decoration: underline; }
-.markdown-body table { border-collapse: collapse; width: 100%; margin: 0.7em 0; font-size: 12.5px; }
+/* 表格布局统一（2026-09-11，方案 B 全表类型覆盖）：markdown 原生表格与
+   dashboard 组件表格共用同一布局口径——铺满到 900px 上限，容器更宽时居中
+   （两侧留白对称），窄容器铺满；行/列在任何宽度下均匀铺开。
+   注意：气泡层的 .chat-bubble .markdown-body table 规则（特异性更高）不得
+   再声明 max-width——否则会静默压过这里（真机踩坑两次）。 */
+.markdown-body table { border-collapse: collapse; width: 100%; max-width: 900px; margin: 0.7em auto; font-size: 12.5px; }
 .markdown-body th, .markdown-body td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; }
 .markdown-body th { background: var(--bg); font-weight: 600; }
 
@@ -11413,11 +11418,11 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 }
 
 /* 其它易撑破气泡的块级内容（表格、长 URL/图片）也约束到气泡宽度以内。
-   dashboard 表格（.db-table）豁免：它由自己的规则管（限宽 900 + 居中，
-   且外层 .db-table-wrap 已有横向滚动兜底）——不能豁免的话本条
-   max-width:100%（特异性 0,2,1）会压过 .dashboard .db-table（0,2,0），
-   900 上限与居中静默失效（真机踩坑 2026-09-11）。 */
-.chat-bubble .markdown-body table:not(.db-table) { display: block; max-width: 100%; overflow-x: auto; }
+   dashboard 表格（.db-table）豁免滚动容器化：布局由 .dashboard/.markdown-body
+   的表格规则统一管（限宽 900 + 居中）。这里不再声明 max-width——本规则
+   特异性更高，声明了会静默压过基础规则（真机踩坑 2026-09-11）。
+   display:block 仅作为极窄屏的横向滚动兜底。 */
+.chat-bubble .markdown-body table:not(.db-table) { display: block; overflow-x: auto; }
 .chat-bubble .markdown-body img   { max-width: 100%; }
 .chat-bubble .markdown-body .chat-md-img { width: 100%; height: 100%; }
 

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -10353,19 +10353,29 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   align-self: flex-end;
   align-items: stretch;
 }
+/* 编辑卡片外框（2026-09-11 设计稿）：中性浅灰、四角同半径、淡边淡影。
+   覆盖用户气泡的绿调背景/绿边与右下 4px 切角——非编辑态消息不受影响。
+   .user 一并入选择器：否则同特异性的绿调气泡规则（后写）会赢。 */
+.chat-message.user.is-message-editing .chat-bubble {
+  background: #f5f6f7;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 18px;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.05);
+  padding: 14px;
+}
 .chat-message-edit-composer {
   width: min(620px, 100%);
   display: grid;
-  gap: 10px;
+  gap: 12px;
 }
 .chat-message-edit-input {
   box-sizing: border-box;
   width: 100%;
-  min-height: 86px;
+  min-height: 108px;
   max-height: 260px;
-  padding: 10px 12px;
-  border: 1px solid var(--border-strong, #cbd5e1);
-  border-radius: 6px;
+  padding: 14px 16px;
+  border: 1px solid rgba(15, 23, 42, 0.10);
+  border-radius: 12px;
   background: var(--surface, var(--color-surface));
   color: var(--text, #1f2937);
   font: inherit;
@@ -10373,6 +10383,7 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   letter-spacing: 0;
   resize: none;
   overflow-y: auto;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 .chat-message-edit-input:focus {
   outline: 0;
@@ -10382,7 +10393,12 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .chat-message-edit-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 10px;
+}
+.chat-message.is-message-editing .chat-message-edit-actions .btn {
+  /* 设计稿按钮：取消白底灰边、主按钮品牌绿、圆角 10（仅编辑卡片内）。 */
+  border-radius: 10px;
+  padding: 8px 18px;
 }
 
 @media (max-width: 720px) {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -4899,13 +4899,15 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
 .dashboard .db-alert[data-level="error"] .db-alert-icon::before { content: "!"; }
 
 /* Table — compact, numeric columns right-aligned.
-   2026-09-11 需求变更：去掉卡片封装（border/radius/background）后表格
-   铺满容器左右边界（width:100%，列按内容比例均匀铺开）——占满即居中；
-   窄屏由 wrap 的横向滚动兜底。 */
+   2026-09-11 需求变更：去掉卡片封装（border/radius/background）。布局=限宽
+   居中铺满（方案 B，子安 2026-09-11 选定）：容器 ≤900px 时表格铺满左右
+   边界；容器更宽时以 900px 为上限居中（两侧对称留白），内部列仍铺满——
+   避免超宽窗口下一行文字横跨全屏、阅读视线来回跳。窄屏由 wrap 的横向
+   滚动兜底。上限调整只改这里一处。 */
 .dashboard .db-table-wrap {
   overflow-x: auto;
 }
-.dashboard .db-table { width: 100%; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
+.dashboard .db-table { width: 100%; max-width: 900px; margin: 0 auto; border-collapse: separate; border-spacing: 0; font-size: 12.5px; }
 .dashboard .db-table th,
 .dashboard .db-table td { padding: 7px 10px; border-bottom: 1px solid rgba(20, 71, 55, 0.08); text-align: left; }
 .dashboard .db-table tr:last-child td { border-bottom: none; }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -10364,7 +10364,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   padding: 14px;
 }
 .chat-message-edit-composer {
-  width: min(620px, 100%);
+  /* 铺满卡片内容宽（2026-09-11 修正）：原 min(620px,100%) 上限让输入框
+     和按钮行在卡片右侧留出一条空白（反馈两轮的"右侧空白"即此）。 */
+  width: 100%;
   display: grid;
   gap: 12px;
 }

--- a/test/main/features/chat_events/process-persist.test.ts
+++ b/test/main/features/chat_events/process-persist.test.ts
@@ -116,4 +116,29 @@ describe('process-persist collector', () => {
     expect((completed[0].item as { status?: string }).status).toBe('completed');
     expect((completed[0].item as { payload?: { text?: string } }).payload?.text).toBe('正在读取文件…继续分析…');
   });
+
+  it('多轮思考-工具交错：completed reasoning 按截断点顺序落盘（2026-09-11 复查）', () => {
+    // 真机现象复查：一轮 33 步的落盘里 13 条 completed reasoning 全部堆在
+    // usage 之后（过程区最末尾），中途的思考在时间线上不可见。本用例验证
+    // 投影+收集在"思考→工具→思考→工具"交错输入下是否保持顺序。
+    const c = createProcessCollector({ cid: 'c1', actorId: 'a1', turnId: 't7' });
+    c.feed({ type: 'progress', text: '思考一' });
+    c.feed(toolEvent('start', 'tool-1', {}));
+    c.feed(toolEvent('end', 'tool-1', {}));
+    c.feed({ type: 'progress', text: '思考二' });
+    c.feed(toolEvent('start', 'tool-2', {}));
+    c.feed(toolEvent('end', 'tool-2', {}));
+    c.finish('completed');
+    const kinds = c.entries.map((e) => (
+      e.type === 'chatItem'
+        ? String((e.item as { kind?: string; type?: string }).kind || (e.item as { type?: string }).type)
+        : e.type
+    ));
+    const reasonIdx = kinds.map((k, i) => (k === 'reasoning' ? i : -1)).filter((i) => i >= 0);
+    const toolIdx = kinds.map((k, i) => (k === 'toolExecution' ? i : -1)).filter((i) => i >= 0);
+    expect(reasonIdx).toHaveLength(2);
+    // 第一条思考在第一条工具之前；第二条思考在第一条工具之后（交错保持）。
+    expect(reasonIdx[0]).toBeLessThan(toolIdx[0]);
+    expect(reasonIdx[1]).toBeGreaterThan(toolIdx[0]);
+  });
 });

--- a/test/main/features/chat_events/process-persist.test.ts
+++ b/test/main/features/chat_events/process-persist.test.ts
@@ -141,4 +141,34 @@ describe('process-persist collector', () => {
     expect(reasonIdx[0]).toBeLessThan(toolIdx[0]);
     expect(reasonIdx[1]).toBeGreaterThan(toolIdx[0]);
   });
+
+  it('真实交错模式回放（19:38 消息形状）：reasoning 保持与工具交错（2026-09-11 深挖）', () => {
+    // 真机数据（180a07715650 / 75b8766fc839）的精确喂入模式：155 条老段
+    // 事件，53 个 progress 与 100 个 tool 事件按下列位置交错（含 10 组
+    // 三连 progress）。复现"收集器产出是否保持交错"。
+    const P_AT = new Set([0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 35, 40, 45, 50, 55, 60, 63, 68, 73, 78, 83, 86, 89, 90, 91, 96, 97, 98, 103, 104, 105, 110, 111, 112, 117, 118, 119, 124, 125, 126, 131, 132, 133, 138, 139, 140, 145, 146, 147, 150, 151, 152]);
+    const c = createProcessCollector({ cid: 'c1', actorId: 'a1', turnId: 't8' });
+    let toolSeq = 0;
+    for (let i = 0; i < 155; i++) {
+      if (P_AT.has(i)) {
+        c.feed({ type: 'progress', text: 'thinking-' + i });
+      } else {
+        toolSeq += 1;
+        c.feed(toolEvent(toolSeq % 2 === 0 ? 'end' : 'start', 'tool-' + Math.floor(toolSeq / 2), {}));
+      }
+    }
+    c.finish('completed');
+    const kinds = c.entries.map((e) => (
+      e.type === 'chatItem'
+        ? String((e.item as { kind?: string; type?: string }).kind || (e.item as { type?: string }).type)
+        : e.type
+    ));
+    const reasonIdx = kinds.map((k, i) => (k === 'reasoning' ? i : -1)).filter((i) => i >= 0);
+    const toolIdx = kinds.map((k, i) => (k === 'toolExecution' ? i : -1)).filter((i) => i >= 0);
+    const firstTool = toolIdx[0];
+    // 关键断言：至少有一条 reasoning 出现在第一个工具之后、最后一个工具之前
+    // （即保持交错，而非全部堆到尾部）。
+    const interleaved = reasonIdx.some((r) => r > firstTool && r < toolIdx[toolIdx.length - 1]);
+    expect({ reasonCount: reasonIdx.length, firstTool, reasonIdx: reasonIdx.slice(0, 6), interleaved }).toMatchObject({ interleaved: true });
+  });
 });

--- a/test/main/features/cogseed_backend/lifecycle.test.ts
+++ b/test/main/features/cogseed_backend/lifecycle.test.ts
@@ -26,6 +26,21 @@ async function createTask(requestId = 'req-lifecycle') {
 }
 
 describe('CogSeed task lifecycle', () => {
+  it('separates executing status from the board-active (waiting_user) status', async () => {
+    // 2026-09-11 实机事故的回归锚点：waiting_user 是"已停止、等用户回话"，
+    // 在运营口径里算活跃（运行中心计数），但绝不能算执行中——否则会话
+    // processing 恒 true，发送按钮卡在停止态、后续消息被错排队。
+    const lifecycle = await import('../../../../src/main/features/cogseed_backend/lifecycle');
+    expect(lifecycle.isCogSeedTaskActiveStatus('waiting_user')).toBe(true);
+    expect(lifecycle.isCogSeedTaskExecutingStatus('waiting_user')).toBe(false);
+    for (const status of ['created', 'queued', 'running'] as const) {
+      expect(lifecycle.isCogSeedTaskExecutingStatus(status)).toBe(true);
+    }
+    for (const status of ['planned', 'completed', 'failed', 'cancelled', 'recoverable'] as const) {
+      expect(lifecycle.isCogSeedTaskExecutingStatus(status)).toBe(false);
+    }
+  });
+
   it('keeps planned tasks inactive and allows direct archive without changing lifecycle status', async () => {
     const tasks = await import('../../../../src/main/features/cogseed_backend/task-store');
     const lifecycle = await import('../../../../src/main/features/cogseed_backend/lifecycle');

--- a/test/main/features/group_chat/merge-process-trail.test.ts
+++ b/test/main/features/group_chat/merge-process-trail.test.ts
@@ -82,6 +82,182 @@ describe('mergeProcessTrail 饱和（PR209 评审 M7）', () => {
   });
 });
 
+// ── 2026-09-11 二次事故（19:38 消息）回归：超额路径重排把整轮思考推到末尾 ──
+//
+// 真机数据（conv 180a07715650 / msg 75b8766fc839）：老格式 155 条（含 33 段
+// 思考 progress，与 reasoning 重复存储），chat_events 164 条（131 非 reasoning
+// + 33 reasoning，到达序与工具交错）。旧代码 budget=145 触发超额分支 → 按
+// "非 reasoning 在前" 重排 + reasoning.slice(0,14) → 落盘 300 条里思考全在
+// 末尾且只剩前 14 段。修复后：丢 19 条重复老格式思考腾预算 → 136+164=300
+// 恰好落回预算内，33 段思考全量保留且维持交错。
+
+function startedItem(): PersistedChatEntry {
+  return {
+    type: 'chatItem',
+    item: { type: 'chat.turn.started', turnId: 't', cid: 'c', actorId: 'a', startedAt: '2026-09-11T19:34:38Z' },
+  } as unknown as PersistedChatEntry;
+}
+
+function textItem(seq: number): PersistedChatEntry {
+  return {
+    type: 'chatItem',
+    item: { type: 'chat.item', turnId: 't', itemId: `t:text:${seq}`, kind: 'text', status: 'completed', payload: { delta: `中间段 ${seq}` } },
+  } as unknown as PersistedChatEntry;
+}
+
+function usageItem(): PersistedChatEntry {
+  return {
+    type: 'chatItem',
+    item: { type: 'chat.item', turnId: 't', itemId: 't:usage:1', kind: 'usage', status: 'completed', payload: { inputTokens: 1 } },
+  } as unknown as PersistedChatEntry;
+}
+
+/** 老格式思考 progress（_thinking 内存态标记，落盘会带上）。 */
+function thinkingLegacy(seq: number) {
+  return { type: 'progress', text: `思考 ${seq}`, _thinking: true };
+}
+
+function plainLegacy(seq: number) {
+  return { type: 'progress', text: `阶段 ${seq}` };
+}
+
+function eventLegacy(seq: number) {
+  return { type: 'event', event: { stream: 'tool', data: { id: `call_${seq}` } } };
+}
+
+/** 老格式 155 条（真机计数：100 工具事件 + 33 思考 + 20 其它 + usage + runtime）。 */
+function realLegacyItems() {
+  return [
+    ...Array.from({ length: 100 }, (_, i) => eventLegacy(i)),
+    ...Array.from({ length: 33 }, (_, i) => thinkingLegacy(i)),
+    ...Array.from({ length: 20 }, (_, i) => plainLegacy(i)),
+    { type: 'event', event: { stream: 'usage', data: { inputTokens: 1 } } },
+    { type: 'event', event: { stream: 'runtime', data: { durationMs: 1 } } },
+  ];
+}
+
+/** 新条目 164 条（真机计数：131 非 reasoning + 33 reasoning，交错到达）。 */
+function realChatEntries(): PersistedChatEntry[] {
+  const entries: PersistedChatEntry[] = [startedItem()];
+  for (let i = 0; i < 29; i += 1) {
+    entries.push(reasoningItem(i));
+    entries.push(toolItem(i * 3));
+    entries.push(toolItem(i * 3 + 1));
+    entries.push(toolItem(i * 3 + 2));
+    entries.push(textItem(i));
+  }
+  for (let i = 29; i < 33; i += 1) {
+    entries.push(reasoningItem(i));
+    entries.push(toolItem(87 + (i - 29)));
+  }
+  for (let i = 91; i < 100; i += 1) entries.push(toolItem(i));
+  entries.push(usageItem());
+  return entries;
+}
+
+describe('mergeProcessTrail 真机 19:38 形状（2026-09-11 二次事故）', () => {
+  it('重复思考换预算后：33 段 reasoning 全保留且维持交错位置', () => {
+    const processItems = realLegacyItems();
+    const entries = realChatEntries();
+    const reasoningCount = entries.filter(
+      (e) => e.type === 'chatItem' && (e.item as { kind?: string }).kind === 'reasoning',
+    ).length;
+    expect(processItems).toHaveLength(155);
+    expect(entries).toHaveLength(164);
+    expect(reasoningCount).toBe(33); // 33 reasoning + 131 非 reasoning
+
+    const merged = mergeProcessTrail(processItems as never, entries);
+    expect(merged.length).toBeLessThanOrEqual(MAX);
+    expect(merged.length).toBe(300); // 155+164=319 超 19 → 丢 19 条重复思考后恰好 300
+
+    const kinds = merged.map((e) => {
+      const item = (e as { item?: { kind?: string } }).item;
+      return item?.kind || (e as { type?: string }).type;
+    });
+    const reasonIdx = kinds.map((k, i) => (k === 'reasoning' ? i : -1)).filter((i) => i >= 0);
+    const toolIdx = kinds.map((k, i) => (k === 'toolExecution' ? i : -1)).filter((i) => i >= 0);
+    // 33 段一段不丢（旧代码只剩 14 段），且不再堆在末尾。
+    expect(reasonIdx).toHaveLength(33);
+    expect(reasonIdx.some((r) => r > toolIdx[0] && r < toolIdx[toolIdx.length - 1])).toBe(true);
+    // 思考顺序 = 到达序（reason:0 在第一段思考之前，reason:32 在最后一段之后）。
+    const firstReason = kinds.indexOf('reasoning');
+    const lastReason = kinds.lastIndexOf('reasoning');
+    const firstItemId = (merged[firstReason] as { item?: { itemId?: string } }).item?.itemId;
+    const lastItemId = (merged[lastReason] as { item?: { itemId?: string } }).item?.itemId;
+    expect(firstItemId).toBe('t:reason:0');
+    expect(lastItemId).toBe('t:reason:32');
+    // 只丢重复的老格式思考（33 条里丢 19 条，留 14 条作老路径兜底），
+    // 工具/usage/runtime 老格式事件一条不少。
+    const keptLegacyThinking = merged.filter((e) => (e as { _thinking?: boolean })._thinking === true).length;
+    expect(keptLegacyThinking).toBe(14);
+    expect(merged.filter((e) => (e as { type?: string }).type === 'event')).toHaveLength(102);
+  });
+
+  it('收集器没产出 reasoning 时不丢老格式思考（那是唯一来源）', () => {
+    const processItems = [
+      ...Array.from({ length: 33 }, (_, i) => thinkingLegacy(i)),
+      ...Array.from({ length: 257 }, (_, i) => plainLegacy(i)),
+    ];
+    const merged = mergeProcessTrail(processItems as never, [toolItem(0), turnEntry()]);
+    expect(merged.length).toBeLessThanOrEqual(MAX);
+    const keptThinking = merged.filter((e) => (e as { _thinking?: boolean })._thinking === true).length;
+    expect(keptThinking).toBe(33);
+  });
+
+  it('老格式自身打满上限时新条目全弃（既有回退语义不变）', () => {
+    const processItems = Array.from({ length: MAX }, (_, i) => plainLegacy(i));
+    const merged = mergeProcessTrail(processItems as never, [toolItem(0), turnEntry()]);
+    expect(merged).toHaveLength(MAX);
+    expect(merged.some((e) => (e as { type?: string }).type === 'chatItem')).toBe(false);
+  });
+
+  it('重复思考不足以腾预算时：仍按原序保留（丢谁不丢序）', () => {
+    const processItems = [
+      ...Array.from({ length: 260 }, (_, i) => plainLegacy(i)),
+      ...Array.from({ length: 20 }, (_, i) => thinkingLegacy(i)),
+    ];
+    // 含 reasoning 才触发「老格式思考=重复」的丢弃；工具与思考交错到达。
+    const entries: PersistedChatEntry[] = [];
+    for (let i = 0; i < 100; i += 1) {
+      entries.push(toolItem(i));
+      if (i >= 50 && i % 10 === 0) entries.push(reasoningItem(i));
+    }
+    const merged = mergeProcessTrail(processItems as never, entries);
+    expect(merged.length).toBeLessThanOrEqual(MAX);
+    // 20 条重复思考全丢（280→260），仍需 100 条 → 保留最早 40 条工具，共 300。
+    expect(merged.length).toBe(300);
+    const keptLegacy = merged.filter((e) => (e as { type?: string }).type === 'progress');
+    expect(keptLegacy).toHaveLength(260);
+    const keptTools = merged
+      .filter((e) => (e as { item?: { kind?: string } }).item?.kind === 'toolExecution')
+      .map((e) => (e as { item?: { itemId?: string } }).item?.itemId);
+    expect(keptTools).toHaveLength(40);
+    expect(keptTools[0]).toBe('t:tool:0');
+    expect(keptTools[keptTools.length - 1]).toBe('t:tool:39');
+    // 保留项相对顺序 = 原序：工具段仍排在老格式之后、且按序号递增。
+    const firstToolPos = merged.findIndex((e) => (e as { item?: { kind?: string } }).item?.kind === 'toolExecution');
+    expect(firstToolPos).toBe(260);
+  });
+
+  it('超额取舍后仍保持交错：reasoning 保留项不回堆到末尾', () => {
+    // 工具少、思考多 → 工具占额后剩余额度给 reasoning；输出按到达序，
+    // 保留的 reasoning 与工具维持交错（旧代码会把它们全部推到末尾）。
+    const entries: PersistedChatEntry[] = [];
+    for (let i = 0; i < 50; i += 1) {
+      entries.push(toolItem(i));
+      for (let j = 0; j < 6; j += 1) entries.push(reasoningItem(i * 6 + j));
+    }
+    const merged = mergeProcessTrail([], entries);
+    expect(merged.length).toBe(MAX);
+    const kinds = merged.map((e) => (e as { item?: { kind?: string } }).item?.kind || (e as { type?: string }).type);
+    const reasonIdx = kinds.map((k, i) => (k === 'reasoning' ? i : -1)).filter((i) => i >= 0);
+    const toolIdx = kinds.map((k, i) => (k === 'toolExecution' ? i : -1)).filter((i) => i >= 0);
+    expect(toolIdx).toHaveLength(50);
+    expect(reasonIdx).toHaveLength(250);
+    expect(reasonIdx.some((r) => r > toolIdx[0] && r < toolIdx[toolIdx.length - 1])).toBe(true);
+  });
+});
+
 describe('_modelSupportsThinkingByDefault 收紧（PR209 评审 M8）', () => {
   const queueItem = (model?: string) => ({ execConfig: { model } }) as never;
 

--- a/test/main/features/group_chat/merge-process-trail.test.ts
+++ b/test/main/features/group_chat/merge-process-trail.test.ts
@@ -57,6 +57,17 @@ describe('mergeProcessTrail 饱和（PR209 评审 M7）', () => {
     expect(merged.length).toBe(MAX);
   });
 
+  it('预算内保持原序：reasoning 维持与工具的交错位置（2026-09-11 回归）', () => {
+    // 真机事故：落盘组装无条件按"非 reasoning 在前"拼接，整轮思考被推到
+    // 过程区末尾，历史重放里中途思考不可见。预算内必须保持条目原序。
+    const seq = mergeProcessTrail([], [toolItem(0), reasoningItem(0), toolItem(1), turnEntry()]);
+    const kinds = seq.map((e) => {
+      const item = (e as { item?: { kind?: string } }).item;
+      return item?.kind || (e as { type?: string }).type;
+    });
+    expect(kinds).toEqual(['toolExecution', 'reasoning', 'toolExecution', 'turn']);
+  });
+
   it('预算内全保留；超限时终态保底 1 条', () => {
     const few = mergeProcessTrail([], [toolItem(0), reasoningItem(0), turnEntry()]);
     expect(few).toHaveLength(3);

--- a/test/main/model/public_model_catalog.test.ts
+++ b/test/main/model/public_model_catalog.test.ts
@@ -62,9 +62,19 @@ describe('publicContextWindowFor', () => {
   });
 
   it('returns undefined instead of guessing for unknown or windowless ids', () => {
-    expect(publicContextWindowFor('deepseek-v4-pro')).toBeUndefined(); // catalog has the id but no window
+    expect(publicContextWindowFor('doubao-seed-2-0-pro-260215')).toBeUndefined(); // catalog has the id but no window
     expect(publicContextWindowFor('no-such-model')).toBeUndefined();
     expect(publicContextWindowFor('vendor/')).toBeUndefined();
     expect(publicContextWindowFor('')).toBeUndefined();
+  });
+
+  it('resolves the deepseek V4/V4.1 family to the confirmed 1M window', () => {
+    // 2026-09-11 口径更新（产品负责人确认）：V4 文本系列与此前已确认 1M 的
+    // v4-flash-vision-exp 共用 1M 窗口，v4.1 为同族迭代。原先本文件把
+    // deepseek-v4-pro 当"有 id 无窗口"的样本，该角色改由豆包条目承担。
+    expect(publicContextWindowFor('deepseek-v4-pro')).toBe(1_048_576);
+    expect(publicContextWindowFor('deepseek-v4.1-flash')).toBe(1_048_576);
+    // 用户实际配置的 id 形态（自定义供应商带 vendor 前缀）解析到同一窗口。
+    expect(publicContextWindowFor('deepseek/deepseek-v4.1-flash')).toBe(1_048_576);
   });
 });

--- a/test/renderer/chat-stream.test.ts
+++ b/test/renderer/chat-stream.test.ts
@@ -776,11 +776,10 @@ describe('chat-stream module', () => {
     expect(rows).toHaveLength(2);
     expect(rows[0].innerHTML).toContain('done');
     expect(rows[0].innerHTML).toContain('npm test');
-    // 工具行显示权威耗时（1500ms → 「1 秒」，floor 整秒口径见
-    // _csFmtDur，交互设计 2026-09-09 去小数需求），徽章显示整段总耗时
-    // （末终态 4s = 幻影收编后跨度）与工具数 2。
-    expect(rows[0].innerHTML).toContain('cs-dur');
-    expect(rows[0].innerHTML).toContain('1 秒');
+    // 工具行不再显示耗时（2026-09-11 需求变更：本地 CLI 毫秒级耗时信息
+    // 量低），行内只有目标与展开区；徽章仍显示整段总耗时与工具数 2。
+    expect(rows[0].innerHTML).not.toContain('cs-dur');
+    expect(rows[0].innerHTML).not.toContain('1 秒');
     expect(rows[1].innerHTML).toContain('搜索');
     expect(rows[1].innerHTML).toContain('ok');
     const badge = flow.querySelector('.cs-badge')!;

--- a/test/renderer/chat-stream.test.ts
+++ b/test/renderer/chat-stream.test.ts
@@ -357,6 +357,28 @@ describe('chat-stream module', () => {
     expect(thinks[0].dataset.csFull).toBe('正在读取文件…还有后续');
   });
 
+  it('思考内容常显单行预览、点击展开纯文本全文（2026-09-11 方案 C）', () => {
+    handle({ type: 'chat.turn.started', turnId: 'T2', cid: 'c-1', actorId: 'a', startedAt: '' });
+    const flow = inserts[0].node;
+    handle({ type: 'chat.item', turnId: 'T2', itemId: 'r1', kind: 'reasoning', status: 'inProgress', payload: { delta: '核对 131072 的来源与回退链路' } });
+    const body = bodyOf(flow);
+    let thinks = body.children.filter((c) => String(c.className).includes('cs-row-think'));
+    expect(thinks).toHaveLength(1);
+    // 运行中：单行预览在。
+    expect(thinks[0].innerHTML).toContain('cs-think-live');
+    // 收行（后续工具行到来）：预览不再消失，全文块存在但默认收起。
+    handle({ type: 'chat.item', turnId: 'T2', itemId: 't1', kind: 'toolExecution', status: 'completed', payload: { toolName: 'bash', argsSummary: 'ls' } });
+    thinks = body.children.filter((c) => String(c.className).includes('cs-row-think'));
+    expect(thinks[0].dataset.csClosed).toBe('1');
+    // 回归锚点：收行后内容必须仍可见（071bd064 曾把这里清空为只剩时长）。
+    expect(thinks[0].innerHTML).toContain('cs-think-live');
+    expect(thinks[0].innerHTML).toContain('cs-think-full');
+    expect(String(thinks[0].className)).not.toContain('cs-open');
+    // 点击行 → 展开纯文本全文（fake DOM 用记录的 handler 触发）。
+    (thinks[0].handlers.click!)();
+    expect(String(thinks[0].className)).toContain('cs-open');
+  });
+
   it('prewarm 发送即起计（2026-09-09）：面板与计时立即存在，真 turnId 首事件迁移接管', () => {
     const prewarm = g.window.chatStreamPrewarm as (c: string, m: unknown, t: number) => void;
     expect(typeof prewarm).toBe('function');

--- a/test/renderer/chat-stream.test.ts
+++ b/test/renderer/chat-stream.test.ts
@@ -335,7 +335,7 @@ describe('chat-stream module', () => {
     expect(thinks[0].innerHTML).toContain('持续了');
   });
 
-  it('思考实时流式（2026-09-09）：inProgress 增量逐段落入且行自动展开，completed 前缀去重不重复', () => {
+  it('思考实时流式（2026-09-11 需求变更）：inProgress 增量逐段落入但行默认折叠，completed 前缀去重不重复', () => {
     handle({ type: 'chat.turn.started', turnId: 'T1', cid: 'c-1', actorId: 'a', startedAt: '' });
     const flow = inserts[0].node;
     handle({ type: 'chat.item', turnId: 'T1', itemId: 'r1', kind: 'reasoning', status: 'inProgress', payload: { delta: '正在' } });
@@ -343,9 +343,10 @@ describe('chat-stream module', () => {
     const body = bodyOf(flow);
     let thinks = body.children.filter((c) => String(c.className).includes('cs-row-think'));
     expect(thinks).toHaveLength(1);
-    // 进行中：增量聚合完整可见，且行自动展开（同步看到推理进度）。
+    // 进行中：增量聚合保留（点开可见全文），但行默认折叠——不自动 cs-open，
+    // 进度由行内 cs-think-live 单行实时预览承担。
     expect(thinks[0].dataset.csFull).toBe('正在读取文件…');
-    expect(String(thinks[0].className)).toContain('cs-open');
+    expect(String(thinks[0].className)).not.toContain('cs-open');
     // completed 整段（=已画前缀，无尾部差额）：不重复落入。
     handle({ type: 'chat.item', turnId: 'T1', itemId: 'r1', kind: 'reasoning', status: 'completed', payload: { text: '正在读取文件…' } });
     thinks = body.children.filter((c) => String(c.className).includes('cs-row-think'));

--- a/test/renderer/conversation-metrics.test.ts
+++ b/test/renderer/conversation-metrics.test.ts
@@ -57,6 +57,18 @@ describe('messageMetricsLine', () => {
     });
     expect(line.titleLines.join(' ')).toContain('50K');
   });
+  it('metrics without usage (CLI turn after stats retirement) renders time-only, no crash', () => {
+    // 2026-09-11 codex 会话整页加载失败事故的回归锚点：bus 剥 usage 后
+    // metrics 只剩时间戳，inputTokens 等字段全部按 0 处理。
+    const line = messageMetricsLine({
+      startedAt: 1_000, firstTokenAt: 3_100, completedAt: 69_100,
+    });
+    expect(line).not.toBeNull();
+    expect(line.durationMs).toBe(68_100);
+    expect(line.inText).toBeNull();
+    expect(line.outText).toBeNull();
+    expect(line.cacheBadgeText).toBeNull();
+  });
 });
 
 describe('foldSessionMetrics', () => {

--- a/test/renderer/conversation-metrics.test.ts
+++ b/test/renderer/conversation-metrics.test.ts
@@ -92,6 +92,30 @@ describe('foldSessionMetrics', () => {
     expect(f.ctxText).toBe('600/4K·15%');
     expect(f.ctxHot).toBe(false);
   });
+  it('occupancy prefers lastCallUsage over the whole-run accumulation (2026-09-11)', () => {
+    // 真机事故回归锚点：单轮 33 步工具循环，累加 usage 566K 被当作窗口占用
+    // 显示。占用必须读最后一次调用的 prompt 侧用量；消耗行（inText 等）继续
+    // 用累加口径。
+    const f = foldSessionMetrics(
+      [m({ usage: {
+        inputTokens: 60_713, outputTokens: 17_083, cacheReadTokens: 505_216,
+        lastCallUsage: { inputTokens: 2_100, outputTokens: 900, cacheReadTokens: 15_400 },
+      } })],
+      { contextWindow: 1_048_576, price: null },
+    );
+    // 占用 = lastCallUsage 的 prompt 侧三项和 = 17.5K（input 2.1K + 缓存读
+    // 15.4K，不含 output；而非累加的 566K）
+    expect(f.ctxText).toBe('17.5K/1M·2%');
+    expect(f.ctxHot).toBe(false);
+    // 消耗口径不变：inText 仍是累加三项和 566K
+    expect(f.inText).toBe('566K');
+    // 无 lastCallUsage 时回退累加（旧数据/CLI 回合兼容）
+    const g = foldSessionMetrics(
+      [m({ usage: { inputTokens: 100, cacheReadTokens: 300 } })],
+      { contextWindow: 4_000, price: null },
+    );
+    expect(g.ctxText).toBe('400/4K·10%');
+  });
   it('cache hit uses billedInput denominator (DSH parity), inText keeps 3-term sum', () => {
     const f = foldSessionMetrics(
       [m({ usage: { inputTokens: 100, cacheReadTokens: 300, cacheWriteTokens: 100 } })],

--- a/test/renderer/conversation-produced-chips.test.ts
+++ b/test/renderer/conversation-produced-chips.test.ts
@@ -86,9 +86,9 @@ describe('conversation produced chips', () => {
 
 
   it('shows intermediate process logs inline by default while keeping the activity strip visible', () => {
-    // 9.1 统一框架：运行中的真实工具事件/状态/检查点内联可见——process
-    // 容器由 document.createElement('details') 动态创建（className 设
-    // stream-process，expanded 时 open=true），activity 条继续显示状态。
+    // 9.1 统一框架 + 2026-09-11 需求变更：运行中的过程行内联平铺可见——
+    // 历史兜底容器由 document.createElement('div') 创建（className 设
+    // stream-process，无折叠卡语义），activity 条继续显示状态。
     expect(source).toContain("details.className = 'stream-process'");
     expect(source).toContain('stream-activity');
   });

--- a/test/renderer/conversation-session-stats.test.ts
+++ b/test/renderer/conversation-session-stats.test.ts
@@ -188,8 +188,9 @@ describe('conversation session stats line', () => {
     // price in=1 out=2 (cache units absent → 0): (100K*1 + 10K*2)/1M = ¥0.12
     expect(texts).toContain('chat.stats.cost|{"c":"¥0.12"}');
     // 150K/128K ≥ 80% threshold → ctx segment carries the hot class.
+    // 2026-09-11：上下文段独立加框（seg-ctx）。
     const hot = h.box.children.find((c) => String(c.textContent).includes('chat.stats.ctxK|')) as { className: string };
-    expect(hot.className).toBe('seg seg-hot');
+    expect(hot.className).toBe('seg seg-hot seg-ctx');
     // Cost span explains it is a local-price estimate, not a bill.
     const cost = h.box.children[h.box.children.length - 1] as { title: string; textContent: string };
     expect(cost.textContent).toContain('¥0.12');
@@ -210,7 +211,8 @@ describe('conversation session stats line', () => {
     // Only the used amount shows (no /window·% part), and it is not hot.
     expect(ctx.textContent).toContain('150K');
     expect(ctx.textContent).not.toContain('%');
-    expect(ctx.className).toBe('seg');
+    // 2026-09-11：上下文段独立加框（seg-ctx）。
+    expect(ctx.className).toBe('seg seg-ctx');
   });
 
   it('declares chat.stats.* keys in all four locales', () => {


### PR DESCRIPTION
## 修复内容

### 过程时间线（核心）
历史消息里"中途思考全部堆到过程区末尾、且被截断"。两处根因都在 `mergeProcessTrail`：

1. **装得下时也重排**：旧代码无条件按「非思考在前 → 思考垫底 → 终态」拼接，预算内同样把整轮思考推到末尾。改为预算内保持到达原序直出。
2. **超额时重排 + 截断**：单轮条目超 300 上限时，旧代码既重排又从最早的思考截断（真机数据：收集器 33 段思考与工具交错，落盘只剩末尾 14 段）。改为：先丢「与 reasoning 重复存储」的老格式思考 progress（`_thinking`）腾预算——真机 155+164=319，丢 19 条重复后恰好 300，33 段全保、位置不变；仍超额才按优先级（终态 > 非思考 > 思考）选保留集合，输出恒按原序。**取舍只决定丢谁，不改变保留项的前后关系。**

附真机形状（155 老格式 + 164 新条目）回归测试与收集层真实事件回放测试。

### 上下文窗口与统计
- DeepSeek V4/V4.1 家族登记 1M 窗口（产品确认口径，含 vendor 前缀 id 形态 `deepseek/deepseek-v4.1-flash`）
- 上下文占用改用 `lastCallUsage`（末次模型调用的 prompt 侧压力），与整轮累计消耗分离——单轮 566K 是整轮累计（含全部工具循环重放），真实上下文占用约 78K
- CLI 回合缺 usage 时安全兜底（修复会话加载崩溃 `Cannot read properties of undefined (reading 'inputTokens')`）
- 上下文占用段加边框突出显示

### 外部智能体
- codex thread id 持久化（cli-session.json），网关重启后 thread/resume 续接
- KStar 需求不再自动注入 gateway goal——会话连续性优先（同会话连续提问不再每次新开 codex 会话）；网关 goal 参数通道保留
- `waiting_user` 任务状态不再视为执行中（修复任务完成后发送按钮仍显示进行中、后续消息被排队）

### 过程 UI
- 过程区扁平化：工具调用与思考不再用卡片容器
- 工具行强制单行显示、超出直接截断、不显示耗时；思考保留时长
- 思考默认折叠、点击展开（纯文本，无边框/底色/圆角）；运行中显示最新思考预览行
- 表格：去卡片封装、居中、900px 上限、补底线；修复 `display:block` 导致的表格宽度异常
- 「修改输入」编辑卡片右对齐，按设计稿重制视觉

### 测试与清理
- 新增/迁移回归测试 6 处（过程时间线真机形状、交错回放、占用口径、窗口解析等）
- 清理死代码（无人引用的 `.cs-dur` 样式、恒假的 goal 分支）与超刻度圆角字面量

## 验证
- 全量 JS 测试：**10886 项通过 / 0 失败**（970 个测试文件）
- `tsc --noEmit`、`eslint`、`tokens:check`、`readme:check`、`builtin:manifest:check`、`audit:identity`、`reuse:check` 全过
- 提交邮箱 noreply（数字 ID 格式）+ DCO `Signed-off-by` 26/26