### PR TITLE
style：输入区纵向留白收平，消息区多出 20px 可视高度

### DIFF
--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -7650,7 +7650,9 @@ body.sidebar-collapsed .hub-chip-menu { left: 0; right: auto; width: 236px; }
   right: 0;
   /* 左右 padding 与 .chat-history 的 10% 一致（交互设计 2026-09-08 布局统一）：
      输入框与对话内容共用同一水平范围，消除 32px 固定 padding 造成的错位。 */
-  padding: 20px 10% 32px;
+  /* 纵向上下同值（16px，同 --space-4 尺度）：输入卡片与统计栏作为一整列贴底，
+     上下只留对称呼吸位，其余高度交给消息区。 */
+  padding: 16px 10%;
   background: linear-gradient(to bottom, transparent 0%, var(--bg) 20%);
   z-index: var(--z-raised);
   pointer-events: none;


### PR DESCRIPTION
## 背景

会话界面输入区（输入框 + 下方统计栏）在垂直方向上下留白不对等：输入框上方 20px、统计栏到窗口底边 32px。结果是整列偏上、底部空出一块，且这两段间距不一致，视觉上不成为一个整体。

## 改动

`src/renderer/style.css` 一行：

```diff
-  padding: 20px 10% 32px;
+  padding: 16px 10%;
```

上下统一为 16px（等于 token 里的 `--space-4`），改动范围仅 `.chat-input-wrapper`。

## 效果（1512x949 实测）

| 元素 | 改前 | 改后 | 变化 |
|---|---|---|---|
| 输入卡片 | top 755 | top 771 | 下移 16px |
| 统计栏 | 889–917 | 905–933 | 下移 16px |
| 统计栏 → 窗口底边 | 32px | 16px | 收 16px |
| 输入卡片上方留白 | 20px | 16px | 收 4px |
| 消息区可视高度 | 690px | 710px | **+20px** |

## 验证

- 在运行中的渲染进程内实测几何值，全部符合上表预期；
- 820x900 / 860x460 / 900x520 / 1000x600 / 1100x700 / 1280x800 / 1512x949 共 7 种窗口尺寸逐一检查：无重叠、无裁切、无多余滚动条；
- 消息区让位高度由 JS `ResizeObserver` 自动跟随，实测 `--chat-input-reserve` 214px → 194px，与容器实际高度一致；
- 全量 JS 测试 10886 通过 / 52 跳过 / 0 失败；
- `npm run typecheck`、`npm run tokens:check` 通过。

## 说明

- 未改动横向布局。输入框当前比消息内容列窄约 24%（`width: min(82%, 1600px)` 与外层 10% padding 叠加），属另一处独立问题，不在本次范围。
- 未引入新的字面量 token 债务：本次改动只涉及 padding，token 门禁计数与改前一致。